### PR TITLE
enable the backup function only when the strategy was configured

### DIFF
--- a/flexibleengine/resource_flexibleengine_css_cluster_v1.go
+++ b/flexibleengine/resource_flexibleengine_css_cluster_v1.go
@@ -199,7 +199,6 @@ func resourceCssClusterV1UserInputParams(d *schema.ResourceData) map[string]inte
 		"engine_version":          d.Get("engine_version"),
 		"node_number":             d.Get("node_number"),
 		"node_config":             d.Get("node_config"),
-		"backup_strategy":         d.Get("backup_strategy"),
 		"tags":                    d.Get("tags"),
 	}
 }
@@ -212,12 +211,10 @@ func resourceCssClusterV1Create(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	opts := resourceCssClusterV1UserInputParams(d)
-
 	arrayIndex := map[string]int{
 		"node_config.network_info": 0,
 		"node_config.volume":       0,
 		"node_config":              0,
-		"backup_strategy":          0,
 	}
 
 	params, err := buildCssClusterV1CreateParameters(opts, arrayIndex)
@@ -240,11 +237,24 @@ func resourceCssClusterV1Create(d *schema.ResourceData, meta interface{}) error 
 	}
 	d.SetId(id.(string))
 
-	// enable snapshot function when "backup_strategy" was not specified
-	if len(d.Get("backup_strategy").([]interface{})) == 0 {
+	// enable snapshot function and set policy when "backup_strategy" was specified
+	backupRaw := d.Get("backup_strategy").([]interface{})
+	if len(backupRaw) == 1 {
 		err = snapshots.Enable(client, d.Id()).ExtractErr()
 		if err != nil {
 			return fmt.Errorf("Error enable snapshot function: %s", err)
+		}
+
+		raw := backupRaw[0].(map[string]interface{})
+		policyOpts := snapshots.PolicyCreateOpts{
+			Prefix:  raw["prefix"].(string),
+			Period:  raw["start_time"].(string),
+			KeepDay: raw["keep_days"].(int),
+			Enable:  "true",
+		}
+		err := snapshots.PolicyCreate(client, &policyOpts, d.Id()).ExtractErr()
+		if err != nil {
+			return fmt.Errorf("Error creating backup strategy: %s", err)
 		}
 	}
 
@@ -258,14 +268,13 @@ func resourceCssClusterV1Read(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating sdk client, err=%s", err)
 	}
 
-	res := make(map[string]interface{})
-
 	v, err := sendCssClusterV1ReadRequest(d, client)
 	if err != nil {
 		return err
 	}
-	res["read"] = fillCssClusterV1ReadRespBody(v)
 
+	res := make(map[string]interface{})
+	res["read"] = fillCssClusterV1ReadRespBody(v)
 	if err := setCssClusterV1Properties(d, res); err != nil {
 		return err
 	}
@@ -302,13 +311,11 @@ func resourceCssClusterV1Update(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	opts := resourceCssClusterV1UserInputParams(d)
-
 	arrayIndex := map[string]int{
 		"node_config.network_info": 0,
 		"node_config.volume":       0,
 		"node_config":              0,
 	}
-	timeout := d.Timeout(schema.TimeoutUpdate)
 
 	params, err := buildCssClusterV1ExtendClusterParameters(opts, arrayIndex)
 	if err != nil {
@@ -319,6 +326,8 @@ func resourceCssClusterV1Update(d *schema.ResourceData, meta interface{}) error 
 		if err != nil {
 			return err
 		}
+
+		timeout := d.Timeout(schema.TimeoutUpdate)
 		_, err = asyncWaitCssClusterV1ExtendCluster(d, config, r, client, timeout)
 		if err != nil {
 			return err
@@ -336,6 +345,18 @@ func resourceCssClusterV1Update(d *schema.ResourceData, meta interface{}) error 
 
 		rawList := d.Get("backup_strategy").([]interface{})
 		if len(rawList) == 1 {
+			// check backup strategy, if the policy was disabled, we should enable it
+			policy, err := snapshots.PolicyGet(client, d.Id()).Extract()
+			if err != nil {
+				return fmt.Errorf("Error extracting Cluster backup_strategy, err: %s", err)
+			}
+			if policy.Enable == "false" {
+				err = snapshots.Enable(client, d.Id()).ExtractErr()
+				if err != nil {
+					return fmt.Errorf("Error enable snapshot function: %s", err)
+				}
+			}
+
 			raw := rawList[0].(map[string]interface{})
 			opts = snapshots.PolicyCreateOpts{
 				Prefix:  raw["prefix"].(string),
@@ -437,16 +458,6 @@ func buildCssClusterV1CreateParameters(opts map[string]interface{}, arrayIndex m
 		return nil, err
 	} else if !e {
 		params["name"] = v
-	}
-
-	v, err = expandCssClusterV1BackupStrategy(opts, arrayIndex)
-	if err != nil {
-		return nil, err
-	}
-	if e, err := isEmptyValue(reflect.ValueOf(v)); err != nil {
-		return nil, err
-	} else if !e {
-		params["backupStrategy"] = v
 	}
 
 	// build tags parameter
@@ -596,42 +607,6 @@ func expandCssClusterV1CreateInstanceVolume(d interface{}, arrayIndex map[string
 		return nil, err
 	} else if !e {
 		req["volume_type"] = v
-	}
-
-	return req, nil
-}
-
-func expandCssClusterV1BackupStrategy(d interface{}, arrayIndex map[string]int) (interface{}, error) {
-	req := make(map[string]interface{})
-
-	v, err := navigateValue(d, []string{"backup_strategy", "start_time"}, arrayIndex)
-	if err != nil {
-		return nil, err
-	}
-	if e, err := isEmptyValue(reflect.ValueOf(v)); err != nil {
-		return nil, err
-	} else if !e {
-		req["period"] = v
-	}
-
-	v, err = navigateValue(d, []string{"backup_strategy", "keep_days"}, arrayIndex)
-	if err != nil {
-		return nil, err
-	}
-	if e, err := isEmptyValue(reflect.ValueOf(v)); err != nil {
-		return nil, err
-	} else if !e {
-		req["keepday"] = v
-	}
-
-	v, err = navigateValue(d, []string{"backup_strategy", "prefix"}, arrayIndex)
-	if err != nil {
-		return nil, err
-	}
-	if e, err := isEmptyValue(reflect.ValueOf(v)); err != nil {
-		return nil, err
-	} else if !e {
-		req["prefix"] = v
 	}
 
 	return req, nil


### PR DESCRIPTION
The backup function was auto enabled since 1.14.0 version, but it requires the authority of OBS Bucket and IAM Agency. 
Actually, it's no necessary to require the authority if we don't configure backup. 