### PR TITLE
make tags of css cluster to be update-able

### DIFF
--- a/flexibleengine/resource_flexibleengine_css_cluster_v1.go
+++ b/flexibleengine/resource_flexibleengine_css_cluster_v1.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/common/tags"
 	"github.com/huaweicloud/golangsdk/openstack/css/v1/snapshots"
 )
 
@@ -151,11 +152,7 @@ func resourceCssClusterV1() *schema.Resource {
 				},
 			},
 
-			"tags": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				ForceNew: true,
-			},
+			"tags": tagsSchema(),
 
 			"created": {
 				Type:     schema.TypeString,
@@ -300,6 +297,17 @@ func resourceCssClusterV1Read(d *schema.ResourceData, meta interface{}) error {
 		d.Set("backup_strategy", nil)
 	}
 
+	// set tags
+	resourceTags, err := tags.Get(client, "css-cluster", d.Id()).Extract()
+	if err != nil {
+		return fmt.Errorf("Error fetching CSS cluster tags: %s", err)
+	}
+
+	tagmap := tagsToMap(resourceTags.Tags)
+	if err := d.Set("tags", tagmap); err != nil {
+		return fmt.Errorf("[DEBUG] Error saving tag to state for CSS cluster (%s): %s", d.Id(), err)
+	}
+
 	return nil
 }
 
@@ -368,6 +376,13 @@ func resourceCssClusterV1Update(d *schema.ResourceData, meta interface{}) error 
 		err := snapshots.PolicyCreate(client, &opts, d.Id()).ExtractErr()
 		if err != nil {
 			return fmt.Errorf("Error updating backup strategy: %s", err)
+		}
+	}
+
+	if d.HasChange("tags") {
+		tagErr := UpdateResourceTags(client, d, "css-cluster")
+		if tagErr != nil {
+			return fmt.Errorf("Error updating tags of CSS cluster:%s, err:%s", d.Id(), tagErr)
 		}
 	}
 

--- a/flexibleengine/resource_flexibleengine_css_cluster_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_css_cluster_v1_test.go
@@ -25,58 +25,35 @@ import (
 )
 
 func TestAccCssClusterV1_basic(t *testing.T) {
+	randName := acctest.RandString(6)
+	resourceName := "flexibleengine_css_cluster_v1.cluster"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCssClusterV1Destroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCssClusterV1_basic(acctest.RandString(10)),
+				Config: testAccCssClusterV1_basic(randName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCssClusterV1Exists(),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_css_cluster_v1.cluster", "node_number", "1"),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_css_cluster_v1.cluster", "engine_type", "elasticsearch"),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_css_cluster_v1.cluster", "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("terraform_test_cluster%s", randName)),
+					resource.TestCheckResourceAttr(resourceName, "node_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "engine_type", "elasticsearch"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+				),
+			},
+			{
+				Config: testAccCssClusterV1_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCssClusterV1Exists(),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key_update", "value"),
 				),
 			},
 		},
 	})
-}
-
-func testAccCssClusterV1_basic(val string) string {
-	return fmt.Sprintf(`
-resource "flexibleengine_networking_secgroup_v2" "secgroup" {
-  name = "terraform_test_security_group%s"
-  description = "terraform security group acceptance test"
-}
-
-resource "flexibleengine_css_cluster_v1" "cluster" {
-  name = "terraform_test_cluster%s"
-  engine_version = "7.1.1"
-  node_number    = 1
-
-  node_config {
-    flavor = "ess.spec-4u16g"
-    network_info {
-      security_group_id = flexibleengine_networking_secgroup_v2.secgroup.id
-      subnet_id = "%s"
-      vpc_id = "%s"
-    }
-    volume {
-      volume_type = "COMMON"
-      size = 40
-    }
-    availability_zone = "%s"
-  }
-  tags = {
-    foo = "bar"
-    key = "value"
-  }
-}
-	`, val, val, OS_NETWORK_ID, OS_VPC_ID, OS_AVAILABILITY_ZONE)
 }
 
 func testAccCheckCssClusterV1Destroy(s *terraform.State) error {
@@ -134,4 +111,70 @@ func testAccCheckCssClusterV1Exists() resource.TestCheckFunc {
 		}
 		return nil
 	}
+}
+
+func testAccCssClusterV1_basic(val string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_networking_secgroup_v2" "secgroup" {
+  name = "terraform_test_security_group%s"
+  description = "terraform security group acceptance test"
+}
+
+resource "flexibleengine_css_cluster_v1" "cluster" {
+  name = "terraform_test_cluster%s"
+  engine_version = "7.1.1"
+  node_number    = 1
+
+  node_config {
+    flavor = "ess.spec-4u16g"
+    network_info {
+      security_group_id = flexibleengine_networking_secgroup_v2.secgroup.id
+      subnet_id = "%s"
+      vpc_id = "%s"
+    }
+    volume {
+      volume_type = "COMMON"
+      size = 40
+    }
+    availability_zone = "%s"
+  }
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+	`, val, val, OS_NETWORK_ID, OS_VPC_ID, OS_AVAILABILITY_ZONE)
+}
+
+func testAccCssClusterV1_update(val string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_networking_secgroup_v2" "secgroup" {
+  name = "terraform_test_security_group%s"
+  description = "terraform security group acceptance test"
+}
+
+resource "flexibleengine_css_cluster_v1" "cluster" {
+  name = "terraform_test_cluster%s"
+  engine_version = "7.1.1"
+  node_number    = 1
+
+  node_config {
+    flavor = "ess.spec-4u16g"
+    network_info {
+      security_group_id = flexibleengine_networking_secgroup_v2.secgroup.id
+      subnet_id = "%s"
+      vpc_id = "%s"
+    }
+    volume {
+      volume_type = "COMMON"
+      size = 40
+    }
+    availability_zone = "%s"
+  }
+  tags = {
+    foo = "bar_update"
+    key_update = "value"
+  }
+}
+	`, val, val, OS_NETWORK_ID, OS_VPC_ID, OS_AVAILABILITY_ZONE)
 }

--- a/flexibleengine/tags.go
+++ b/flexibleengine/tags.go
@@ -11,6 +11,7 @@ func tagsSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeMap,
 		Optional: true,
+		Elem:     &schema.Schema{Type: schema.TypeString},
 	}
 }
 

--- a/website/docs/r/css_cluster_v1.html.markdown
+++ b/website/docs/r/css_cluster_v1.html.markdown
@@ -76,7 +76,6 @@ The following arguments are supported:
 * `backup_strategy` - (Optional) Specifies the advanced backup policy. Structure is documented below.
 
 * `tags` - (Optional) The key/value pairs to associate with the cluster.
-  Changing this parameter will create a new resource.
 
 The `node_config` block supports:
 


### PR DESCRIPTION
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCssClusterV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCssClusterV1_basic -timeout 720m
=== RUN   TestAccCssClusterV1_basic
--- PASS: TestAccCssClusterV1_basic (951.95s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine
```