### PR TITLE
support security mode for css cluster

### DIFF
--- a/flexibleengine/resource_flexibleengine_css_cluster_v1.go
+++ b/flexibleengine/resource_flexibleengine_css_cluster_v1.go
@@ -34,7 +34,7 @@ func resourceCssClusterV1() *schema.Resource {
 		Delete: resourceCssClusterV1Delete,
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(30 * time.Minute),
+			Create: schema.DefaultTimeout(60 * time.Minute),
 			Update: schema.DefaultTimeout(60 * time.Minute),
 		},
 
@@ -47,9 +47,9 @@ func resourceCssClusterV1() *schema.Resource {
 
 			"engine_type": {
 				Type:     schema.TypeString,
-				Computed: true,
 				Optional: true,
 				ForceNew: true,
+				Default:  "elasticsearch",
 			},
 			"engine_version": {
 				Type:     schema.TypeString,
@@ -61,6 +61,18 @@ func resourceCssClusterV1() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  1,
+			},
+
+			"security_mode": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Optional:  true,
+				ForceNew:  true,
 			},
 
 			"node_config": {
@@ -435,6 +447,11 @@ func resourceCssClusterV1Delete(d *schema.ResourceData, meta interface{}) error 
 func buildCssClusterV1CreateParameters(opts map[string]interface{}, arrayIndex map[string]int) (interface{}, error) {
 	params := make(map[string]interface{})
 
+	resourceData := opts["terraform_resource_data"].(*schema.ResourceData)
+	if resourceData == nil {
+		return nil, fmt.Errorf("failed to build parameters: Resource Data is null")
+	}
+
 	v, err := expandCssClusterV1CreateDatastore(opts, arrayIndex)
 	if err != nil {
 		return nil, err
@@ -455,24 +472,22 @@ func buildCssClusterV1CreateParameters(opts map[string]interface{}, arrayIndex m
 		params["instance"] = v
 	}
 
-	v, err = navigateValue(opts, []string{"node_number"}, arrayIndex)
-	if err != nil {
-		return nil, err
+	if nodeNumber := resourceData.Get("node_number").(int); nodeNumber != 0 {
+		params["instanceNum"] = nodeNumber
 	}
-	if e, err := isEmptyValue(reflect.ValueOf(v)); err != nil {
-		return nil, err
-	} else if !e {
-		params["instanceNum"] = v
+	if clusterName := resourceData.Get("name").(string); clusterName != "" {
+		params["name"] = clusterName
 	}
 
-	v, err = navigateValue(opts, []string{"name"}, arrayIndex)
-	if err != nil {
-		return nil, err
-	}
-	if e, err := isEmptyValue(reflect.ValueOf(v)); err != nil {
-		return nil, err
-	} else if !e {
-		params["name"] = v
+	securityMode := resourceData.Get("security_mode").(bool)
+	if securityMode == true {
+		adminPassword := resourceData.Get("password").(string)
+		if adminPassword == "" {
+			return nil, fmt.Errorf("Administrator password is required in security mode")
+		}
+		params["httpsEnable"] = true
+		params["authorityEnable"] = true
+		params["adminPwd"] = adminPassword
 	}
 
 	// build tags parameter
@@ -502,8 +517,6 @@ func expandCssClusterV1CreateDatastore(d interface{}, arrayIndex map[string]int)
 		return nil, err
 	} else if !e {
 		req["type"] = v
-	} else {
-		req["type"] = "elasticsearch"
 	}
 
 	v, err = navigateValue(d, []string{"engine_version"}, arrayIndex)
@@ -831,6 +844,10 @@ func fillCssClusterV1ReadRespBody(body interface{}) interface{} {
 		result["name"] = nil
 	}
 
+	if v, ok := val["httpsEnable"]; ok {
+		result["security_mode"] = v
+	}
+
 	if v, ok := val["status"]; ok {
 		result["status"] = v
 	} else {
@@ -959,6 +976,13 @@ func setCssClusterV1Properties(d *schema.ResourceData, response map[string]inter
 	}
 	if err = d.Set("name", v); err != nil {
 		return fmt.Errorf("Error setting Cluster:name, err: %s", err)
+	}
+
+	v, err = navigateValue(response, []string{"read", "security_mode"}, nil)
+	if err == nil {
+		if err = d.Set("security_mode", v); err != nil {
+			return fmt.Errorf("Error setting Cluster:security_mode, err: %s", err)
+		}
 	}
 
 	v, _ = opts["nodes"]

--- a/flexibleengine/resource_flexibleengine_css_cluster_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_css_cluster_v1_test.go
@@ -56,6 +56,29 @@ func TestAccCssClusterV1_basic(t *testing.T) {
 	})
 }
 
+func TestAccCssClusterV1_security(t *testing.T) {
+	randName := acctest.RandString(6)
+	resourceName := "flexibleengine_css_cluster_v1.cluster"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCssClusterV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCssClusterV1_security(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCssClusterV1Exists(),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("terraform_test_cluster%s", randName)),
+					resource.TestCheckResourceAttr(resourceName, "node_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "engine_type", "elasticsearch"),
+					resource.TestCheckResourceAttr(resourceName, "security_mode", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckCssClusterV1Destroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	client, err := config.sdkClient(OS_REGION_NAME, "css")
@@ -174,6 +197,37 @@ resource "flexibleengine_css_cluster_v1" "cluster" {
   tags = {
     foo = "bar_update"
     key_update = "value"
+  }
+}
+	`, val, val, OS_NETWORK_ID, OS_VPC_ID, OS_AVAILABILITY_ZONE)
+}
+
+func testAccCssClusterV1_security(val string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_networking_secgroup_v2" "secgroup" {
+  name = "terraform_test_security_group%s"
+  description = "terraform security group acceptance test"
+}
+
+resource "flexibleengine_css_cluster_v1" "cluster" {
+  name = "terraform_test_cluster%s"
+  engine_version = "7.6.2"
+  node_number    = 1
+  security_mode  = true
+  password       = "Test@passw0rd"
+
+  node_config {
+    flavor = "ess.spec-4u16g"
+    network_info {
+      security_group_id = flexibleengine_networking_secgroup_v2.secgroup.id
+      subnet_id = "%s"
+      vpc_id = "%s"
+    }
+    volume {
+      volume_type = "COMMON"
+      size = 40
+    }
+    availability_zone = "%s"
   }
 }
 	`, val, val, OS_NETWORK_ID, OS_VPC_ID, OS_AVAILABILITY_ZONE)

--- a/website/docs/r/css_cluster_v1.html.markdown
+++ b/website/docs/r/css_cluster_v1.html.markdown
@@ -69,6 +69,17 @@ The following arguments are supported:
   (Optional)
   Number of cluster instances. The value range is 1 to 32. Defaults to 1.
 
+* `security_mode` - (Optional) Whether to enable communication encryption and security authentication.
+  Available values include *true* and *false*. security_mode is disabled by default.
+  Changing this parameter will create a new resource.
+
+* `password` - (Optional) Password of the cluster administrator admin in security mode.
+  This parameter is mandatory only when security_mode is set to true. Changing this parameter will create a new resource.
+  The administrator password must meet the following requirements:
+  - The password can contain 8 to 32 characters.
+  - The password must contain at least 3 of the following character types: uppercase letters, lowercase letters,
+    digits, and special characters (~!@#$%^&*()-_=+\\|[{}];:,<.>/?).
+
 * `node_config` -
   (Required)
   Node configuration. Structure is documented below. Changing this parameter will create a new resource.


### PR DESCRIPTION
Fixes #399 

This PR will support security mode for css cluster by adding two parameters `security_mode` and `password`.
The testing result as follows:

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCssClusterV1_security'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCssClusterV1_security -timeout 720m
=== RUN   TestAccCssClusterV1_security

--- PASS: TestAccCssClusterV1_security (995.06s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 995.070s
```