### PR TITLE
unwrap chooseECSV1Client into config.computeV1Client

### DIFF
--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -379,6 +379,15 @@ func (c *Config) blockStorageV2Client(region string) (*golangsdk.ServiceClient, 
 	})
 }
 
+// client for ecs v1
+func (c *Config) computeV1Client(region string) (*golangsdk.ServiceClient, error) {
+	return huaweisdk.NewComputeV1(c.HwClient, golangsdk.EndpointOpts{
+		Region:       region,
+		Availability: c.getHwEndpointType(),
+	})
+}
+
+// client for nova v2
 func (c *Config) computeV2Client(region string) (*golangsdk.ServiceClient, error) {
 	return huaweisdk.NewComputeV2(c.HwClient, golangsdk.EndpointOpts{
 		Region:       c.determineRegion(region),
@@ -619,13 +628,6 @@ func (c *Config) cceV3Client(region string) (*golangsdk.ServiceClient, error) {
 
 func (c *Config) kmsKeyV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return huaweisdk.NewKMSV1(c.HwClient, golangsdk.EndpointOpts{
-		Region:       region,
-		Availability: c.getHwEndpointType(),
-	})
-}
-
-func (c *Config) loadECSV1Client(region string) (*golangsdk.ServiceClient, error) {
-	return huaweisdk.NewComputeV1(c.HwClient, golangsdk.EndpointOpts{
 		Region:       region,
 		Availability: c.getHwEndpointType(),
 	})

--- a/flexibleengine/golangsdk_utils.go
+++ b/flexibleengine/golangsdk_utils.go
@@ -5,10 +5,6 @@ import (
 	"github.com/huaweicloud/golangsdk"
 )
 
-func chooseECSV1Client(d *schema.ResourceData, config *Config) (*golangsdk.ServiceClient, error) {
-	return config.loadECSV1Client(GetRegion(d, config))
-}
-
 func chooseCESClient(d *schema.ResourceData, config *Config) (*golangsdk.ServiceClient, error) {
 	return config.loadCESClient(GetRegion(d, config))
 }

--- a/flexibleengine/resource_flexibleengine_cce_node_v3.go
+++ b/flexibleengine/resource_flexibleengine_cce_node_v3.go
@@ -532,7 +532,7 @@ func resourceCCENodeV3Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("server_id", serverId)
 
 	// fetch tags from ECS instance
-	computeClient, err := config.loadECSV1Client(GetRegion(d, config))
+	computeClient, err := config.computeV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating Flexibleengine compute client: %s", err)
 	}
@@ -573,7 +573,7 @@ func resourceCCENodeV3Update(d *schema.ResourceData, meta interface{}) error {
 
 	// update tags
 	if d.HasChange("tags") {
-		computeClient, err := config.loadECSV1Client(GetRegion(d, config))
+		computeClient, err := config.computeV1Client(GetRegion(d, config))
 		if err != nil {
 			return fmt.Errorf("Error creating Flexibleengine compute client: %s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_compute_instance_v2.go
+++ b/flexibleengine/resource_flexibleengine_compute_instance_v2.go
@@ -493,7 +493,7 @@ func resourceComputeInstanceV2Create(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if hasFilledOpt(d, "tags") {
-		ecsClient, err := chooseECSV1Client(d, config)
+		ecsClient, err := config.computeV1Client(GetRegion(d, config))
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine compute v1 client: %s", err)
 		}
@@ -791,7 +791,7 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 		oMap := oRaw.(map[string]interface{})
 		nMap := nRaw.(map[string]interface{})
 
-		ecsClient, err := chooseECSV1Client(d, config)
+		ecsClient, err := config.computeV1Client(GetRegion(d, config))
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine compute v1 client: %s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_ecs_v1_util.go
+++ b/flexibleengine/resource_flexibleengine_ecs_v1_util.go
@@ -14,7 +14,7 @@ import (
 
 func resourceECSAutoRecoveryV1Read(d *schema.ResourceData, meta interface{}, instanceID string) (bool, error) {
 	config := meta.(*Config)
-	client, err := chooseECSV1Client(d, config)
+	client, err := config.computeV1Client(GetRegion(d, config))
 	if err != nil {
 		return false, fmt.Errorf("Error creating FlexibleEngine client: %s", err)
 	}
@@ -31,7 +31,7 @@ func resourceECSAutoRecoveryV1Read(d *schema.ResourceData, meta interface{}, ins
 
 func setAutoRecoveryForInstance(d *schema.ResourceData, meta interface{}, instanceID string, ar bool) error {
 	config := meta.(*Config)
-	client, err := chooseECSV1Client(d, config)
+	client, err := config.computeV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine client: %s", err)
 	}
@@ -60,7 +60,7 @@ func resourceECSTagsV1Read(d *schema.ResourceData, meta interface{}, instanceID 
 	tagmap := make(map[string]string)
 
 	config := meta.(*Config)
-	client, err := chooseECSV1Client(d, config)
+	client, err := config.computeV1Client(GetRegion(d, config))
 	if err != nil {
 		return tagmap, fmt.Errorf("Error creating FlexibleEngine compute v1 client: %s", err)
 	}


### PR DESCRIPTION
unwrap `chooseECSV1Client` into `config.computeV1Client`

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccComputeV2Instance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccComputeV2Instance_basic -timeout 720m
=== RUN   TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (240.26s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 240.275s
```