### PR TITLE
add compute instance data source and docs

### DIFF
--- a/flexibleengine/data_source_flexibleengine_compute_instance_v2.go
+++ b/flexibleengine/data_source_flexibleengine_compute_instance_v2.go
@@ -1,0 +1,320 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk/openstack/common/tags"
+	"github.com/huaweicloud/golangsdk/openstack/ecs/v1/block_devices"
+	"github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers"
+	"github.com/huaweicloud/golangsdk/openstack/networking/v2/ports"
+)
+
+func dataSourceComputeInstance() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceComputeInstanceRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"flavor_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"fixed_ip_v4": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"flavor_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"image_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"key_pair": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"user_data": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"security_groups": {
+				Type:     schema.TypeSet,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"system_disk_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"floating_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"network": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"fixed_ip_v4": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"fixed_ip_v6": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"mac": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"block_device": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"uuid": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"boot_index": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"size": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"pci_address": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"scheduler_hints": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"group": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	ecsClient, err := config.computeV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine ECS client: %s", err)
+	}
+
+	listOpts := &cloudservers.ListOpts{
+		Name:   d.Get("name").(string),
+		Flavor: d.Get("flavor_id").(string),
+		IP:     d.Get("fixed_ip_v4").(string),
+	}
+
+	pages, err := cloudservers.List(ecsClient, listOpts).AllPages()
+	if err != nil {
+		return err
+	}
+
+	allServers, err := cloudservers.ExtractServers(pages)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve cloud servers: %s ", err)
+	}
+
+	if len(allServers) < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+	if len(allServers) > 1 {
+		return fmt.Errorf("Your query returned more than one result. " +
+			"Please try a more specific search criteria.")
+	}
+
+	server := allServers[0]
+	log.Printf("[DEBUG] fetching the ecs instance: %#v", server)
+
+	d.SetId(server.ID)
+	d.Set("region", GetRegion(d, config))
+	d.Set("availability_zone", server.AvailabilityZone)
+	d.Set("name", server.Name)
+	d.Set("status", server.Status)
+
+	flavorInfo := server.Flavor
+	d.Set("flavor_id", flavorInfo.ID)
+	d.Set("flavor_name", flavorInfo.Name)
+	d.Set("image_id", server.Image.ID)
+
+	metaData := server.Metadata
+	if metaData.ImageName != "" {
+		d.Set("image_name", metaData.ImageName)
+	}
+	if server.KeyName != "" {
+		d.Set("key_pair", server.KeyName)
+	}
+	if server.UserData != "" {
+		d.Set("user_data", server.UserData)
+	}
+
+	// set security groups
+	secGrpNames := make([]string, len(server.SecurityGroups))
+	for i, sg := range server.SecurityGroups {
+		secGrpNames[i] = sg.Name
+	}
+	d.Set("security_groups", secGrpNames)
+
+	// set os:scheduler_hints
+	osHints := server.OsSchedulerHints
+	if len(osHints.Group) > 0 {
+		schedulerHints := make([]map[string]interface{}, len(osHints.Group))
+		for i, v := range osHints.Group {
+			schedulerHints[i] = map[string]interface{}{
+				"group": v,
+			}
+		}
+		d.Set("scheduler_hints", schedulerHints)
+	}
+
+	// Set the instance network and address information
+	networks, eip := flattenComputeNetworks(d, meta, &server)
+	if err := d.Set("network", networks); err != nil {
+		log.Printf("[WARN] Error setting network of ecs instance %s: %s", d.Id(), err)
+	}
+	if eip != "" {
+		d.Set("floating_ip", eip)
+	}
+
+	// Set volume attached
+	instanceVolumes := []map[string]interface{}{}
+	if len(server.VolumeAttached) > 0 {
+		for _, b := range server.VolumeAttached {
+			va, err := block_devices.Get(ecsClient, d.Id(), b.ID).Extract()
+			if err != nil {
+				return err
+			}
+			log.Printf("[DEBUG] Retrieved block device %s: %#v", d.Id(), va)
+			v := map[string]interface{}{
+				"uuid":        b.ID,
+				"boot_index":  va.BootIndex,
+				"size":        va.Size,
+				"pci_address": va.PciAddress,
+			}
+			instanceVolumes = append(instanceVolumes, v)
+			if va.BootIndex == 0 {
+				d.Set("system_disk_id", b.ID)
+			}
+		}
+		d.Set("block_device", instanceVolumes)
+	}
+
+	// Set instance tags
+	resourceTags, err := tags.Get(ecsClient, "servers", d.Id()).Extract()
+	if err == nil {
+		tagmap := tagsToMap(resourceTags.Tags)
+		d.Set("tags", tagmap)
+	} else {
+		log.Printf("[WARN] Error fetching tags of ecs instance %s: %s", d.Id(), err)
+	}
+
+	return nil
+}
+
+// flattenComputeNetworks collects instance network information
+func flattenComputeNetworks(
+	d *schema.ResourceData, meta interface{}, server *cloudservers.CloudServer) ([]map[string]interface{}, string) {
+
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		log.Printf("[ERROR] failed to create FlexibleEngine networking client: %s", err)
+		return nil, ""
+	}
+
+	publicIP := ""
+	networks := []map[string]interface{}{}
+
+	for _, addresses := range server.Addresses {
+		for _, addr := range addresses {
+			if addr.Type == "floating" {
+				publicIP = addr.Addr
+				continue
+			}
+
+			// get networkID
+			var networkID string
+			p, err := ports.Get(networkingClient, addr.PortID).Extract()
+			if err != nil {
+				networkID = ""
+				log.Printf("[DEBUG] failed to fetch port %s", addr.PortID)
+			} else {
+				networkID = p.NetworkID
+			}
+
+			v := map[string]interface{}{
+				"uuid": networkID,
+				"port": addr.PortID,
+				"mac":  addr.MacAddr,
+			}
+			if addr.Version == "6" {
+				v["fixed_ip_v6"] = addr.Addr
+			} else {
+				v["fixed_ip_v4"] = addr.Addr
+			}
+
+			networks = append(networks, v)
+		}
+	}
+
+	log.Printf("[DEBUG] flatten Instance Networks: %#v", networks)
+	return networks, publicIP
+}

--- a/flexibleengine/data_source_flexibleengine_compute_instance_v2_test.go
+++ b/flexibleengine/data_source_flexibleengine_compute_instance_v2_test.go
@@ -1,0 +1,61 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk/openstack/compute/v2/servers"
+)
+
+func TestAccComputeInstanceDataSource_basic(t *testing.T) {
+	resourceName := "data.flexibleengine_compute_instance_v2.this"
+	var instance servers.Server
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceDataSource_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeV2InstanceExists("flexibleengine_compute_instance_v2.instance_1", &instance),
+					testAccCheckComputeInstanceDataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "instance_1"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+					resource.TestCheckResourceAttrSet(resourceName, "system_disk_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "security_groups.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "network.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "block_device.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckComputeInstanceDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find compute instance data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Compute instance data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+func testAccComputeInstanceDataSource_basic() string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_compute_instance_v2" "this" {
+  name = flexibleengine_compute_instance_v2.instance_1.name
+}
+`, testAccComputeV2Instance_basic)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -165,6 +165,7 @@ func Provider() terraform.ResourceProvider {
 			"flexibleengine_blockstorage_availability_zones_v3": dataSourceBlockStorageAvailabilityZonesV3(),
 			"flexibleengine_blockstorage_volume_v2":             dataSourceBlockStorageVolumeV2(),
 			"flexibleengine_compute_availability_zones_v2":      dataSourceComputeAvailabilityZonesV2(),
+			"flexibleengine_compute_instance_v2":                dataSourceComputeInstance(),
 			"flexibleengine_images_image_v2":                    dataSourceImagesImageV2(),
 			"flexibleengine_networking_network_v2":              dataSourceNetworkingNetworkV2(),
 			"flexibleengine_networking_secgroup_v2":             dataSourceNetworkingSecGroupV2(),

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
-	github.com/huaweicloud/golangsdk v0.0.0-20201204094050-adf7043d8e5d
+	github.com/huaweicloud/golangsdk v0.0.0-20201217022317-b78db54d0391
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huaweicloud/golangsdk v0.0.0-20201204094050-adf7043d8e5d h1:vgu8OCZqnWHgA168mX5hxrIvVonKEldl/iybN1hD5Bg=
 github.com/huaweicloud/golangsdk v0.0.0-20201204094050-adf7043d8e5d/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
+github.com/huaweicloud/golangsdk v0.0.0-20201217022317-b78db54d0391 h1:juU0iXFrCv9xcalFIRDINvAzYMjKHJAIe29mnxcGelo=
+github.com/huaweicloud/golangsdk v0.0.0-20201217022317-b78db54d0391/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/client.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/client.go
@@ -689,6 +689,11 @@ func NewComputeV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (
 	return sc, err
 }
 
+func NewComputeV11(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
+	sc, err := initClientOpts(client, eo, "ecsv1.1")
+	return sc, err
+}
+
 func NewRdsTagV1(client *golangsdk.ProviderClient, eo golangsdk.EndpointOpts) (*golangsdk.ServiceClient, error) {
 	sc, err := initClientOpts(client, eo, "network")
 	sc.Endpoint = strings.Replace(sc.Endpoint, "vpc", "rds", 1)

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/compute/v2/servers/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/compute/v2/servers/results.go
@@ -214,6 +214,9 @@ type Server struct {
 
 	// Fault contains failure information about a server.
 	Fault Fault `json:"fault"`
+
+	// VolumeAttached includes the volumes that attached to the server.
+	VolumesAttached []map[string]string `json:"os-extended-volumes:volumes_attached"`
 }
 
 type Fault struct {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/block_devices/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/block_devices/requests.go
@@ -1,0 +1,10 @@
+package block_devices
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+func Get(c *golangsdk.ServiceClient, server_id string, volume_id string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, server_id, volume_id), &r.Body, nil)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/block_devices/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/block_devices/results.go
@@ -1,0 +1,48 @@
+package block_devices
+
+import (
+	"encoding/json"
+
+	"github.com/huaweicloud/golangsdk"
+)
+
+type VolumeAttachment struct {
+	PciAddress string `json:"pciAddress"`
+	Size       int    `json:"size"`
+	BootIndex  int    `json:"-"`
+}
+
+func (r *VolumeAttachment) UnmarshalJSON(b []byte) error {
+	type tmp VolumeAttachment
+	var s struct {
+		tmp
+		BootIndex interface{} `json:"bootIndex"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = VolumeAttachment(s.tmp)
+
+	if s.BootIndex == nil {
+		r.BootIndex = -1
+	} else {
+		r.BootIndex = int(s.BootIndex.(float64))
+	}
+
+	return err
+}
+
+type GetResult struct {
+	golangsdk.Result
+}
+
+func (r GetResult) Extract() (*VolumeAttachment, error) {
+	s := &VolumeAttachment{}
+	return s, r.ExtractInto(s)
+}
+
+func (r GetResult) ExtractInto(v interface{}) error {
+	return r.Result.ExtractIntoStructPtr(v, "volumeAttachment")
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/block_devices/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/block_devices/urls.go
@@ -1,0 +1,7 @@
+package block_devices
+
+import "github.com/huaweicloud/golangsdk"
+
+func getURL(c *golangsdk.ServiceClient, server_id string, volume_id string) string {
+	return c.ServiceURL("cloudservers", server_id, "block_device", volume_id)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers/requests.go
@@ -1,0 +1,278 @@
+package cloudservers
+
+import (
+	"encoding/base64"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type CreateOpts struct {
+	ImageRef string `json:"imageRef" required:"true"`
+
+	FlavorRef string `json:"flavorRef" required:"true"`
+
+	Name string `json:"name" required:"true"`
+
+	UserData []byte `json:"-"`
+
+	// AdminPass sets the root user password. If not set, a randomly-generated
+	// password will be created and returned in the response.
+	AdminPass string `json:"adminPass,omitempty"`
+
+	KeyName string `json:"key_name,omitempty"`
+
+	VpcId string `json:"vpcid" required:"true"`
+
+	Nics []Nic `json:"nics" required:"true"`
+
+	PublicIp *PublicIp `json:"publicip,omitempty"`
+
+	Count int `json:"count,omitempty"`
+
+	IsAutoRename *bool `json:"isAutoRename,omitempty"`
+
+	RootVolume RootVolume `json:"root_volume" required:"true"`
+
+	DataVolumes []DataVolume `json:"data_volumes,omitempty"`
+
+	SecurityGroups []SecurityGroup `json:"security_groups,omitempty"`
+
+	AvailabilityZone string `json:"availability_zone" required:"true"`
+
+	ExtendParam *ServerExtendParam `json:"extendparam,omitempty"`
+
+	MetaData *MetaData `json:"metadata,omitempty"`
+
+	SchedulerHints *SchedulerHints `json:"os:scheduler_hints,omitempty"`
+
+	Tags []string `json:"tags,omitempty"`
+
+	ServerTags []ServerTags `json:"server_tags,omitempty"`
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToServerCreateMap() (map[string]interface{}, error)
+}
+
+// ToServerCreateMap assembles a request body based on the contents of a
+// CreateOpts.
+func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.UserData != nil {
+		var userData string
+		if _, err := base64.StdEncoding.DecodeString(string(opts.UserData)); err != nil {
+			userData = base64.StdEncoding.EncodeToString(opts.UserData)
+		} else {
+			userData = string(opts.UserData)
+		}
+		b["user_data"] = &userData
+	}
+
+	return map[string]interface{}{"server": b}, nil
+}
+
+type Nic struct {
+	SubnetId string `json:"subnet_id" required:"true"`
+
+	IpAddress string `json:"ip_address,omitempty"`
+}
+
+type PublicIp struct {
+	Id string `json:"id,omitempty"`
+
+	Eip *Eip `json:"eip,omitempty"`
+}
+
+type Eip struct {
+	IpType string `json:"iptype" required:"true"`
+
+	BandWidth *BandWidth `json:"bandwidth" required:"true"`
+
+	ExtendParam *EipExtendParam `json:"extendparam,omitempty"`
+}
+
+type BandWidth struct {
+	Size int `json:"size,omitempty"`
+
+	ShareType string `json:"sharetype" required:"true"`
+
+	ChargeMode string `json:"chargemode,omitempty"`
+
+	Id string `json:"id,omitempty"`
+}
+
+type EipExtendParam struct {
+	ChargingMode string `json:"chargingMode,omitempty"`
+}
+
+type RootVolume struct {
+	VolumeType string `json:"volumetype" required:"true"`
+
+	Size int `json:"size,omitempty"`
+
+	ExtendParam *VolumeExtendParam `json:"extendparam,omitempty"`
+}
+
+type DataVolume struct {
+	VolumeType string `json:"volumetype" required:"true"`
+
+	Size int `json:"size" required:"true"`
+
+	MultiAttach *bool `json:"multiattach,omitempty"`
+
+	PassThrough *bool `json:"hw:passthrough,omitempty"`
+
+	Extendparam *VolumeExtendParam `json:"extendparam,omitempty"`
+}
+
+type VolumeExtendParam struct {
+	SnapshotId string `json:"snapshotId,omitempty"`
+}
+
+type ServerExtendParam struct {
+	ChargingMode string `json:"chargingMode,omitempty"`
+
+	RegionID string `json:"regionID,omitempty"`
+
+	PeriodType string `json:"periodType,omitempty"`
+
+	PeriodNum int `json:"periodNum,omitempty"`
+
+	IsAutoRenew string `json:"isAutoRenew,omitempty"`
+
+	IsAutoPay string `json:"isAutoPay,omitempty"`
+
+	SupportAutoRecovery string `json:"support_auto_recovery,omitempty"`
+}
+
+type MetaData struct {
+	OpSvcUserId string `json:"op_svc_userid,omitempty"`
+}
+
+type SecurityGroup struct {
+	ID string `json:"id" required:"true"`
+}
+
+type SchedulerHints struct {
+	Group string `json:"group,omitempty"`
+}
+
+type ServerTags struct {
+	Key   string `json:"key" required:"true"`
+	Value string `json:"value,omitempty"`
+}
+
+// Create requests a server to be provisioned to the user in the current tenant.
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r JobResult) {
+	reqBody, err := opts.ToServerCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(createURL(client), reqBody, &r.Body, &golangsdk.RequestOpts{OkCodes: []int{200}})
+	return
+}
+
+// Get retrieves a particular Server based on its unique ID.
+func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, id), &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 203},
+	})
+	return
+}
+
+type DeleteOpts struct {
+	Servers        []Server `json:"servers" required:"true"`
+	DeletePublicIP bool     `json:"delete_publicip,omitempty"`
+	DeleteVolume   bool     `json:"delete_volume,omitempty"`
+}
+
+type Server struct {
+	Id string `json:"id" required:"true"`
+}
+
+// ToServerDeleteMap assembles a request body based on the contents of a
+// DeleteOpts.
+func (opts DeleteOpts) ToServerDeleteMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Delete requests a server to be deleted to the user in the current tenant.
+func Delete(client *golangsdk.ServiceClient, opts DeleteOpts) (r JobResult) {
+	reqBody, err := opts.ToServerDeleteMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(deleteURL(client), reqBody, &r.Body, &golangsdk.RequestOpts{OkCodes: []int{200}})
+	return
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToServerListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the server attributes you want to see returned. Marker and Limit are used
+// for pagination.
+type ListOpts struct {
+	// Name of the server as a string; can be queried with regular expressions.
+	// Realize that ?name=bob returns both bob and bobb. If you need to match bob
+	// only, you can use a regular expression matching the syntax of the
+	// underlying database server implemented for Compute.
+	Name string `q:"name"`
+
+	// Flavor is the name of the flavor in URL format.
+	Flavor string `q:"flavor"`
+
+	// Status is the value of the status of the server so that you can filter on
+	// "ACTIVE" for example.
+	Status string `q:"status"`
+
+	// Specifies the ECS that is bound to an enterprise project.
+	EnterpriseProjectID string `q:"enterprise_project_id"`
+
+	// Indicates the filtering result for IPv4 addresses, which are fuzzy matched.
+	// These IP addresses are private IP addresses of the ECS.
+	IP string `q:"ip"`
+
+	// Specifies the maximum number of ECSs on one page.
+	// Each page contains 25 ECSs by default, and a maximum of 1000 ECSs are returned.
+	Limit int `q:"limit"`
+
+	// Specifies a page number. The default value is 1.
+	// The value must be greater than or equal to 0. If the value is 0, the first page is displayed.
+	Offset int `q:"offset"`
+}
+
+// ToServerListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToServerListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List makes a request against the API to list servers accessible to you.
+func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listDetailURL(client)
+	if opts != nil {
+		query, err := opts.ToServerListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return ServerPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers/results.go
@@ -1,0 +1,177 @@
+package cloudservers
+
+import (
+	"time"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+type cloudServerResult struct {
+	golangsdk.Result
+}
+
+type Flavor struct {
+	Disk  string `json:"disk"`
+	Vcpus string `json:"vcpus"`
+	RAM   string `json:"ram"`
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+}
+
+// Image defines a image struct in details of a server.
+type Image struct {
+	ID string `json:"id"`
+}
+
+type SysTags struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type OsSchedulerHints struct {
+	Group []string `json:"group"`
+}
+
+// Metadata is only used for method that requests details on a single server, by ID.
+// Because metadata struct must be a map.
+type Metadata struct {
+	ChargingMode      string `json:"charging_mode"`
+	OrderID           string `json:"metering.order_id"`
+	ProductID         string `json:"metering.product_id"`
+	VpcID             string `json:"vpc_id"`
+	EcmResStatus      string `json:"EcmResStatus"`
+	ImageID           string `json:"metering.image_id"`
+	Imagetype         string `json:"metering.imagetype"`
+	Resourcespeccode  string `json:"metering.resourcespeccode"`
+	ImageName         string `json:"image_name"`
+	OsBit             string `json:"os_bit"`
+	LockCheckEndpoint string `json:"lock_check_endpoint"`
+	LockSource        string `json:"lock_source"`
+	LockSourceID      string `json:"lock_source_id"`
+	LockScene         string `json:"lock_scene"`
+	VirtualEnvType    string `json:"virtual_env_type"`
+}
+
+type Address struct {
+	Version string `json:"version"`
+	Addr    string `json:"addr"`
+	MacAddr string `json:"OS-EXT-IPS-MAC:mac_addr"`
+	PortID  string `json:"OS-EXT-IPS:port_id"`
+	Type    string `json:"OS-EXT-IPS:type"`
+}
+
+type VolumeAttached struct {
+	ID                  string `json:"id"`
+	DeleteOnTermination string `json:"delete_on_termination"`
+	BootIndex           string `json:"bootIndex"`
+	Device              string `json:"device"`
+}
+
+type SecurityGroups struct {
+	Name string `json:"name"`
+}
+
+// CloudServer is only used for method that requests details on a single server, by ID.
+// Because metadata struct must be a map.
+type CloudServer struct {
+	Status              string               `json:"status"`
+	Updated             time.Time            `json:"updated"`
+	HostID              string               `json:"hostId"`
+	Addresses           map[string][]Address `json:"addresses"`
+	ID                  string               `json:"id"`
+	Name                string               `json:"name"`
+	AccessIPv4          string               `json:"accessIPv4"`
+	AccessIPv6          string               `json:"accessIPv6"`
+	Created             time.Time            `json:"created"`
+	Tags                []string             `json:"tags"`
+	Description         string               `json:"description"`
+	Locked              *bool                `json:"locked"`
+	ConfigDrive         string               `json:"config_drive"`
+	TenantID            string               `json:"tenant_id"`
+	UserID              string               `json:"user_id"`
+	HostStatus          string               `json:"host_status"`
+	EnterpriseProjectID string               `json:"enterprise_project_id"`
+	SysTags             []SysTags            `json:"sys_tags"`
+	Flavor              Flavor               `json:"flavor"`
+	Metadata            Metadata             `json:"metadata"`
+	SecurityGroups      []SecurityGroups     `json:"security_groups"`
+	KeyName             string               `json:"key_name"`
+	Image               Image                `json:"image"`
+	Progress            *int                 `json:"progress"`
+	PowerState          *int                 `json:"OS-EXT-STS:power_state"`
+	VMState             string               `json:"OS-EXT-STS:vm_state"`
+	TaskState           string               `json:"OS-EXT-STS:task_state"`
+	DiskConfig          string               `json:"OS-DCF:diskConfig"`
+	AvailabilityZone    string               `json:"OS-EXT-AZ:availability_zone"`
+	LaunchedAt          string               `json:"OS-SRV-USG:launched_at"`
+	TerminatedAt        string               `json:"OS-SRV-USG:terminated_at"`
+	RootDeviceName      string               `json:"OS-EXT-SRV-ATTR:root_device_name"`
+	RamdiskID           string               `json:"OS-EXT-SRV-ATTR:ramdisk_id"`
+	KernelID            string               `json:"OS-EXT-SRV-ATTR:kernel_id"`
+	LaunchIndex         *int                 `json:"OS-EXT-SRV-ATTR:launch_index"`
+	ReservationID       string               `json:"OS-EXT-SRV-ATTR:reservation_id"`
+	Hostname            string               `json:"OS-EXT-SRV-ATTR:hostname"`
+	UserData            string               `json:"OS-EXT-SRV-ATTR:user_data"`
+	Host                string               `json:"OS-EXT-SRV-ATTR:host"`
+	InstanceName        string               `json:"OS-EXT-SRV-ATTR:instance_name"`
+	HypervisorHostname  string               `json:"OS-EXT-SRV-ATTR:hypervisor_hostname"`
+	VolumeAttached      []VolumeAttached     `json:"os-extended-volumes:volumes_attached"`
+	OsSchedulerHints    OsSchedulerHints     `json:"os:scheduler_hints"`
+}
+
+// NewCloudServer defines the response from details on a single server, by ID.
+type NewCloudServer struct {
+	CloudServer
+	Metadata map[string]string `json:"metadata"`
+}
+
+// GetResult is the response from a Get operation. Call its Extract
+// method to interpret it as a Server.
+type GetResult struct {
+	cloudServerResult
+}
+
+func (r GetResult) Extract() (*CloudServer, error) {
+	var s struct {
+		Server *CloudServer `json:"server"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Server, err
+}
+
+// ServerPage abstracts the raw results of making a List() request against
+// the API.
+type ServerPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty returns true if a page contains no Server results.
+func (r ServerPage) IsEmpty() (bool, error) {
+	s, err := ExtractServers(r)
+	return len(s) == 0, err
+}
+
+// NextPageURL uses the response's embedded link reference to navigate to the
+// next page of results.
+func (r ServerPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []golangsdk.Link `json:"servers_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return golangsdk.ExtractNextURL(s.Links)
+}
+
+// ExtractServers interprets the results of a single page from a List() call,
+// producing a slice of CloudServer entities.
+func ExtractServers(r pagination.Page) ([]CloudServer, error) {
+	var s struct {
+		Servers []CloudServer `json:"servers"`
+	}
+
+	err := (r.(ServerPage)).ExtractInto(&s)
+	return s.Servers, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers/results_job.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers/results_job.go
@@ -1,0 +1,116 @@
+package cloudservers
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/huaweicloud/golangsdk"
+)
+
+type JobResponse struct {
+	JobID string `json:"job_id"`
+}
+
+type JobStatus struct {
+	Status     string    `json:"status"`
+	Entities   JobEntity `json:"entities"`
+	JobID      string    `json:"job_id"`
+	JobType    string    `json:"job_type"`
+	BeginTime  string    `json:"begin_time"`
+	EndTime    string    `json:"end_time"`
+	ErrorCode  string    `json:"error_code"`
+	FailReason string    `json:"fail_reason"`
+}
+
+type JobEntity struct {
+	// Specifies the number of subtasks.
+	// When no subtask exists, the value of this parameter is 0.
+	SubJobsTotal int `json:"sub_jobs_total"`
+
+	// Specifies the execution information of a subtask.
+	// When no subtask exists, the value of this parameter is left blank.
+	SubJobs []SubJob `json:"sub_jobs"`
+}
+
+type SubJob struct {
+	// Specifies the task ID.
+	Id string `json:"job_id"`
+
+	// Task type.
+	Type string `json:"job_type"`
+
+	//Specifies the task status.
+	//  SUCCESS: indicates the task is successfully executed.
+	//  RUNNING: indicates that the task is in progress.
+	//  FAIL: indicates that the task failed.
+	//  INIT: indicates that the task is being initialized.
+	Status string `json:"status"`
+
+	// Specifies the time when the task started.
+	BeginTime string `json:"begin_time"`
+
+	// Specifies the time when the task finished.
+	EndTime string `json:"end_time"`
+
+	// Specifies the returned error code when the task execution fails.
+	ErrorCode string `json:"error_code"`
+
+	// Specifies the cause of the task execution failure.
+	FailReason string `json:"fail_reason"`
+
+	// Specifies the object of the task.
+	Entities map[string]string `json:"entities"`
+}
+
+type JobResult struct {
+	golangsdk.Result
+}
+
+func (r JobResult) ExtractJobResponse() (*JobResponse, error) {
+	job := new(JobResponse)
+	err := r.ExtractInto(job)
+	return job, err
+}
+
+func (r JobResult) ExtractJobStatus() (*JobStatus, error) {
+	job := new(JobStatus)
+	err := r.ExtractInto(job)
+	return job, err
+}
+
+func WaitForJobSuccess(client *golangsdk.ServiceClient, secs int, jobID string) error {
+	return golangsdk.WaitFor(secs, func() (bool, error) {
+		job := new(JobStatus)
+		_, err := client.Get(jobURL(client, jobID), &job, nil)
+		time.Sleep(5 * time.Second)
+		if err != nil {
+			return false, err
+		}
+
+		if job.Status == "SUCCESS" {
+			return true, nil
+		}
+		if job.Status == "FAIL" {
+			err = fmt.Errorf("Job failed with code %s: %s.\n", job.ErrorCode, job.FailReason)
+			return false, err
+		}
+
+		return false, nil
+	})
+}
+
+func GetJobEntity(client *golangsdk.ServiceClient, jobID string, label string) (interface{}, error) {
+	job := new(JobStatus)
+	_, err := client.Get(jobURL(client, jobID), &job, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if job.Status == "SUCCESS" {
+		if e := job.Entities.SubJobs[0].Entities[label]; e != "" {
+			return e, nil
+		}
+	}
+
+	return nil, fmt.Errorf("Unexpected conversion error in GetJobEntity.")
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers/urls.go
@@ -1,0 +1,23 @@
+package cloudservers
+
+import "github.com/huaweicloud/golangsdk"
+
+func createURL(sc *golangsdk.ServiceClient) string {
+	return sc.ServiceURL("cloudservers")
+}
+
+func deleteURL(sc *golangsdk.ServiceClient) string {
+	return sc.ServiceURL("cloudservers", "delete")
+}
+
+func getURL(sc *golangsdk.ServiceClient, serverID string) string {
+	return sc.ServiceURL("cloudservers", serverID)
+}
+
+func listDetailURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL("cloudservers", "detail")
+}
+
+func jobURL(sc *golangsdk.ServiceClient, jobId string) string {
+	return sc.ServiceURL("jobs", jobId)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -183,7 +183,7 @@ github.com/hashicorp/terraform-plugin-sdk/plugin
 github.com/hashicorp/terraform-plugin-sdk/terraform
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20201204094050-adf7043d8e5d
+# github.com/huaweicloud/golangsdk v0.0.0-20201217022317-b78db54d0391
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -235,6 +235,8 @@ github.com/huaweicloud/golangsdk/openstack/drs/v2/replicationconsistencygroups
 github.com/huaweicloud/golangsdk/openstack/drs/v2/replications
 github.com/huaweicloud/golangsdk/openstack/dws/cluster
 github.com/huaweicloud/golangsdk/openstack/ecs/v1/auto_recovery
+github.com/huaweicloud/golangsdk/openstack/ecs/v1/block_devices
+github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers
 github.com/huaweicloud/golangsdk/openstack/ecs/v1/tags
 github.com/huaweicloud/golangsdk/openstack/identity/v2/tenants
 github.com/huaweicloud/golangsdk/openstack/identity/v2/tokens

--- a/website/docs/d/compute_instance_v2.html.md
+++ b/website/docs/d/compute_instance_v2.html.md
@@ -1,0 +1,76 @@
+---
+layout: "flexibleengine"
+page_title: "FlexibleEngine: flexibleengine_compute_instance_v2"
+sidebar_current: "docs-flexibleengine-datasource-compute-instance-v2"
+description: |-
+  Get the details of a specified compute instance from FlexibleEngine
+---
+
+# flexibleengine\_compute\_instance
+
+Use this data source to get the details of a specified compute instance.
+
+## Example Usage
+
+```hcl
+variable "server_name" {}
+
+data "flexibleengine_compute_instance_v2" "demo" {
+  name = var.server_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional) The region in which to obtain the server instance.
+
+* `name` - (Optional) Specifies the server name, which can be queried with a regular expression.
+
+* `fixed_ip_v4` - (Optional)  Specifies the IPv4 addresses of the server.
+
+* `flavor_id` - (Optional) Specifies the flavor ID.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The instance ID in UUID format.
+* `availability_zone` - The availability zone where the instance is located.
+* `image_id` - The image ID of the instance.
+* `image_name` - The image name of the instance.
+* `flavor_name` - The flavor name of the instance.
+* `key_pair` - The key pair that is used to authenticate the instance.
+* `floating_ip` - The EIP address that is associted to the instance.
+* `system_disk_id` - The system disk voume ID.
+* `security_groups` - An array of one or more security group names
+    to associate with the instance.
+* `network` - An array of one or more networks to attach to the instance.
+    The network object structure is documented below.
+* `block_device` - An array of one or more disks to attach to the instance.
+    The block_device object structure is documented below.
+* `scheduler_hints` - The scheduler with hints on how the instance should be launched.
+    The available hints are described below.
+* `tags` - The key/value pairs to associate with the instance.
+* `status` - The status of the instance.
+
+The `network` block supports:
+
+* `uuid` - The network UUID to attach to the server.
+* `port` - The port ID corresponding to the IP address on that network.
+* `mac` - The MAC address of the NIC on that network.
+* `fixed_ip_v4` - The fixed IPv4 address of the instance on this network.
+* `fixed_ip_v6` - The Fixed IPv6 address of the instance on that network.
+
+The `volume_attached` block supports:
+
+* `uuid` - The volume id on that attachment.
+* `boot_index` - The volume boot index on that attachment.
+* `size` - The volume size on that attachment.
+* `pci_address` - The volume pci address on that attachment.
+
+The `scheduler_hints` block supports:
+
+* `group` - The UUID of a Server Group where the instance will be placed into.

--- a/website/flexibleengine.erb
+++ b/website/flexibleengine.erb
@@ -43,6 +43,9 @@
             <li<%= sidebar_current("docs-flexibleengine-datasource-compute-availability-zones-v2") %>>
               <a href="/docs/providers/flexibleengine/d/compute_availability_zones_v2.html">flexibleengine_compute_availability_zones_v2</a>
             </li>
+            <li<%= sidebar_current("docs-flexibleengine-datasource-compute-instance-v2") %>>
+              <a href="/docs/providers/flexibleengine/d/compute_instance_v2.html">flexibleengine_compute_instance_v2</a>
+            </li>
             <li<%= sidebar_current("docs-flexibleengine-datasource-csbs-backup-v1") %>>
               <a href="/docs/providers/flexibleengine/d/csbs_backup_v1.html">flexibleengine_csbs_backup_v1</a>
             </li>


### PR DESCRIPTION
the testing result as follows:

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccComputeInstanceDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccComputeInstanceDataSource_basic -timeout 720m
=== RUN   TestAccComputeInstanceDataSource_basic
=== PAUSE TestAccComputeInstanceDataSource_basic
=== CONT  TestAccComputeInstanceDataSource_basic
--- PASS: TestAccComputeInstanceDataSource_basic (226.41s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 226.423s
```