### PR TITLE
support to import compute instance and add more attributes

### DIFF
--- a/flexibleengine/resource_flexibleengine_compute_instance_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_compute_instance_v2_test.go
@@ -16,6 +16,7 @@ import (
 
 func TestAccComputeV2Instance_basic(t *testing.T) {
 	var instance servers.Server
+	resourceName := "flexibleengine_compute_instance_v2.instance_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -25,14 +26,10 @@ func TestAccComputeV2Instance_basic(t *testing.T) {
 			{
 				Config: testAccComputeV2Instance_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeV2InstanceExists("flexibleengine_compute_instance_v2.instance_1", &instance),
+					testAccCheckComputeV2InstanceExists(resourceName, &instance),
 					testAccCheckComputeV2InstanceMetadata(&instance, "foo", "bar"),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_compute_instance_v2.instance_1", "all_metadata.foo", "bar"),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_compute_instance_v2.instance_1", "availability_zone", OS_AVAILABILITY_ZONE),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_compute_instance_v2.instance_1", "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "availability_zone", OS_AVAILABILITY_ZONE),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
 		},

--- a/website/docs/d/compute_instance_v2.html.md
+++ b/website/docs/d/compute_instance_v2.html.md
@@ -45,6 +45,7 @@ In addition to all arguments above, the following attributes are exported:
 * `key_pair` - The key pair that is used to authenticate the instance.
 * `floating_ip` - The EIP address that is associted to the instance.
 * `system_disk_id` - The system disk voume ID.
+* `user_data` -  The user data (information after encoding) configured during instance creation.
 * `security_groups` - An array of one or more security group names
     to associate with the instance.
 * `network` - An array of one or more networks to attach to the instance.
@@ -64,7 +65,7 @@ The `network` block supports:
 * `fixed_ip_v4` - The fixed IPv4 address of the instance on this network.
 * `fixed_ip_v6` - The Fixed IPv6 address of the instance on that network.
 
-The `volume_attached` block supports:
+The `block_device` block supports:
 
 * `uuid` - The volume id on that attachment.
 * `boot_index` - The volume boot index on that attachment.

--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -284,8 +284,8 @@ The following arguments are supported:
 * `flavor_name` - (Optional; Required if `flavor_id` is empty) The name of the
     desired flavor for the server. Changing this resizes the existing server.
 
-* `user_data` - (Optional) The user data to provide when launching the instance.
-    Changing this creates a new server.
+* `availability_zone` - (Optional) The availability zone in which to create
+    the server. Changing this creates a new server.
 
 * `security_groups` - (Optional) An array of one or more security group names
     to associate with the server. Changing this results in adding/removing
@@ -293,12 +293,12 @@ The following arguments are supported:
     instance to networks using Ports, place the security groups on the Port
     and not the instance.
 
-* `availability_zone` - (Optional) The availability zone in which to create
-    the server. Changing this creates a new server.
-
 * `network` - (Optional) An array of one or more networks to attach to the
     instance. The network object structure is documented below. Changing this
     creates a new server.
+
+* `user_data` - (Optional) The user data to provide when launching the instance.
+    Changing this creates a new server.
 
 * `metadata` - (Optional) Metadata key/value pairs to make available from
     within the instance. Changing this updates the existing server metadata.
@@ -426,6 +426,31 @@ The following attributes are exported:
     by Terraform.
 * `auto_recovery` - See Argument Reference above.
 * `tags` - See Argument Reference above.
+* `floating_ip` - The EIP address that is associted to the instance.
+* `system_disk_id` - The system disk voume ID.
+* `volume_attached` - An array of one or more disks to attach to the instance.
+    The volume_attached object structure is documented below.
+* `status` - The status of the instance.
+
+The `volume_attached` block supports:
+
+* `uuid` - The volume id on that attachment.
+* `boot_index` - The volume boot index on that attachment.
+* `size` - The volume size on that attachment.
+* `pci_address` - The volume pci address on that attachment.
+
+## Import
+
+Instances can be imported by their `id`. For example,
+```
+terraform import flexibleengine_compute_instance_v2.my_instance b11b407c-e604-4e8d-8bc4-92398320b847
+```
+Note that the imported state may not be identical to your resource definition, which
+could be because of a different network interface attachment order, missing ephemeral
+disk configuration, or some other reason. It is generally recommended running
+`terraform plan` after importing an instance. You can then decide if changes should
+be applied to the instance, or the resource definition should be updated to align
+with the instance.
 
 ## Notes
 


### PR DESCRIPTION
Compute instances can be imported by their `id`. For example,
```
terraform import flexibleengine_compute_instance_v2.my_instance b11b407c-e604-4e8d-8bc4-92398320b847
```