### PR TITLE
support import fixed_ip block to networking port

### DIFF
--- a/flexibleengine/import_flexibleengine_networking_port_v2_test.go
+++ b/flexibleengine/import_flexibleengine_networking_port_v2_test.go
@@ -22,9 +22,6 @@ func TestAccNetworkingV2Port_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"fixed_ip",
-				},
 			},
 		},
 	})

--- a/flexibleengine/resource_flexibleengine_networking_port_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_networking_port_v2_test.go
@@ -178,24 +178,24 @@ func testAccCheckNetworkingV2PortCountSecurityGroups(port *ports.Port, expected 
 
 const testAccNetworkingV2Port_basic = `
 resource "flexibleengine_networking_network_v2" "network_1" {
-  name = "network_1"
-  admin_state_up = "true"
+  name           = "network_1"
+  admin_state_up = true
 }
 
 resource "flexibleengine_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
   ip_version = 4
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
+  network_id = flexibleengine_networking_network_v2.network_1.id
 }
 
 resource "flexibleengine_networking_port_v2" "port_1" {
-  name = "port_1"
-  admin_state_up = "true"
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
+  name           = "port_1"
+  admin_state_up = true
+  network_id     = flexibleengine_networking_network_v2.network_1.id
 
   fixed_ip {
-    subnet_id =  "${flexibleengine_networking_subnet_v2.subnet_1.id}"
+    subnet_id  = flexibleengine_networking_subnet_v2.subnet_1.id
     ip_address = "192.168.199.23"
   }
 }
@@ -203,75 +203,75 @@ resource "flexibleengine_networking_port_v2" "port_1" {
 
 const testAccNetworkingV2Port_noip = `
 resource "flexibleengine_networking_network_v2" "network_1" {
-  name = "network_1"
-  admin_state_up = "true"
+  name           = "network_1"
+  admin_state_up = true
 }
 
 resource "flexibleengine_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
   ip_version = 4
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
+  network_id = flexibleengine_networking_network_v2.network_1.id
 }
 
 resource "flexibleengine_networking_port_v2" "port_1" {
-  name = "port_1"
-  admin_state_up = "true"
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
+  name           = "port_1"
+  admin_state_up = true
+  network_id     = flexibleengine_networking_network_v2.network_1.id
 
   fixed_ip {
-    subnet_id =  "${flexibleengine_networking_subnet_v2.subnet_1.id}"
+    subnet_id = flexibleengine_networking_subnet_v2.subnet_1.id
   }
 }
 `
 
 const testAccNetworkingV2Port_multipleNoIP = `
 resource "flexibleengine_networking_network_v2" "network_1" {
-  name = "network_1"
-  admin_state_up = "true"
+  name           = "network_1"
+  admin_state_up = true
 }
 
 resource "flexibleengine_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
   ip_version = 4
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
+  network_id = flexibleengine_networking_network_v2.network_1.id
 }
 
 resource "flexibleengine_networking_port_v2" "port_1" {
-  name = "port_1"
-  admin_state_up = "true"
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
+  name           = "port_1"
+  admin_state_up = true
+  network_id     = flexibleengine_networking_network_v2.network_1.id
 
   fixed_ip {
-    subnet_id =  "${flexibleengine_networking_subnet_v2.subnet_1.id}"
+    subnet_id = flexibleengine_networking_subnet_v2.subnet_1.id
   }
 
   fixed_ip {
-    subnet_id =  "${flexibleengine_networking_subnet_v2.subnet_1.id}"
+    subnet_id = flexibleengine_networking_subnet_v2.subnet_1.id
   }
 
   fixed_ip {
-    subnet_id =  "${flexibleengine_networking_subnet_v2.subnet_1.id}"
+    subnet_id = flexibleengine_networking_subnet_v2.subnet_1.id
   }
 }
 `
 
 const testAccNetworkingV2Port_allowedAddressPairs = `
 resource "flexibleengine_networking_network_v2" "vrrp_network" {
-  name = "vrrp_network"
-  admin_state_up = "true"
+  name           = "vrrp_network"
+  admin_state_up = true
 }
 
 resource "flexibleengine_networking_subnet_v2" "vrrp_subnet" {
-  name = "vrrp_subnet"
-  cidr = "10.0.0.0/24"
+  name       = "vrrp_subnet"
+  cidr       = "10.0.0.0/24"
   ip_version = 4
-  network_id = "${flexibleengine_networking_network_v2.vrrp_network.id}"
+  network_id = flexibleengine_networking_network_v2.vrrp_network.id
 
   allocation_pools {
     start = "10.0.0.2"
-    end = "10.0.0.200"
+    end   = "10.0.0.200"
   }
 }
 
@@ -280,79 +280,79 @@ resource "flexibleengine_networking_router_v2" "vrrp_router" {
 }
 
 resource "flexibleengine_networking_router_interface_v2" "vrrp_interface" {
-  router_id = "${flexibleengine_networking_router_v2.vrrp_router.id}"
-  subnet_id = "${flexibleengine_networking_subnet_v2.vrrp_subnet.id}"
+  router_id = flexibleengine_networking_router_v2.vrrp_router.id
+  subnet_id = flexibleengine_networking_subnet_v2.vrrp_subnet.id
 }
 
 resource "flexibleengine_networking_port_v2" "vrrp_port_1" {
-  name = "vrrp_port_1"
-  admin_state_up = "true"
-  network_id = "${flexibleengine_networking_network_v2.vrrp_network.id}"
+  name           = "vrrp_port_1"
+  admin_state_up = true
+  network_id     = flexibleengine_networking_network_v2.vrrp_network.id
 
   fixed_ip {
-    subnet_id =  "${flexibleengine_networking_subnet_v2.vrrp_subnet.id}"
+    subnet_id  = flexibleengine_networking_subnet_v2.vrrp_subnet.id
     ip_address = "10.0.0.202"
   }
 }
 
 resource "flexibleengine_networking_port_v2" "vrrp_port_2" {
-  name = "vrrp_port_2"
-  admin_state_up = "true"
-  network_id = "${flexibleengine_networking_network_v2.vrrp_network.id}"
+  name           = "vrrp_port_2"
+  admin_state_up = true
+  network_id     = flexibleengine_networking_network_v2.vrrp_network.id
 
   fixed_ip {
-    subnet_id =  "${flexibleengine_networking_subnet_v2.vrrp_subnet.id}"
+    subnet_id  = flexibleengine_networking_subnet_v2.vrrp_subnet.id
     ip_address = "10.0.0.201"
   }
 }
 
 resource "flexibleengine_networking_port_v2" "instance_port" {
-  name = "instance_port"
-  admin_state_up = "true"
-  network_id = "${flexibleengine_networking_network_v2.vrrp_network.id}"
+  name           = "instance_port"
+  admin_state_up = true
+  network_id     = flexibleengine_networking_network_v2.vrrp_network.id
 
   allowed_address_pairs {
-    ip_address = "${flexibleengine_networking_port_v2.vrrp_port_1.fixed_ip.0.ip_address}"
-    mac_address = "${flexibleengine_networking_port_v2.vrrp_port_1.mac_address}"
+    ip_address  = tolist(flexibleengine_networking_port_v2.vrrp_port_1.fixed_ip).0.ip_address
+    mac_address = flexibleengine_networking_port_v2.vrrp_port_1.mac_address
   }
 
   allowed_address_pairs {
-    ip_address = "${flexibleengine_networking_port_v2.vrrp_port_2.fixed_ip.0.ip_address}"
-    mac_address = "${flexibleengine_networking_port_v2.vrrp_port_2.mac_address}"
+    ip_address  = tolist(flexibleengine_networking_port_v2.vrrp_port_2.fixed_ip).0.ip_address
+    mac_address = flexibleengine_networking_port_v2.vrrp_port_2.mac_address
   }
 }
 `
 
 const testAccNetworkingV2Port_multipleFixedIPs = `
 resource "flexibleengine_networking_network_v2" "network_1" {
-  name = "network_1"
-  admin_state_up = "true"
+  name           = "network_1"
+  admin_state_up = true
 }
 
 resource "flexibleengine_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
   ip_version = 4
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
+  network_id = flexibleengine_networking_network_v2.network_1.id
 }
 
 resource "flexibleengine_networking_port_v2" "port_1" {
-  name = "port_1"
-  admin_state_up = "true"
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
+  name           = "port_1"
+  admin_state_up = true
+  network_id     = flexibleengine_networking_network_v2.network_1.id
 
   fixed_ip {
-    subnet_id =  "${flexibleengine_networking_subnet_v2.subnet_1.id}"
+    subnet_id  = flexibleengine_networking_subnet_v2.subnet_1.id
     ip_address = "192.168.199.23"
   }
 
   fixed_ip {
-    subnet_id =  "${flexibleengine_networking_subnet_v2.subnet_1.id}"
+    subnet_id  = flexibleengine_networking_subnet_v2.subnet_1.id
     ip_address = "192.168.199.20"
   }
 
   fixed_ip {
-    subnet_id =  "${flexibleengine_networking_subnet_v2.subnet_1.id}"
+    subnet_id  = flexibleengine_networking_subnet_v2.subnet_1.id
     ip_address = "192.168.199.40"
   }
 }
@@ -360,24 +360,24 @@ resource "flexibleengine_networking_port_v2" "port_1" {
 
 const testAccNetworkingV2Port_timeout = `
 resource "flexibleengine_networking_network_v2" "network_1" {
-  name = "network_1"
-  admin_state_up = "true"
+  name           = "network_1"
+  admin_state_up = true
 }
 
 resource "flexibleengine_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
   ip_version = 4
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
+  network_id = flexibleengine_networking_network_v2.network_1.id
 }
 
 resource "flexibleengine_networking_port_v2" "port_1" {
-  name = "port_1"
-  admin_state_up = "true"
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
+  name           = "port_1"
+  admin_state_up = true
+  network_id     = flexibleengine_networking_network_v2.network_1.id
 
   fixed_ip {
-    subnet_id =  "${flexibleengine_networking_subnet_v2.subnet_1.id}"
+    subnet_id  = flexibleengine_networking_subnet_v2.subnet_1.id
     ip_address = "192.168.199.23"
   }
 
@@ -390,29 +390,29 @@ resource "flexibleengine_networking_port_v2" "port_1" {
 
 const testAccNetworkingV2Port_fixedIPs = `
 resource "flexibleengine_networking_network_v2" "network_1" {
-  name = "network_1"
-  admin_state_up = "true"
+  name           = "network_1"
+  admin_state_up = true
 }
 
 resource "flexibleengine_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
   ip_version = 4
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
+  network_id = flexibleengine_networking_network_v2.network_1.id
 }
 
 resource "flexibleengine_networking_port_v2" "port_1" {
-  name = "port_1"
-  admin_state_up = "true"
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
+  name           = "port_1"
+  admin_state_up = true
+  network_id     = flexibleengine_networking_network_v2.network_1.id
 
   fixed_ip {
-    subnet_id =  "${flexibleengine_networking_subnet_v2.subnet_1.id}"
+    subnet_id  = flexibleengine_networking_subnet_v2.subnet_1.id
     ip_address = "192.168.199.24"
   }
 
   fixed_ip {
-    subnet_id =  "${flexibleengine_networking_subnet_v2.subnet_1.id}"
+    subnet_id  = flexibleengine_networking_subnet_v2.subnet_1.id
     ip_address = "192.168.199.23"
   }
 }
@@ -420,29 +420,29 @@ resource "flexibleengine_networking_port_v2" "port_1" {
 
 const testAccNetworkingV2Port_updateSecurityGroups_1 = `
 resource "flexibleengine_networking_network_v2" "network_1" {
-  name = "network_1"
-  admin_state_up = "true"
+  name           = "network_1"
+  admin_state_up = true
 }
 
 resource "flexibleengine_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
   ip_version = 4
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
+  network_id = flexibleengine_networking_network_v2.network_1.id
 }
 
 resource "flexibleengine_networking_secgroup_v2" "secgroup_1" {
-  name = "security_group"
+  name        = "security_group"
   description = "terraform security group acceptance test"
 }
 
 resource "flexibleengine_networking_port_v2" "port_1" {
-  name = "port_1"
-  admin_state_up = "true"
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
+  name           = "port_1"
+  admin_state_up = true
+  network_id     = flexibleengine_networking_network_v2.network_1.id
 
   fixed_ip {
-    subnet_id =  "${flexibleengine_networking_subnet_v2.subnet_1.id}"
+    subnet_id  = flexibleengine_networking_subnet_v2.subnet_1.id
     ip_address = "192.168.199.23"
   }
 }
@@ -450,30 +450,30 @@ resource "flexibleengine_networking_port_v2" "port_1" {
 
 const testAccNetworkingV2Port_updateSecurityGroups_2 = `
 resource "flexibleengine_networking_network_v2" "network_1" {
-  name = "network_1"
-  admin_state_up = "true"
+  name           = "network_1"
+  admin_state_up = true
 }
 
 resource "flexibleengine_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
   ip_version = 4
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
+  network_id = flexibleengine_networking_network_v2.network_1.id
 }
 
 resource "flexibleengine_networking_secgroup_v2" "secgroup_1" {
-  name = "security_group"
+  name        = "security_group"
   description = "terraform security group acceptance test"
 }
 
 resource "flexibleengine_networking_port_v2" "port_1" {
-  name = "port_1"
-  admin_state_up = "true"
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
-  security_group_ids = ["${flexibleengine_networking_secgroup_v2.secgroup_1.id}"]
+  name               = "port_1"
+  admin_state_up     = true
+  network_id         = flexibleengine_networking_network_v2.network_1.id
+  security_group_ids = [flexibleengine_networking_secgroup_v2.secgroup_1.id]
 
   fixed_ip {
-    subnet_id =  "${flexibleengine_networking_subnet_v2.subnet_1.id}"
+    subnet_id  = flexibleengine_networking_subnet_v2.subnet_1.id
     ip_address = "192.168.199.23"
   }
 }
@@ -481,30 +481,30 @@ resource "flexibleengine_networking_port_v2" "port_1" {
 
 const testAccNetworkingV2Port_updateSecurityGroups_3 = `
 resource "flexibleengine_networking_network_v2" "network_1" {
-  name = "network_1"
-  admin_state_up = "true"
+  name           = "network_1"
+  admin_state_up = true
 }
 
 resource "flexibleengine_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
   ip_version = 4
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
+  network_id = flexibleengine_networking_network_v2.network_1.id
 }
 
 resource "flexibleengine_networking_secgroup_v2" "secgroup_1" {
-  name = "security_group_1"
+  name        = "security_group_1"
   description = "terraform security group acceptance test"
 }
 
 resource "flexibleengine_networking_port_v2" "port_1" {
-  name = "port_1"
-  admin_state_up = "true"
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
-  security_group_ids = ["${flexibleengine_networking_secgroup_v2.secgroup_1.id}"]
+  name               = "port_1"
+  admin_state_up     = true
+  network_id         = flexibleengine_networking_network_v2.network_1.id
+  security_group_ids = [flexibleengine_networking_secgroup_v2.secgroup_1.id]
 
   fixed_ip {
-    subnet_id =  "${flexibleengine_networking_subnet_v2.subnet_1.id}"
+    subnet_id  = flexibleengine_networking_subnet_v2.subnet_1.id
     ip_address = "192.168.199.23"
   }
 }
@@ -512,30 +512,30 @@ resource "flexibleengine_networking_port_v2" "port_1" {
 
 const testAccNetworkingV2Port_updateSecurityGroups_4 = `
 resource "flexibleengine_networking_network_v2" "network_1" {
-  name = "network_1"
-  admin_state_up = "true"
+  name           = "network_1"
+  admin_state_up = true
 }
 
 resource "flexibleengine_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
+  name       = "subnet_1"
+  cidr       = "192.168.199.0/24"
   ip_version = 4
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
+  network_id = flexibleengine_networking_network_v2.network_1.id
 }
 
 resource "flexibleengine_networking_secgroup_v2" "secgroup_1" {
-  name = "security_group"
+  name        = "security_group"
   description = "terraform security group acceptance test"
 }
 
 resource "flexibleengine_networking_port_v2" "port_1" {
-  name = "port_1"
-  admin_state_up = "true"
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
+  name               = "port_1"
+  admin_state_up     = true
+  network_id         = flexibleengine_networking_network_v2.network_1.id
 	security_group_ids = []
 
   fixed_ip {
-    subnet_id =  "${flexibleengine_networking_subnet_v2.subnet_1.id}"
+    subnet_id  = flexibleengine_networking_subnet_v2.subnet_1.id
     ip_address = "192.168.199.23"
   }
 }


### PR DESCRIPTION
the testing result as follows:
```
make testacc TEST='./flexibleengine' TESTARGS='-run TestAccNetworkingV2Port'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccNetworkingV2Port -timeout 720m
=== RUN   TestAccNetworkingV2Port_importBasic
--- PASS: TestAccNetworkingV2Port_importBasic (61.74s)
=== RUN   TestAccNetworkingV2Port_basic
--- PASS: TestAccNetworkingV2Port_basic (69.90s)
=== RUN   TestAccNetworkingV2Port_fixedip
--- PASS: TestAccNetworkingV2Port_fixedip (71.48s)
=== RUN   TestAccNetworkingV2Port_allowedAddressPairs
--- PASS: TestAccNetworkingV2Port_allowedAddressPairs (81.09s)
=== RUN   TestAccNetworkingV2Port_securityGroup
--- PASS: TestAccNetworkingV2Port_securityGroup (73.58s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 344.863s
```