### PR TITLE
add vpc endpoint service resource and docs

### DIFF
--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -312,6 +312,7 @@ func Provider() terraform.ResourceProvider {
 			"flexibleengine_sdrs_protectedinstance_v1":          resourceSdrsProtectedInstanceV1(),
 			"flexibleengine_sdrs_replication_pair_v1":           resourceSdrsReplicationPairV1(),
 			"flexibleengine_sdrs_replication_attach_v1":         resourceSdrsReplicationAttachV1(),
+			"flexibleengine_vpcep_service":                      resourceVPCEndpointService(),
 		},
 	}
 

--- a/flexibleengine/resource_flexibleengine_vpcep_service.go
+++ b/flexibleengine/resource_flexibleengine_vpcep_service.go
@@ -1,0 +1,423 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services"
+)
+
+func resourceVPCEndpointService() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVPCEndpointServiceCreate,
+		Read:   resourceVPCEndpointServiceRead,
+		Update: resourceVPCEndpointServiceUpdate,
+		Delete: resourceVPCEndpointServiceDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"server_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"port_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"port_mapping": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"protocol": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "TCP",
+						},
+						"service_port": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"terminal_port": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[a-zA-Z0-9_-]{0,16}$"),
+					"The name must have a maximum of 16 characters, and only contains letters, digits, underscores (_), and hyphens (-)."),
+			},
+			"service_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "interface",
+				ValidateFunc: validation.StringInSlice([]string{"interface"}, false),
+			},
+			"approval": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"permissions": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"service_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"connections": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"endpoint_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"packet_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"domain_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func expandPortMappingOpts(d *schema.ResourceData) []services.PortOpts {
+	portMapping := d.Get("port_mapping").([]interface{})
+
+	portOpts := make([]services.PortOpts, len(portMapping))
+	for i, raw := range portMapping {
+		port := raw.(map[string]interface{})
+		portOpts[i].Protocol = port["protocol"].(string)
+		portOpts[i].ServerPort = port["service_port"].(int)
+		portOpts[i].ClientPort = port["terminal_port"].(int)
+	}
+	return portOpts
+}
+
+func doPermissionAction(client *golangsdk.ServiceClient, serviceID, action string, raw []interface{}) error {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	permissions := make([]string, len(raw))
+	for i, v := range raw {
+		permissions[i] = v.(string)
+	}
+	permOpts := services.PermActionOpts{
+		Action:      action,
+		Permissions: permissions,
+	}
+
+	log.Printf("[DEBUG] %s permissions %#v to VPC endpoint service %s", action, permissions, serviceID)
+	result := services.PermAction(client, serviceID, permOpts)
+
+	return result.Err
+}
+
+func resourceVPCEndpointServiceCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	vpcepClient, err := config.vpcepV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine VPC endpoint client: %s", err)
+	}
+
+	approval := d.Get("approval").(bool)
+	createOpts := services.CreateOpts{
+		VpcID:       d.Get("vpc_id").(string),
+		PortID:      d.Get("port_id").(string),
+		ServerType:  d.Get("server_type").(string),
+		ServiceName: d.Get("name").(string),
+		ServiceType: d.Get("service_type").(string),
+		Approval:    &approval,
+		Ports:       expandPortMappingOpts(d),
+	}
+	//set tags
+	tagRaw := d.Get("tags").(map[string]interface{})
+	if len(tagRaw) > 0 {
+		taglist := expandResourceTags(tagRaw)
+		createOpts.Tags = taglist
+	}
+
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	n, err := services.Create(vpcepClient, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine VPC endpoint service: %s", err)
+	}
+
+	d.SetId(n.ID)
+	log.Printf("[INFO] Waiting for FlexibleEngine VPC endpoint service(%s) to become available", n.ID)
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"creating"},
+		Target:     []string{"available"},
+		Refresh:    waitForResourceStatus(vpcepClient, n.ID),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, stateErr := stateConf.WaitForState()
+	if stateErr != nil {
+		return fmt.Errorf(
+			"Error waiting for VPC endpoint service(%s) to become available: %s",
+			n.ID, stateErr)
+	}
+
+	// add permissions
+	raw := d.Get("permissions").(*schema.Set).List()
+	err = doPermissionAction(vpcepClient, d.Id(), "add", raw)
+	if err != nil {
+		return fmt.Errorf("Error adding permissions to VPC endpoint service %s: %s", d.Id(), err)
+	}
+
+	return resourceVPCEndpointServiceRead(d, meta)
+}
+
+func resourceVPCEndpointServiceRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	vpcepClient, err := config.vpcepV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine VPC endpoint client: %s", err)
+	}
+
+	n, err := services.Get(vpcepClient, d.Id()).Extract()
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error retrieving FlexibleEngine VPC endpoint service: %s", err)
+	}
+
+	log.Printf("[DEBUG] retrieving FlexibleEngine VPC endpoint service: %#v", n)
+	d.Set("region", GetRegion(d, config))
+	d.Set("status", n.Status)
+	d.Set("service_name", n.ServiceName)
+	nameList := strings.Split(n.ServiceName, ".")
+	if len(nameList) > 2 {
+		d.Set("name", nameList[1])
+	}
+
+	d.Set("vpc_id", n.VpcID)
+	d.Set("port_id", n.PortID)
+	d.Set("approval", n.Approval)
+	d.Set("server_type", n.ServerType)
+	d.Set("service_type", n.ServiceType)
+
+	ports := make([]map[string]interface{}, len(n.Ports))
+	for i, v := range n.Ports {
+		ports[i] = map[string]interface{}{
+			"protocol":      v.Protocol,
+			"service_port":  v.ServerPort,
+			"terminal_port": v.ClientPort,
+		}
+	}
+	d.Set("port_mapping", ports)
+
+	// fetch tags from Services.Service
+	tagmap := make(map[string]string)
+	for _, val := range n.Tags {
+		tagmap[val.Key] = val.Value
+	}
+	d.Set("tags", tagmap)
+
+	// fetch connections
+	if conns, err := flattenVPCEndpointConnections(vpcepClient, d.Id()); err == nil {
+		d.Set("connections", conns)
+	}
+
+	// fetch permissions
+	if perms, err := flattenVPCEndpointPermissions(vpcepClient, d.Id()); err == nil {
+		d.Set("permissions", perms)
+	}
+	return nil
+}
+
+func resourceVPCEndpointServiceUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	vpcepClient, err := config.vpcepV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine VPC endpoint client: %s", err)
+	}
+
+	updateOpts := services.UpdateOpts{
+		ServiceName: d.Get("name").(string),
+	}
+
+	if d.HasChange("approval") {
+		approval := d.Get("approval").(bool)
+		updateOpts.Approval = &approval
+	}
+	if d.HasChange("port_id") {
+		updateOpts.PortID = d.Get("port_id").(string)
+	}
+	if d.HasChange("port_mapping") {
+		updateOpts.Ports = expandPortMappingOpts(d)
+	}
+
+	_, err = services.Update(vpcepClient, d.Id(), updateOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error updating FlexibleEngine VPC endpoint service: %s", err)
+	}
+
+	//update tags
+	if d.HasChange("tags") {
+		tagErr := UpdateResourceTags(vpcepClient, d, tagVPCEPService, d.Id())
+		if tagErr != nil {
+			return fmt.Errorf("Error updating tags of VPC endpoint service %s: %s", d.Id(), tagErr)
+		}
+	}
+
+	// update
+	if d.HasChange("permissions") {
+		old, new := d.GetChange("permissions")
+		oldPermSet := old.(*schema.Set)
+		newPermSet := new.(*schema.Set)
+		added := newPermSet.Difference(oldPermSet)
+		removed := oldPermSet.Difference(newPermSet)
+
+		err = doPermissionAction(vpcepClient, d.Id(), "add", added.List())
+		if err != nil {
+			return fmt.Errorf("Error adding permissions to VPC endpoint service %s: %s", d.Id(), err)
+		}
+
+		err = doPermissionAction(vpcepClient, d.Id(), "remove", removed.List())
+		if err != nil {
+			return fmt.Errorf("Error removing permissions to VPC endpoint service %s: %s", d.Id(), err)
+		}
+	}
+
+	return resourceVPCEndpointServiceRead(d, meta)
+}
+
+func resourceVPCEndpointServiceDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	vpcepClient, err := config.vpcepV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine VPC endpoint client: %s", err)
+	}
+
+	err = services.Delete(vpcepClient, d.Id()).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("Error deleting FlexibleEngine VPC endpoint service %s: %s", d.Id(), err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"available", "deleting"},
+		Target:     []string{"deleted"},
+		Refresh:    waitForResourceStatus(vpcepClient, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error deleting FlexibleEngine VPC endpoint service %s: %s", d.Id(), err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func flattenVPCEndpointConnections(client *golangsdk.ServiceClient, id string) ([]map[string]interface{}, error) {
+	allConns, err := services.ListConnections(client, id, nil)
+	if err != nil {
+		log.Printf("[WARN] Error querying connections of VPC endpoint service: %s", err)
+		return nil, err
+	}
+
+	log.Printf("[DEBUG] retrieving connections of VPC endpoint service: %#v", allConns)
+	connections := make([]map[string]interface{}, len(allConns))
+	for i, v := range allConns {
+		connections[i] = map[string]interface{}{
+			"endpoint_id": v.EndpointID,
+			"packet_id":   v.MarkerID,
+			"domain_id":   v.DomainID,
+			"status":      v.Status,
+		}
+	}
+
+	return connections, nil
+}
+
+func flattenVPCEndpointPermissions(client *golangsdk.ServiceClient, id string) ([]string, error) {
+	allPerms, err := services.ListPermissions(client, id)
+	if err != nil {
+		log.Printf("[WARN] Error querying permissions of VPC endpoint service: %s", err)
+		return nil, err
+	}
+
+	log.Printf("[DEBUG] retrieving permissions of VPC endpoint service: %#v", allPerms)
+	perms := make([]string, len(allPerms))
+	for i, v := range allPerms {
+		perms[i] = v.Permission
+	}
+
+	return perms, nil
+}
+
+func waitForResourceStatus(vpcepClient *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		n, err := services.Get(vpcepClient, id).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				log.Printf("[INFO] Successfully deleted FlexibleEngine VPC endpoint service %s", id)
+				return n, "deleted", nil
+			}
+			return n, "error", err
+		}
+
+		return n, n.Status, nil
+	}
+}

--- a/flexibleengine/resource_flexibleengine_vpcep_service_test.go
+++ b/flexibleengine/resource_flexibleengine_vpcep_service_test.go
@@ -1,0 +1,246 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services"
+)
+
+func TestAccVPCEPServiceBasic(t *testing.T) {
+	var service services.Service
+
+	rName := fmt.Sprintf("acc-test-%s", acctest.RandString(4))
+	resourceName := "flexibleengine_vpcep_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVPCEPServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCEPServiceBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCEPServiceExists(resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", "available"),
+					resource.TestCheckResourceAttr(resourceName, "approval", "false"),
+					resource.TestCheckResourceAttr(resourceName, "server_type", "VM"),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "interface"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "tf-acc"),
+					resource.TestCheckResourceAttr(resourceName, "port_mapping.0.protocol", "TCP"),
+					resource.TestCheckResourceAttr(resourceName, "port_mapping.0.service_port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "port_mapping.0.terminal_port", "80"),
+				),
+			},
+			{
+				Config: testAccVPCEPServiceUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", "tf-"+rName),
+					resource.TestCheckResourceAttr(resourceName, "status", "available"),
+					resource.TestCheckResourceAttr(resourceName, "approval", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "tf-acc-update"),
+					resource.TestCheckResourceAttr(resourceName, "port_mapping.0.protocol", "TCP"),
+					resource.TestCheckResourceAttr(resourceName, "port_mapping.0.service_port", "8088"),
+					resource.TestCheckResourceAttr(resourceName, "port_mapping.0.terminal_port", "80"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccVPCEPServicePermission(t *testing.T) {
+	var service services.Service
+
+	rName := fmt.Sprintf("acc-test-%s", acctest.RandString(4))
+	resourceName := "flexibleengine_vpcep_service.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVPCEPServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCEPServicePermission(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCEPServiceExists(resourceName, &service),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", "available"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "2"),
+				),
+			},
+			{
+				Config: testAccVPCEPServicePermissionUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", "available"),
+					resource.TestCheckResourceAttr(resourceName, "permissions.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVPCEPServiceDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	vpcepClient, err := config.vpcepV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating VPC endpoint client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_vpcep_service" {
+			continue
+		}
+
+		_, err := services.Get(vpcepClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("VPC endpoint service still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckVPCEPServiceExists(n string, service *services.Service) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		vpcepClient, err := config.vpcepV1Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating VPC endpoint client: %s", err)
+		}
+
+		found, err := services.Get(vpcepClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("VPC endpoint service not found")
+		}
+
+		*service = *found
+
+		return nil
+	}
+}
+
+func testAccVPCEPServicePrecondition(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_compute_instance_v2" "instance_1" {
+  name = "%s"
+  security_groups = ["default"]
+  availability_zone = "%s"
+
+  network {
+    uuid = "%s"
+  }
+  tags = {
+    owner   = "terraform"
+    service = "vpc-endpoint"
+  }
+}
+`, rName, OS_AVAILABILITY_ZONE, OS_NETWORK_ID)
+}
+
+func testAccVPCEPServiceBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpcep_service" "test" {
+  name        = "%s"
+  server_type = "VM"
+  vpc_id      = "%s"
+  port_id     = flexibleengine_compute_instance_v2.instance_1.network[0].port
+  approval    = false
+
+  port_mapping {
+    service_port  = 8080
+    terminal_port = 80
+  }
+  tags = {
+    owner = "tf-acc"
+  }
+}
+`, testAccVPCEPServicePrecondition(rName), rName, OS_VPC_ID)
+}
+
+func testAccVPCEPServiceUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpcep_service" "test" {
+  name        = "tf-%s"
+  server_type = "VM"
+  vpc_id      = "%s"
+  port_id     = flexibleengine_compute_instance_v2.instance_1.network[0].port
+  approval    = true
+
+  port_mapping {
+    service_port  = 8088
+    terminal_port = 80
+  }
+  tags = {
+    owner = "tf-acc-update"
+  }
+}
+`, testAccVPCEPServicePrecondition(rName), rName, OS_VPC_ID)
+}
+
+func testAccVPCEPServicePermission(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpcep_service" "test" {
+  name        = "%s"
+  server_type = "VM"
+  vpc_id      = "%s"
+  port_id     = flexibleengine_compute_instance_v2.instance_1.network[0].port
+  approval    = false
+  permissions = ["iam:domain::1234", "iam:domain::5678"]
+
+  port_mapping {
+    service_port  = 8080
+    terminal_port = 80
+  }
+}
+`, testAccVPCEPServicePrecondition(rName), rName, OS_VPC_ID)
+}
+
+func testAccVPCEPServicePermissionUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpcep_service" "test" {
+  name        = "%s"
+  server_type = "VM"
+  vpc_id      = "%s"
+  port_id     = flexibleengine_compute_instance_v2.instance_1.network[0].port
+  approval    = false
+  permissions = ["iam:domain::abcd"]
+
+  port_mapping {
+    service_port  = 8080
+    terminal_port = 80
+  }
+}
+`, testAccVPCEPServicePrecondition(rName), rName, OS_VPC_ID)
+}

--- a/flexibleengine/tags.go
+++ b/flexibleengine/tags.go
@@ -6,6 +6,11 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/common/tags"
 )
 
+const (
+	tagVPCEP        string = "endpoint"
+	tagVPCEPService string = "endpoint_service"
+)
+
 // tagsSchema returns the schema to use for tags.
 func tagsSchema() *schema.Schema {
 	return &schema.Schema{

--- a/website/docs/r/vpcep_service.html.md
+++ b/website/docs/r/vpcep_service.html.md
@@ -1,0 +1,98 @@
+---
+subcategory: "VPC Endpoint"
+layout: "flexibleengine"
+page_title: "FlexibleEngine: flexibleengine_vpcep_service"
+description: |-
+  Provides a resource to manage a VPC endpoint service resource.
+---
+
+# flexibleengine\_vpcep\_service
+
+Provides a resource to manage a VPC endpoint service resource.
+
+## Example Usage
+
+```hcl
+variable "vpc_id" {}
+variable "vm_port" {}
+
+resource "flexibleengine_vpcep_service" "demo" {
+  name        = "demo-service"
+  server_type = "VM"
+  vpc_id      = var.vpc_id
+  port_id     = var.vm_port
+
+  port_mapping {
+    service_port  = 8080
+    terminal_port = 80
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` (Optional) - Specifies the name of the VPC endpoint service. The value contains a maximum of
+    16 characters, including letters, digits, underscores (_), and hyphens (-).
+
+* `vpc_id` (Required) - Specifies the ID of the VPC to which the backend resource of
+    the VPC endpoint service belongs. Changing this creates a new VPC endpoint service.
+
+* `server_type` (Required) - Specifies the backend resource type. The value can be **VM**, **VIP** or **LB**.
+    Changing this creates a new VPC endpoint service.
+
+* `port_id` (Required) - Specifies the ID for identifying the backend resource of the VPC endpoint service.
+    - If the `server_type` is **VM**, the value is the NIC ID of the ECS where the VPC endpoint service is deployed. 
+    - If the `server_type` is **VIP**, the value is the NIC ID of the physical server where virtual resources are created.
+    - If the `server_type` is **LB**, the value is the ID of the port bound to the private IP address of the load balancer.
+
+* `port_mapping` (Required) - Specified the port mappings opened to the VPC endpoint service.
+    Structure is documented below.
+
+* `approval` (Optional) - Specifies whether connection approval is required. The default value is false.
+
+* `permissions` (Optional) - Specifies the list of accounts to access the VPC endpoint service.
+    The record is in the `iam:domain::domain_id` format. *iam:domain::\** allows all users to access the VPC endpoint service.
+
+* `tags` - (Optional) The key/value pairs to associate with the VPC endpoint service.
+
+The `port_mapping` block supports:
+
+* `type` - (Optional) Specifies the protocol used in port mappings.
+    The value can be TCP or UDP. The default value is TCP.
+
+* `service_port` - (Optional) Specifies the port for accessing the VPC endpoint service.
+    This port is provided by the backend service to provide services. The value ranges from 1 to 65535.
+
+* `terminal_port` - (Optional) Specifies the port for accessing the VPC endpoint.
+    This port is provided by the VPC endpoint, allowing you to access the VPC endpoint service.
+    The value ranges from 1 to 65535.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The unique ID of the VPC endpoint service.
+
+* `region` - The region in which to create the VPC endpoint service.
+
+* `status` - The status of the VPC endpoint service. The value can be **available** or **failed**.
+
+* `service_name` - The full name of the VPC endpoint service in the format: *region.name.id*.
+
+* `service_type` - The type of the VPC endpoint service. Only **interface** can be configured.
+
+* `connections` - An array of VPC endpoints connect to the VPC endpoint service. Structure is documented below.
+    - `endpoint_id` - The unique ID of the VPC endpoint.
+    - `packet_id` - The packet ID of the VPC endpoint.
+    - `domain_id` - The user's domain ID.
+    - `status` - The connection status of the VPC endpoint.
+
+## Import
+
+VPC endpoint services can be imported using the `id`, e.g.
+
+```
+$ terraform import flexibleengine_vpcep_service.test_service 950cd3ba-9d0e-4451-97c1-3e97dd515d46
+```

--- a/website/flexibleengine.erb
+++ b/website/flexibleengine.erb
@@ -657,6 +657,16 @@
              </li>
            </ul>
         </li>
+
+        <li<%= sidebar_current("docs-flexibleengine-resource-vpc-endpoint") %>>
+          <a href="#">VPC Endpoint Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-flexibleengine-resource-vpcep-service") %>>
+              <a href="/docs/providers/flexibleengine/r/vpcep_service.html">flexibleengine_vpcep_service</a>
+            </li>
+          </ul>
+        </li>
+
       </ul>
     </div>
   <% end %>


### PR DESCRIPTION
the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccVPCEPService'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccVPCEPService -timeout 720m
=== RUN   TestAccVPCEPServiceBasic
=== PAUSE TestAccVPCEPServiceBasic
=== RUN   TestAccVPCEPServicePermission
=== PAUSE TestAccVPCEPServicePermission
=== CONT  TestAccVPCEPServiceBasic
=== CONT  TestAccVPCEPServicePermission
--- PASS: TestAccVPCEPServiceBasic (244.11s)
--- PASS: TestAccVPCEPServicePermission (287.40s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 287.410s
```