### PR TITLE
add dns ptr record resource and docs

### DIFF
--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -217,6 +217,7 @@ func Provider() terraform.ResourceProvider {
 			"flexibleengine_compute_floatingip_v2":              resourceComputeFloatingIPV2(),
 			"flexibleengine_compute_floatingip_associate_v2":    resourceComputeFloatingIPAssociateV2(),
 			"flexibleengine_compute_volume_attach_v2":           resourceComputeVolumeAttachV2(),
+			"flexibleengine_dns_ptrrecord_v2":                   resourceDNSPtrRecordV2(),
 			"flexibleengine_dns_recordset_v2":                   resourceDNSRecordSetV2(),
 			"flexibleengine_dns_zone_v2":                        resourceDNSZoneV2(),
 			"flexibleengine_dcs_instance_v1":                    resourceDcsInstanceV1(),

--- a/flexibleengine/resource_flexibleengine_dns_ptrrecord_v2.go
+++ b/flexibleengine/resource_flexibleengine_dns_ptrrecord_v2.go
@@ -1,0 +1,270 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/common/tags"
+	"github.com/huaweicloud/golangsdk/openstack/dns/v2/ptrrecords"
+)
+
+func resourceDNSPtrRecordV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDNSPtrRecordV2Create,
+		Read:   resourceDNSPtrRecordV2Read,
+		Update: resourceDNSPtrRecordV2Update,
+		Delete: resourceDNSPtrRecordV2Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"floatingip_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"ttl": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(1, 2147483647),
+			},
+			"tags": tagsSchema(),
+			"address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDNSPtrRecordV2Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	region := GetRegion(d, config)
+	dnsClient, err := config.dnsV2Client(region)
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
+	}
+
+	tagmap := d.Get("tags").(map[string]interface{})
+	taglist := []ptrrecords.Tag{}
+	for k, v := range tagmap {
+		tag := ptrrecords.Tag{
+			Key:   k,
+			Value: v.(string),
+		}
+		taglist = append(taglist, tag)
+	}
+
+	createOpts := ptrrecords.CreateOpts{
+		PtrName:     d.Get("name").(string),
+		Description: d.Get("description").(string),
+		TTL:         d.Get("ttl").(int),
+		Tags:        taglist,
+	}
+
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	fipID := d.Get("floatingip_id").(string)
+	n, err := ptrrecords.Create(dnsClient, region, fipID, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine DNS PTR record: %s", err)
+	}
+
+	log.Printf("[DEBUG] Waiting for DNS PTR record (%s) to become available", n.ID)
+	stateConf := &resource.StateChangeConf{
+		Target:     []string{"ACTIVE"},
+		Pending:    []string{"PENDING_CREATE"},
+		Refresh:    waitForDNSPtrRecord(dnsClient, n.ID),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+
+	if err != nil {
+		return fmt.Errorf(
+			"Error waiting for PTR record (%s) to become ACTIVE for creation: %s",
+			n.ID, err)
+	}
+	d.SetId(n.ID)
+
+	log.Printf("[DEBUG] Created FlexibleEngine DNS PTR record %s: %#v", n.ID, n)
+	return resourceDNSPtrRecordV2Read(d, meta)
+}
+
+func resourceDNSPtrRecordV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
+	}
+
+	n, err := ptrrecords.Get(dnsClient, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "ptr_record")
+	}
+
+	log.Printf("[DEBUG] Retrieved PTR record %s: %#v", d.Id(), n)
+
+	// Obtain relevant info from parsing the ID
+	fipID, err := parseDNSV2PtrRecordID(d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.Set("name", n.PtrName)
+	d.Set("description", n.Description)
+	d.Set("floatingip_id", fipID)
+	d.Set("ttl", n.TTL)
+	d.Set("address", n.Address)
+
+	// save tags
+	resourceTags, err := tags.Get(dnsClient, "DNS-ptr_record", d.Id()).Extract()
+	if err == nil {
+		tagmap := tagsToMap(resourceTags.Tags)
+		d.Set("tags", tagmap)
+	} else {
+		log.Printf("[WARN] Error fetching FlexibleEngine DNS ptr record tags: %s", err)
+	}
+
+	return nil
+}
+
+func resourceDNSPtrRecordV2Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	region := GetRegion(d, config)
+	dnsClient, err := config.dnsV2Client(region)
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
+	}
+
+	if d.HasChange("name") || d.HasChange("description") || d.HasChange("ttl") {
+		updateOpts := ptrrecords.CreateOpts{
+			PtrName:     d.Get("name").(string),
+			Description: d.Get("description").(string),
+			TTL:         d.Get("ttl").(int),
+		}
+
+		log.Printf("[DEBUG] Update Options: %#v", updateOpts)
+		fipID := d.Get("floatingip_id").(string)
+		n, err := ptrrecords.Create(dnsClient, region, fipID, updateOpts).Extract()
+		if err != nil {
+			return fmt.Errorf("Error updating FlexibleEngine DNS PTR record: %s", err)
+		}
+
+		log.Printf("[DEBUG] Waiting for DNS PTR record (%s) to become available", n.ID)
+		stateConf := &resource.StateChangeConf{
+			Target:     []string{"ACTIVE"},
+			Pending:    []string{"PENDING_CREATE"},
+			Refresh:    waitForDNSPtrRecord(dnsClient, n.ID),
+			Timeout:    d.Timeout(schema.TimeoutCreate),
+			Delay:      5 * time.Second,
+			MinTimeout: 3 * time.Second,
+		}
+
+		_, err = stateConf.WaitForState()
+		if err != nil {
+			return fmt.Errorf(
+				"Error waiting for PTR record (%s) to become ACTIVE for update: %s",
+				n.ID, err)
+		}
+
+		log.Printf("[DEBUG] Updated FlexibleEngine DNS PTR record %s: %#v", n.ID, n)
+	}
+
+	// update tags
+	tagErr := UpdateResourceTags(dnsClient, d, "DNS-ptr_record", d.Id())
+	if tagErr != nil {
+		return fmt.Errorf("Error updating tags of DNS PTR record %s: %s", d.Id(), tagErr)
+	}
+
+	return resourceDNSPtrRecordV2Read(d, meta)
+
+}
+
+func resourceDNSPtrRecordV2Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
+	}
+
+	err = ptrrecords.Delete(dnsClient, d.Id()).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("Error deleting FlexibleEngine DNS PTR record: %s", err)
+	}
+
+	log.Printf("[DEBUG] Waiting for DNS PTR record (%s) to be deleted", d.Id())
+	stateConf := &resource.StateChangeConf{
+		Target:     []string{"DELETED"},
+		Pending:    []string{"ACTIVE", "PENDING_DELETE", "ERROR"},
+		Refresh:    waitForDNSPtrRecord(dnsClient, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf(
+			"Error waiting for PTR record (%s) to become DELETED for deletion: %s",
+			d.Id(), err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func waitForDNSPtrRecord(dnsClient *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		ptrrecord, err := ptrrecords.Get(dnsClient, id).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return ptrrecord, "DELETED", nil
+			}
+
+			return nil, "", err
+		}
+
+		log.Printf("[DEBUG] FlexibleEngine DNS PTR record (%s) current status: %s", ptrrecord.ID, ptrrecord.Status)
+		return ptrrecord, ptrrecord.Status, nil
+	}
+}
+
+func parseDNSV2PtrRecordID(id string) (string, error) {
+	idParts := strings.Split(id, ":")
+	if len(idParts) != 2 {
+		return "", fmt.Errorf("Unable to determine DNS PTR record ID from raw ID: %s", id)
+	}
+
+	fipID := idParts[1]
+	return fipID, nil
+}

--- a/flexibleengine/resource_flexibleengine_dns_ptrrecord_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_dns_ptrrecord_v2_test.go
@@ -1,0 +1,148 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/huaweicloud/golangsdk/openstack/dns/v2/ptrrecords"
+)
+
+func randomPtrName() string {
+	return fmt.Sprintf("acpttest-%s.com.", acctest.RandString(5))
+}
+
+func TestAccDNSV2PtrRecord_basic(t *testing.T) {
+	var ptrrecord ptrrecords.Ptr
+	ptrName := randomPtrName()
+	resourceName := "flexibleengine_dns_ptrrecord_v2.ptr_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSV2PtrRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDNSV2PtrRecord_basic(ptrName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDNSV2PtrRecordExists(resourceName, &ptrrecord),
+					resource.TestCheckResourceAttr(resourceName, "description", "a ptr record"),
+				),
+			},
+			{
+				Config: testAccDNSV2PtrRecord_update(ptrName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDNSV2PtrRecordExists(resourceName, &ptrrecord),
+					resource.TestCheckResourceAttr(resourceName, "description", "ptr record updated"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDNSV2PtrRecordDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	dnsClient, err := config.dnsV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_dns_ptrrecord_v2" {
+			continue
+		}
+
+		_, err = ptrrecords.Get(dnsClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Ptr record still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckDNSV2PtrRecordExists(n string, ptrrecord *ptrrecords.Ptr) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		dnsClient, err := config.dnsV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
+		}
+
+		found, err := ptrrecords.Get(dnsClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("Ptr record not found")
+		}
+
+		*ptrrecord = *found
+
+		return nil
+	}
+}
+
+func testAccDNSV2PtrRecord_basic(ptrName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc_eip_v1" "eip_1" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "flexibleengine_dns_ptrrecord_v2" "ptr_1" {
+  name          = "%s"
+  description   = "a ptr record"
+  floatingip_id = flexibleengine_vpc_eip_v1.eip_1.id
+  ttl           = 6000
+}
+`, ptrName)
+}
+
+func testAccDNSV2PtrRecord_update(ptrName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc_eip_v1" "eip_1" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "flexibleengine_dns_ptrrecord_v2" "ptr_1" {
+  name          = "%s"
+  description   = "ptr record updated"
+  floatingip_id = flexibleengine_vpc_eip_v1.eip_1.id
+  ttl           = 6000
+
+  tags = {
+    foo = "bar"
+  }
+}
+`, ptrName)
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210105091610-2bcf49579b5d
+	github.com/huaweicloud/golangsdk v0.0.0-20210107071541-9c863834030e
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20201222074916-da363b3d1be2 h1:Fx4aqNr2z
 github.com/huaweicloud/golangsdk v0.0.0-20201222074916-da363b3d1be2/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/huaweicloud/golangsdk v0.0.0-20210105091610-2bcf49579b5d h1:MfYVRow1DKVV+UOalnqdkHmK/9JeS8o3PodH1VEbncQ=
 github.com/huaweicloud/golangsdk v0.0.0-20210105091610-2bcf49579b5d/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
+github.com/huaweicloud/golangsdk v0.0.0-20210107071541-9c863834030e h1:Tu2c737YvXBuKejxgXMOlngYaa5uTM+c4cIRt6Er1hI=
+github.com/huaweicloud/golangsdk v0.0.0-20210107071541-9c863834030e/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/dns/v2/ptrrecords/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/dns/v2/ptrrecords/requests.go
@@ -1,0 +1,78 @@
+package ptrrecords
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+// Get returns information about a ptr, given its ID.
+func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, id), &r.Body, nil)
+	return
+}
+
+// CreateOptsBuilder allows extensions to add additional attributes to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToPtrCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts specifies the attributes used to create a ptr.
+type CreateOpts struct {
+	// Name of the ptr.
+	PtrName string `json:"ptrdname" required:"true"`
+
+	// Description of the ptr.
+	Description string `json:"description,omitempty"`
+
+	// TTL is the time to live of the ptr.
+	TTL int `json:"-"`
+
+	// Tags of the ptr.
+	Tags []Tag `json:"tags,omitempty"`
+}
+
+// Tag is a structure of key value pair.
+type Tag struct {
+	//tag key
+	Key string `json:"key" required:"true"`
+	//tag value
+	Value string `json:"value" required:"true"`
+}
+
+// ToPtrCreateMap formats an CreateOpts structure into a request body.
+func (opts CreateOpts) ToPtrCreateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.TTL > 0 {
+		b["ttl"] = opts.TTL
+	}
+
+	return b, nil
+}
+
+// Create implements a ptr create/update request.
+func Create(client *golangsdk.ServiceClient, region string, fip_id string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToPtrCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Patch(baseURL(client, region, fip_id), &b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	return
+}
+
+// Delete implements a ptr delete request.
+func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
+	b := map[string]string{
+		"ptrname": "null",
+	}
+	_, r.Err = client.Patch(resourceURL(client, id), &b, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/dns/v2/ptrrecords/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/dns/v2/ptrrecords/results.go
@@ -1,0 +1,56 @@
+package ptrrecords
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract interprets a GetResult, CreateResult as a Ptr.
+// An error is returned if the original call or the extraction failed.
+func (r commonResult) Extract() (*Ptr, error) {
+	var s *Ptr
+	err := r.ExtractInto(&s)
+	return s, err
+}
+
+// CreateResult is the result of a Create request. Call its Extract method
+// to interpret the result as a Ptr.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult is the result of a Get request. Call its Extract method
+// to interpret the result as a Ptr.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult is the result of a Delete request. Call its ExtractErr method
+// to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+// Ptr represents a ptr record.
+type Ptr struct {
+	// ID uniquely identifies this ptr amongst all other ptr records.
+	ID string `json:"id"`
+
+	// Name for this ptr.
+	PtrName string `json:"ptrdname"`
+
+	// Description for this ptr.
+	Description string `json:"description"`
+
+	// TTL is the Time to Live for the ptr.
+	TTL int `json:"ttl"`
+
+	// Address of the floating ip.
+	Address string `json:"address"`
+
+	// Status of the PTR.
+	Status string `json:"status"`
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/dns/v2/ptrrecords/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/dns/v2/ptrrecords/urls.go
@@ -1,0 +1,11 @@
+package ptrrecords
+
+import "github.com/huaweicloud/golangsdk"
+
+func baseURL(c *golangsdk.ServiceClient, region string, floatingip_id string) string {
+	return c.ServiceURL("reverse/floatingips", region+":"+floatingip_id)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL("reverse/floatingips", id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -183,7 +183,7 @@ github.com/hashicorp/terraform-plugin-sdk/plugin
 github.com/hashicorp/terraform-plugin-sdk/terraform
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210105091610-2bcf49579b5d
+# github.com/huaweicloud/golangsdk v0.0.0-20210107071541-9c863834030e
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -228,6 +228,7 @@ github.com/huaweicloud/golangsdk/openstack/dcs/v1/maintainwindows
 github.com/huaweicloud/golangsdk/openstack/dcs/v1/products
 github.com/huaweicloud/golangsdk/openstack/dds/v3/flavors
 github.com/huaweicloud/golangsdk/openstack/dds/v3/instances
+github.com/huaweicloud/golangsdk/openstack/dns/v2/ptrrecords
 github.com/huaweicloud/golangsdk/openstack/dns/v2/recordsets
 github.com/huaweicloud/golangsdk/openstack/dns/v2/zones
 github.com/huaweicloud/golangsdk/openstack/drs/v2/replicationconsistencygroups

--- a/website/docs/r/dns_ptrrecord_v2.html.markdown
+++ b/website/docs/r/dns_ptrrecord_v2.html.markdown
@@ -1,0 +1,76 @@
+---
+subcategory: "Domain Name Service (DNS)"
+layout: "flexibleengine"
+page_title: "FlexibleEngine: flexibleengine_dns_ptrrecord_v2"
+sidebar_current: "docs-flexibleengine-resource-dns-ptrrecord-v2"
+description: |-
+  Manages a DNS PTR record in the FlexibleEngine DNS Service
+---
+
+# flexibleengine\_dns\_ptrrecord_v2
+
+Manages a DNS PTR record in the FlexibleEngine DNS Service.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_vpc_eip_v1" "eip_1" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "flexibleengine_dns_ptrrecord_v2" "ptr_1" {
+  name          = "ptr.example.com."
+  description   = "An example PTR record"
+  floatingip_id = flexibleengine_vpc_eip_v1.eip_1.id
+  ttl           = 3000
+
+  tags = {
+    foo = "bar"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional) The region in which to create the PTR record.
+    If omitted, the `region` argument of the provider is used.
+    Changing this creates a new PTR record.
+
+* `name` - (Required) Domain name of the PTR record. A domain name is case insensitive.
+  Uppercase letters will also be converted into lowercase letters.
+
+* `description` - (Optional) Description of the PTR record.
+
+* `floatingip_id` - (Required) The ID of the FloatingIP/EIP.
+  Changing this creates a new PTR record.
+
+* `ttl` - (Optional) The time to live (TTL) of the record set (in seconds). The value
+  range is 300–2147483647. The default value is 300.
+
+* `tags` - (Optional) Tags key/value pairs to associate with the PTR record.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` -  The PTR record ID, which is in {region}:{floatingip_id} format.
+
+* `address` - The address of the FloatingIP/EIP.
+
+## Import
+
+PTR records can be imported using region and floatingip/eip ID, separated by a colon(:), e.g.
+
+```
+$ terraform import flexibleengine_dns_ptrrecord_v2.ptr_1 eu-west-0:d90ce693-5ccf-4136-a0ed-152ce412b6b9
+```

--- a/website/docs/r/dns_recordset_v2.html.markdown
+++ b/website/docs/r/dns_recordset_v2.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Domain Name Service (DNS)"
 layout: "flexibleengine"
 page_title: "FlexibleEngine: flexibleengine_dns_recordset_v2"
 sidebar_current: "docs-flexibleengine-resource-dns-recordset-v2"

--- a/website/docs/r/dns_zone_v2.html.markdown
+++ b/website/docs/r/dns_zone_v2.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Domain Name Service (DNS)"
 layout: "flexibleengine"
 page_title: "FlexibleEngine: flexibleengine_dns_zone_v2"
 sidebar_current: "docs-flexibleengine-resource-dns-zone-v2"
@@ -46,7 +47,7 @@ The following arguments are supported:
 
 * `region` - (Optional) The region in which to create the DNS zone.
     If omitted, the `region` argument of the provider is used.
-    Changing this creates a new DNS zone. Changing this creates a new DNS zone.
+    Changing this creates a new DNS zone.
 
 * `name` - (Required) The name of the zone. Note the `.` at the end of the name.
   Changing this creates a new DNS zone.

--- a/website/flexibleengine.erb
+++ b/website/flexibleengine.erb
@@ -295,6 +295,9 @@
         <li<%= sidebar_current("docs-flexibleengine-resource-dns") %>>
           <a href="#">DNS Resources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-flexibleengine-resource-dns-ptrrecord-v2") %>>
+              <a href="/docs/providers/flexibleengine/r/dns_ptrrecord_v2.html">flexibleengine_dns_ptrrecord_v2</a>
+            </li>
             <li<%= sidebar_current("docs-flexibleengine-resource-dns-recordset-v2") %>>
               <a href="/docs/providers/flexibleengine/r/dns_recordset_v2.html">flexibleengine_dns_recordset_v2</a>
             </li>


### PR DESCRIPTION
add a new resource named `flexibleengine_dns_ptrrecord_v2`, the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDNSV2PtrRecord_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDNSV2PtrRecord_basic -timeout 720m
=== RUN   TestAccDNSV2PtrRecord_basic
=== PAUSE TestAccDNSV2PtrRecord_basic
=== CONT  TestAccDNSV2PtrRecord_basic
--- PASS: TestAccDNSV2PtrRecord_basic (55.97s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 55.987s
```