### PR TITLE
add vpc endpoint resource and docs

### DIFF
--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -313,6 +313,7 @@ func Provider() terraform.ResourceProvider {
 			"flexibleengine_sdrs_protectedinstance_v1":          resourceSdrsProtectedInstanceV1(),
 			"flexibleengine_sdrs_replication_pair_v1":           resourceSdrsReplicationPairV1(),
 			"flexibleengine_sdrs_replication_attach_v1":         resourceSdrsReplicationAttachV1(),
+			"flexibleengine_vpcep_endpoint":                     resourceVPCEndpoint(),
 			"flexibleengine_vpcep_service":                      resourceVPCEndpointService(),
 		},
 	}

--- a/flexibleengine/resource_flexibleengine_vpcep_endpoint.go
+++ b/flexibleengine/resource_flexibleengine_vpcep_endpoint.go
@@ -1,0 +1,267 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/vpcep/v1/endpoints"
+)
+
+func resourceVPCEndpoint() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVPCEndpointCreate,
+		Read:   resourceVPCEndpointRead,
+		Update: resourceVPCEndpointUpdate,
+		Delete: resourceVPCEndpointDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"service_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"network_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"enable_dns": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  true,
+			},
+			"enable_whitelist": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+			"whitelist": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"service_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"packet_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"private_domain_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceVPCEndpointCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	vpcepClient, err := config.vpcepV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine VPC endpoint client: %s", err)
+	}
+
+	enableDNS := d.Get("enable_dns").(bool)
+	enableACL := d.Get("enable_whitelist").(bool)
+	createOpts := endpoints.CreateOpts{
+		ServiceID:       d.Get("service_id").(string),
+		VpcID:           d.Get("vpc_id").(string),
+		SubnetID:        d.Get("network_id").(string),
+		PortIP:          d.Get("ip_address").(string),
+		EnableDNS:       &enableDNS,
+		EnableWhitelist: &enableACL,
+	}
+
+	raw := d.Get("whitelist").(*schema.Set).List()
+	if enableACL && len(raw) > 0 {
+		whitelists := make([]string, len(raw))
+		for i, v := range raw {
+			whitelists[i] = v.(string)
+		}
+		createOpts.Whitelist = whitelists
+	}
+
+	//set tags
+	tagRaw := d.Get("tags").(map[string]interface{})
+	if len(tagRaw) > 0 {
+		taglist := expandResourceTags(tagRaw)
+		createOpts.Tags = taglist
+	}
+
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	ep, err := endpoints.Create(vpcepClient, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine VPC endpoint: %s", err)
+	}
+
+	d.SetId(ep.ID)
+	log.Printf("[INFO] Waiting for FlexibleEngine VPC endpoint(%s) to become accepted", ep.ID)
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"creating"},
+		Target:     []string{"accepted", "pendingAcceptance"},
+		Refresh:    waitForVPCEndpointStatus(vpcepClient, ep.ID),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, stateErr := stateConf.WaitForState()
+	if stateErr != nil {
+		return fmt.Errorf(
+			"Error waiting for VPC endpoint(%s) to become accepted: %s",
+			ep.ID, stateErr)
+	}
+
+	return resourceVPCEndpointRead(d, meta)
+}
+
+func resourceVPCEndpointRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	vpcepClient, err := config.vpcepV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine VPC endpoint client: %s", err)
+	}
+
+	ep, err := endpoints.Get(vpcepClient, d.Id()).Extract()
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			d.SetId("")
+			return nil
+		}
+		return fmt.Errorf("Error retrieving FlexibleEngine VPC endpoint: %s", err)
+	}
+
+	log.Printf("[DEBUG] retrieving FlexibleEngine VPC endpoint: %#v", ep)
+	d.Set("region", GetRegion(d, config))
+	d.Set("status", ep.Status)
+	d.Set("service_id", ep.ServiceID)
+	d.Set("service_name", ep.ServiceName)
+	d.Set("service_type", ep.ServiceType)
+	d.Set("vpc_id", ep.VpcID)
+	d.Set("network_id", ep.SubnetID)
+	d.Set("ip_address", ep.IPAddr)
+	d.Set("enable_dns", ep.EnableDNS)
+	d.Set("enable_whitelist", ep.EnableWhitelist)
+	d.Set("whitelist", ep.Whitelist)
+	d.Set("packet_id", ep.MarkerID)
+
+	if len(ep.DNSNames) > 0 {
+		d.Set("private_domain_name", ep.DNSNames[0])
+	} else {
+		d.Set("private_domain_name", nil)
+	}
+
+	// fetch tags from endpoints.Endpoint
+	tagmap := make(map[string]string)
+	for _, val := range ep.Tags {
+		tagmap[val.Key] = val.Value
+	}
+	d.Set("tags", tagmap)
+
+	return nil
+}
+
+func resourceVPCEndpointUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	vpcepClient, err := config.vpcepV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine VPC endpoint client: %s", err)
+	}
+
+	//update tags
+	if d.HasChange("tags") {
+		tagErr := UpdateResourceTags(vpcepClient, d, tagVPCEP, d.Id())
+		if tagErr != nil {
+			return fmt.Errorf("Error updating tags of VPC endpoint service %s: %s", d.Id(), tagErr)
+		}
+	}
+	return resourceVPCEndpointRead(d, meta)
+}
+
+func resourceVPCEndpointDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	vpcepClient, err := config.vpcepV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine VPC endpoint client: %s", err)
+	}
+
+	err = endpoints.Delete(vpcepClient, d.Id()).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("Error deleting FlexibleEngine VPC endpoint %s: %s", d.Id(), err)
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"deleting"},
+		Target:     []string{"deleted"},
+		Refresh:    waitForVPCEndpointStatus(vpcepClient, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Delay:      5 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error deleting FlexibleEngine VPC endpoint %s: %s", d.Id(), err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func waitForVPCEndpointStatus(vpcepClient *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		ep, err := endpoints.Get(vpcepClient, id).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				log.Printf("[INFO] Successfully deleted FlexibleEngine VPC endpoint %s", id)
+				return ep, "deleted", nil
+			}
+			return ep, "error", err
+		}
+
+		return ep, ep.Status, nil
+	}
+}

--- a/flexibleengine/resource_flexibleengine_vpcep_endpoint_test.go
+++ b/flexibleengine/resource_flexibleengine_vpcep_endpoint_test.go
@@ -1,0 +1,213 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/huaweicloud/golangsdk/openstack/vpcep/v1/endpoints"
+)
+
+func TestAccVPCEndpointBasic(t *testing.T) {
+	var endpoint endpoints.Endpoint
+
+	rName := fmt.Sprintf("acc-test-%s", acctest.RandString(4))
+	resourceName := "flexibleengine_vpcep_endpoint.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVPCEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCEndpointBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCEndpointExists(resourceName, &endpoint),
+					resource.TestCheckResourceAttr(resourceName, "status", "accepted"),
+					resource.TestCheckResourceAttr(resourceName, "enable_dns", "true"),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "interface"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "tf-acc"),
+					resource.TestCheckResourceAttrSet(resourceName, "service_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "private_domain_name"),
+				),
+			},
+			{
+				Config: testAccVPCEndpointUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "status", "accepted"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "tf-acc-update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccVPCEndpointPublic(t *testing.T) {
+	var endpoint endpoints.Endpoint
+	resourceName := "flexibleengine_vpcep_endpoint.myendpoint"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVPCEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCEndpointPublic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCEndpointExists(resourceName, &endpoint),
+					resource.TestCheckResourceAttr(resourceName, "status", "accepted"),
+					resource.TestCheckResourceAttr(resourceName, "enable_dns", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enable_whitelist", "true"),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "interface"),
+					resource.TestCheckResourceAttr(resourceName, "whitelist.#", "2"),
+					resource.TestCheckResourceAttrSet(resourceName, "service_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "private_domain_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "ip_address"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVPCEndpointDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	vpcepClient, err := config.vpcepV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating VPC endpoint client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_vpcep_endpoint" {
+			continue
+		}
+
+		_, err := endpoints.Get(vpcepClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("VPC endpoint still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckVPCEndpointExists(n string, endpoint *endpoints.Endpoint) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		vpcepClient, err := config.vpcepV1Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating VPC endpoint client: %s", err)
+		}
+
+		found, err := endpoints.Get(vpcepClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("VPC endpoint not found")
+		}
+
+		*endpoint = *found
+
+		return nil
+	}
+}
+
+func testAccVPCEndpointBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpcep_service" "test" {
+  name        = "%s"
+  server_type = "VM"
+  vpc_id      = "%s"
+  port_id     = flexibleengine_compute_instance_v2.instance_1.network[0].port
+  approval    = false
+
+  port_mapping {
+    service_port  = 8080
+    terminal_port = 80
+  }
+  tags = {
+    owner = "tf-acc"
+  }
+}
+
+resource "flexibleengine_vpcep_endpoint" "test" {
+  service_id  = flexibleengine_vpcep_service.test.id
+  vpc_id      = "%s"
+  network_id  = "%s"
+  enable_dns  = true
+
+  tags = {
+    owner = "tf-acc"
+  }
+}
+`, testAccVPCEndpointPrecondition(rName), rName, OS_VPC_ID, OS_VPC_ID, OS_NETWORK_ID)
+}
+
+func testAccVPCEndpointUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpcep_service" "test" {
+  name        = "tf-%s"
+  server_type = "VM"
+  vpc_id      = "%s"
+  port_id     = flexibleengine_compute_instance_v2.instance_1.network[0].port
+  approval    = false
+
+  port_mapping {
+    service_port  = 8088
+    terminal_port = 80
+  }
+  tags = {
+    owner = "tf-acc"
+  }
+}
+
+resource "flexibleengine_vpcep_endpoint" "test" {
+  service_id  = flexibleengine_vpcep_service.test.id
+  vpc_id      = "%s"
+  network_id  = "%s"
+  enable_dns  = true
+
+  tags = {
+    owner = "tf-acc-update"
+    foo   = "bar"
+  }
+}
+`, testAccVPCEndpointPrecondition(rName), rName, OS_VPC_ID, OS_VPC_ID, OS_NETWORK_ID)
+}
+
+var testAccVPCEndpointPublic string = fmt.Sprintf(`
+data "flexibleengine_vpcep_public_services" "cloud_service" {
+  service_name = "dns"
+}
+
+resource "flexibleengine_vpcep_endpoint" "myendpoint" {
+  service_id       = data.flexibleengine_vpcep_public_services.cloud_service.services[0].id
+  vpc_id           = "%s"
+  network_id       = "%s"
+  enable_dns       = true
+  enable_whitelist = true
+  whitelist        = ["192.168.0.0/24", "10.10.10.10"]
+}
+`, OS_VPC_ID, OS_NETWORK_ID)

--- a/flexibleengine/resource_flexibleengine_vpcep_service_test.go
+++ b/flexibleengine/resource_flexibleengine_vpcep_service_test.go
@@ -143,7 +143,7 @@ func testAccCheckVPCEPServiceExists(n string, service *services.Service) resourc
 	}
 }
 
-func testAccVPCEPServicePrecondition(rName string) string {
+func testAccVPCEndpointPrecondition(rName string) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_compute_instance_v2" "instance_1" {
   name = "%s"
@@ -180,7 +180,7 @@ resource "flexibleengine_vpcep_service" "test" {
     owner = "tf-acc"
   }
 }
-`, testAccVPCEPServicePrecondition(rName), rName, OS_VPC_ID)
+`, testAccVPCEndpointPrecondition(rName), rName, OS_VPC_ID)
 }
 
 func testAccVPCEPServiceUpdate(rName string) string {
@@ -202,7 +202,7 @@ resource "flexibleengine_vpcep_service" "test" {
     owner = "tf-acc-update"
   }
 }
-`, testAccVPCEPServicePrecondition(rName), rName, OS_VPC_ID)
+`, testAccVPCEndpointPrecondition(rName), rName, OS_VPC_ID)
 }
 
 func testAccVPCEPServicePermission(rName string) string {
@@ -222,7 +222,7 @@ resource "flexibleengine_vpcep_service" "test" {
     terminal_port = 80
   }
 }
-`, testAccVPCEPServicePrecondition(rName), rName, OS_VPC_ID)
+`, testAccVPCEndpointPrecondition(rName), rName, OS_VPC_ID)
 }
 
 func testAccVPCEPServicePermissionUpdate(rName string) string {
@@ -242,5 +242,5 @@ resource "flexibleengine_vpcep_service" "test" {
     terminal_port = 80
   }
 }
-`, testAccVPCEPServicePrecondition(rName), rName, OS_VPC_ID)
+`, testAccVPCEndpointPrecondition(rName), rName, OS_VPC_ID)
 }

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/vpcep/v1/endpoints/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/vpcep/v1/endpoints/requests.go
@@ -1,0 +1,110 @@
+package endpoints
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/common/tags"
+)
+
+// CreateOptsBuilder allows extensions to add parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToEndpointCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains the options for create a VPC endpoint
+// This object is passed to Create().
+type CreateOpts struct {
+	// Specifies the ID of the VPC endpoint service
+	ServiceID string `json:"endpoint_service_id" required:"true"`
+	// Specifies the ID of the VPC where the VPC endpoint is to be created
+	VpcID string `json:"vpc_id" required:"true"`
+
+	// Specifies the network ID of the subnet created in the VPC specified by vpc_id
+	// The parameter is mandatory to create an interface VPC endpoint
+	SubnetID string `json:"subnet_id,omitempty"`
+	// Specifies the IP address for accessing the associated VPC endpoint service
+	PortIP string `json:"port_ip,omitempty"`
+	// Specifies whether to create a private domain name
+	EnableDNS *bool `json:"enable_dns,omitempty"`
+	// Specifies whether to enable access control
+	EnableWhitelist *bool `json:"enable_whitelist,omitempty"`
+	// Specifies the whitelist for controlling access to the VPC endpoint
+	Whitelist []string `json:"whitelist,omitempty"`
+	// Specifies the IDs of route tables
+	RouteTables []string `json:"routeTables,omitempty"`
+	// Specifies the resource tags in key/value format
+	Tags []tags.ResourceTag `json:"tags,omitempty"`
+}
+
+// ToEndpointCreateMap assembles a request body based on the contents of a CreateOpts.
+func (opts CreateOpts) ToEndpointCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create accepts a CreateOpts struct and uses the values to create a new
+// VPC endpoint
+func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToEndpointCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, reqOpt)
+	return
+}
+
+// Get retrieves a particular VPC endpoint based on its unique ID
+func Get(c *golangsdk.ServiceClient, endpointID string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, endpointID), &r.Body, nil)
+	return
+}
+
+// Delete will permanently delete a particular VPC endpoint based on its unique ID
+func Delete(c *golangsdk.ServiceClient, endpointID string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, endpointID), nil)
+	return
+}
+
+// ListOptsBuilder allows extensions to add parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToEndpointListQuery() (string, error)
+}
+
+// ListOpts allows the filtering of list data using given parameters.
+type ListOpts struct {
+	ServiceName string `q:"endpoint_service_name"`
+	VPCID       string `q:"vpc_id"`
+	ID          string `q:"id"`
+}
+
+// ToEndpointListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToEndpointListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List makes a request against the API to list VPC endpoints.
+func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) ([]Endpoint, error) {
+	var r ListResult
+	url := rootURL(client)
+	if opts != nil {
+		query, err := opts.ToEndpointListQuery()
+		if err != nil {
+			return nil, err
+		}
+		url += query
+	}
+	_, r.Err = client.Get(url, &r.Body, nil)
+	if r.Err != nil {
+		return nil, r.Err
+	}
+
+	allEndpoints, err := r.ExtractEndpoints()
+	if err != nil {
+		return nil, err
+	}
+
+	return allEndpoints, nil
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/vpcep/v1/endpoints/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/vpcep/v1/endpoints/results.go
@@ -1,0 +1,96 @@
+package endpoints
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/common/tags"
+)
+
+// Endpoint contains the response of the VPC endpoint
+type Endpoint struct {
+	// the ID of the VPC endpoint
+	ID string `json:"id"`
+	// the connection status of the VPC endpoint
+	Status string `json:"status"`
+	// the account status: frozen or active
+	ActiveStatus []string `json:"active_status"`
+	// the type of the VPC endpoint service that is associated with the VPC endpoint
+	ServiceType string `json:"service_type"`
+	// the name of the VPC endpoint service
+	ServiceName string `json:"endpoint_service_name"`
+	// the ID of the VPC endpoint service
+	ServiceID string `json:"endpoint_service_id"`
+	// the ID of the VPC where the VPC endpoint is to be created
+	VpcID string `json:"vpc_id"`
+	// the network ID of the subnet in the VPC specified by vpc_id
+	SubnetID string `json:"subnet_id"`
+	// the IP address for accessing the associated VPC endpoint service
+	IPAddr string `json:"ip"`
+	// the packet ID of the VPC endpoint
+	MarkerID int `json:"marker_id"`
+	// whether to create a private domain name
+	EnableDNS bool `json:"enable_dns"`
+	// the domain name for accessing the associated VPC endpoint service
+	DNSNames []string `json:"dns_names"`
+	// whether to enable access control
+	EnableWhitelist bool `json:"enable_whitelist"`
+	// the whitelist for controlling access to the VPC endpoint
+	Whitelist []string `json:"whitelist"`
+	// the IDs of route tables
+	RouteTables []string `json:"routetables"`
+	// the resource tags
+	Tags []tags.ResourceTag `json:"tags"`
+	// the project ID
+	ProjectID string `json:"project_id"`
+	// the creation time of the VPC endpoint
+	Created string `json:"created_at"`
+	// the update time of the VPC endpoint
+	Updated string `json:"updated_at"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Endpoint.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Endpoint.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+// ListResult represents the result of a list operation. Call its ExtractEndpoints
+// method to interpret it as Endpoints.
+type ListResult struct {
+	commonResult
+}
+
+// Extract is a function that accepts a result and extracts a Endpoint
+func (r commonResult) Extract() (*Endpoint, error) {
+	var ep Endpoint
+	err := r.ExtractInto(&ep)
+	return &ep, err
+}
+
+// ExtractEndpoints is a function that accepts a result and extracts the given Endpoints
+func (r ListResult) ExtractEndpoints() ([]Endpoint, error) {
+	var s struct {
+		Endpoints []Endpoint `json:"endpoints"`
+	}
+
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+	return s.Endpoints, nil
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/vpcep/v1/endpoints/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/vpcep/v1/endpoints/urls.go
@@ -1,0 +1,15 @@
+package endpoints
+
+import "github.com/huaweicloud/golangsdk"
+
+const (
+	rootPath = "vpc-endpoints"
+)
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, endpointID string) string {
+	return c.ServiceURL(rootPath, endpointID)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -311,6 +311,7 @@ github.com/huaweicloud/golangsdk/openstack/smn/v2/topics
 github.com/huaweicloud/golangsdk/openstack/utils
 github.com/huaweicloud/golangsdk/openstack/vbs/v2/backups
 github.com/huaweicloud/golangsdk/openstack/vbs/v2/policies
+github.com/huaweicloud/golangsdk/openstack/vpcep/v1/endpoints
 github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services
 github.com/huaweicloud/golangsdk/pagination
 # github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a

--- a/website/docs/r/vpcep_endpoint.html.md
+++ b/website/docs/r/vpcep_endpoint.html.md
@@ -1,0 +1,115 @@
+---
+subcategory: "VPC Endpoint"
+layout: "flexibleengine"
+page_title: "FlexibleEngine: flexibleengine_vpcep_endpoint"
+description: |-
+  Provides a resource to manage a VPC endpoint resource.
+---
+
+# flexibleengine\_vpcep\_endpoint
+
+Provides a resource to manage a VPC endpoint resource.
+
+## Example Usage
+
+### Access to the public service
+
+```hcl
+variable "vpc_id" {}
+variable "network_id" {}
+
+data "flexibleengine_vpcep_public_services" "cloud_service" {
+  service_name = "dns"
+}
+
+resource "flexibleengine_vpcep_endpoint" "myendpoint" {
+  service_id       = data.flexibleengine_vpcep_public_services.cloud_service.services[0].id
+  vpc_id           = var.vpc_id
+  network_id       = var.network_id
+  enable_dns       = true
+  enable_whitelist = true
+  whitelist        = ["192.168.0.0/24"]
+}
+```
+
+### Access to the private service
+
+```hcl
+variable "service_vpc_id" {}
+variable "vm_port" {}
+variable "vpc_id" {}
+variable "network_id" {}
+
+resource "flexibleengine_vpcep_service" "demo" {
+  name        = "demo-service"
+  server_type = "VM"
+  vpc_id      = var.service_vpc_id
+  port_id     = var.vm_port
+
+  port_mapping {
+    service_port  = 8080
+    terminal_port = 80
+  }
+}
+
+resource "flexibleengine_vpcep_endpoint" "demo" {
+  service_id  = flexibleengine_vpcep_service.demo.id
+  vpc_id      = var.vpc_id
+  network_id  = var.network_id
+  enable_dns  = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_id` (Required) - Specifies the ID of the VPC endpoint service.
+    Changing this creates a new VPC endpoint.
+
+* `vpc_id` (Required) - Specifies the ID of the VPC where the VPC endpoint is to be created.
+    Changing this creates a new VPC endpoint.
+
+* `network_id` (Required) - Specifies the network ID of the subnet in the VPC specified by `vpc_id`.
+    Changing this creates a new VPC endpoint.
+
+* `ip_address` (Optional) - Specifies the IP address for accessing the associated VPC endpoint service.
+    Only IPv4 addresses are supported. Changing this creates a new VPC endpoint.
+
+* `enable_dns` (Optional) - Specifies whether to create a private domain name. The default value is true.
+    Changing this creates a new VPC endpoint.
+
+* `enable_whitelist` (Optional) - Specifies whether to enable access control. The default value is false.
+    Changing this creates a new VPC endpoint.
+
+* `whitelist` (Optional) - Specifies the list of IP address or CIDR block which can be accessed to the VPC endpoint.
+    Changing this creates a new VPC endpoint.
+
+* `tags` - (Optional) The key/value pairs to associate with the VPC endpoint.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The unique ID of the VPC endpoint.
+
+* `region` - The region in which to create the VPC endpoint.
+
+* `status` - The status of the VPC endpoint. The value can be **accepted**, **pendingAcceptance** or **rejected**.
+
+* `service_name` - The name of the VPC endpoint service.
+
+* `service_type` - The type of the VPC endpoint service.
+
+* `packet_id` - The packet ID of the VPC endpoint.
+
+* `private_domain_name` -  The domain name for accessing the associated VPC endpoint service.
+    This parameter is only available when enable_dns is set to true.
+
+## Import
+
+VPC endpoint can be imported using the `id`, e.g.
+
+```
+$ terraform import flexibleengine_vpcep_endpoint.test 828907cc-40c9-42fe-8206-ecc1bdd30060
+```

--- a/website/flexibleengine.erb
+++ b/website/flexibleengine.erb
@@ -664,6 +664,9 @@
         <li<%= sidebar_current("docs-flexibleengine-resource-vpc-endpoint") %>>
           <a href="#">VPC Endpoint Resources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-flexibleengine-resource-vpcep-endpoint") %>>
+              <a href="/docs/providers/flexibleengine/r/vpcep_endpoint.html">flexibleengine_vpcep_endpoint</a>
+            </li>
             <li<%= sidebar_current("docs-flexibleengine-resource-vpcep-service") %>>
               <a href="/docs/providers/flexibleengine/r/vpcep_service.html">flexibleengine_vpcep_service</a>
             </li>


### PR DESCRIPTION
add a new resource named `flexibleengine_vpcep_endpoint` to manage a VPC endpoint. The testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccVPCEndpoint'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccVPCEndpoint -timeout 720m
=== RUN   TestAccVPCEndpointBasic
=== PAUSE TestAccVPCEndpointBasic
=== RUN   TestAccVPCEndpointPublic
=== PAUSE TestAccVPCEndpointPublic
=== CONT  TestAccVPCEndpointBasic
=== CONT  TestAccVPCEndpointPublic
--- PASS: TestAccVPCEndpointPublic (21.39s)
--- PASS: TestAccVPCEndpointBasic (239.39s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 239.399s
```