### PR TITLE
add vpc endpoint approval resource and docs

### DIFF
--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -313,6 +313,7 @@ func Provider() terraform.ResourceProvider {
 			"flexibleengine_sdrs_protectedinstance_v1":          resourceSdrsProtectedInstanceV1(),
 			"flexibleengine_sdrs_replication_pair_v1":           resourceSdrsReplicationPairV1(),
 			"flexibleengine_sdrs_replication_attach_v1":         resourceSdrsReplicationAttachV1(),
+			"flexibleengine_vpcep_approval":                     resourceVPCEndpointApproval(),
 			"flexibleengine_vpcep_endpoint":                     resourceVPCEndpoint(),
 			"flexibleengine_vpcep_service":                      resourceVPCEndpointService(),
 		},

--- a/flexibleengine/resource_flexibleengine_vpcep_approval.go
+++ b/flexibleengine/resource_flexibleengine_vpcep_approval.go
@@ -1,0 +1,212 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services"
+)
+
+const (
+	actionReceive string = "receive"
+	actionReject  string = "reject"
+)
+
+var approvalActionStatusMap = map[string]string{
+	actionReceive: "accepted",
+	actionReject:  "rejected",
+}
+
+func resourceVPCEndpointApproval() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVPCEndpointApprovalCreate,
+		Read:   resourceVPCEndpointApprovalRead,
+		Update: resourceVPCEndpointApprovalUpdate,
+		Delete: resourceVPCEndpointApprovalDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(3 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"service_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"endpoints": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"connections": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"endpoint_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"packet_id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"domain_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"status": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceVPCEndpointApprovalCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	vpcepClient, err := config.vpcepV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine VPC endpoint client: %s", err)
+	}
+
+	// check status of the VPC endpoint service
+	serviceID := d.Get("service_id").(string)
+	n, err := services.Get(vpcepClient, serviceID).Extract()
+	if err != nil {
+		return fmt.Errorf("Error retrieving VPC endpoint service %s: %s", serviceID, err)
+	}
+	if n.Status != "available" {
+		return fmt.Errorf("Error the status of VPC endpoint service is %s, expected to be available", n.Status)
+	}
+
+	raw := d.Get("endpoints").(*schema.Set).List()
+	err = doConnectionAction(d, vpcepClient, serviceID, actionReceive, raw)
+	if err != nil {
+		return fmt.Errorf("Error receiving connections to VPC endpoint service %s: %s", serviceID, err)
+	}
+
+	d.SetId(serviceID)
+	return resourceVPCEndpointApprovalRead(d, meta)
+}
+
+func resourceVPCEndpointApprovalRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	vpcepClient, err := config.vpcepV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine VPC endpoint client: %s", err)
+	}
+
+	serviceID := d.Get("service_id").(string)
+	if conns, err := flattenVPCEndpointConnections(vpcepClient, serviceID); err == nil {
+		d.Set("connections", conns)
+	}
+
+	return nil
+}
+
+func resourceVPCEndpointApprovalUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	vpcepClient, err := config.vpcepV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine VPC endpoint client: %s", err)
+	}
+
+	if d.HasChange("endpoints") {
+		old, new := d.GetChange("endpoints")
+		oldConnSet := old.(*schema.Set)
+		newConnSet := new.(*schema.Set)
+		received := newConnSet.Difference(oldConnSet)
+		rejected := oldConnSet.Difference(newConnSet)
+
+		serviceID := d.Get("service_id").(string)
+		err = doConnectionAction(d, vpcepClient, serviceID, actionReceive, received.List())
+		if err != nil {
+			return fmt.Errorf("Error receiving connections to VPC endpoint service %s: %s", serviceID, err)
+		}
+
+		err = doConnectionAction(d, vpcepClient, serviceID, actionReject, rejected.List())
+		if err != nil {
+			return fmt.Errorf("Error rejecting connections to VPC endpoint service %s: %s", serviceID, err)
+		}
+	}
+	return resourceVPCEndpointApprovalRead(d, meta)
+}
+
+func resourceVPCEndpointApprovalDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	vpcepClient, err := config.vpcepV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine VPC endpoint client: %s", err)
+	}
+
+	serviceID := d.Get("service_id").(string)
+	raw := d.Get("endpoints").(*schema.Set).List()
+	err = doConnectionAction(d, vpcepClient, serviceID, actionReject, raw)
+	if err != nil {
+		return fmt.Errorf("Error rejecting connections to VPC endpoint service %s: %s", serviceID, err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func doConnectionAction(d *schema.ResourceData, client *golangsdk.ServiceClient, serviceID, action string, raw []interface{}) error {
+	if len(raw) == 0 {
+		return nil
+	}
+
+	if _, ok := approvalActionStatusMap[action]; !ok {
+		return fmt.Errorf("approval action(%s) is invalid, only support %s or %s", action, actionReceive, actionReject)
+	}
+
+	targetStatus := approvalActionStatusMap[action]
+	for _, v := range raw {
+		// Each request accepts or rejects only one VPC endpoint
+		epID := v.(string)
+		connOpts := services.ConnActionOpts{
+			Action:    action,
+			Endpoints: []string{epID},
+		}
+
+		log.Printf("[DEBUG] %s to endpoint %s from VPC endpoint service %s", action, epID, serviceID)
+		if result := services.ConnAction(client, serviceID, connOpts); result.Err != nil {
+			return result.Err
+		}
+
+		log.Printf("[INFO] Waiting for VPC endpoint(%s) to become %s", epID, targetStatus)
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{"creating", "pendingAcceptance"},
+			Target:     []string{targetStatus},
+			Refresh:    waitForVPCEndpointStatus(client, epID),
+			Timeout:    d.Timeout(schema.TimeoutCreate),
+			Delay:      3 * time.Second,
+			MinTimeout: 3 * time.Second,
+		}
+
+		_, stateErr := stateConf.WaitForState()
+		if stateErr != nil {
+			return fmt.Errorf(
+				"Error waiting for VPC endpoint(%s) to become %s: %s",
+				epID, targetStatus, stateErr)
+		}
+	}
+
+	return nil
+}

--- a/flexibleengine/resource_flexibleengine_vpcep_approval_test.go
+++ b/flexibleengine/resource_flexibleengine_vpcep_approval_test.go
@@ -1,0 +1,126 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/huaweicloud/golangsdk/openstack/vpcep/v1/endpoints"
+	"github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services"
+)
+
+func TestAccVPCEndpointApproval(t *testing.T) {
+	var service services.Service
+	var endpoint endpoints.Endpoint
+
+	rName := fmt.Sprintf("acc-test-%s", acctest.RandString(4))
+	resourceName := "flexibleengine_vpcep_approval.approval"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVPCEPServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCEndpointApprovalBasic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVPCEPServiceExists("flexibleengine_vpcep_service.test", &service),
+					testAccCheckVPCEndpointExists("flexibleengine_vpcep_endpoint.test", &endpoint),
+					resource.TestCheckResourceAttrPtr(resourceName, "id", &service.ID),
+					resource.TestCheckResourceAttrPtr(resourceName, "connections.0.endpoint_id", &endpoint.ID),
+					resource.TestCheckResourceAttr(resourceName, "connections.0.status", "accepted"),
+				),
+			},
+			{
+				Config: testAccVPCEndpointApprovalUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPtr(resourceName, "connections.0.endpoint_id", &endpoint.ID),
+					resource.TestCheckResourceAttr(resourceName, "connections.0.status", "rejected"),
+				),
+			},
+		},
+	})
+}
+
+func testAccVPCEndpointApprovalBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpcep_service" "test" {
+  name        = "%s"
+  server_type = "VM"
+  vpc_id      = "%s"
+  port_id     = flexibleengine_compute_instance_v2.instance_1.network[0].port
+  approval    = true
+
+  port_mapping {
+    service_port  = 8080
+    terminal_port = 80
+  }
+  tags = {
+    owner = "tf-acc"
+  }
+}
+
+resource "flexibleengine_vpcep_endpoint" "test" {
+  service_id  = flexibleengine_vpcep_service.test.id
+  vpc_id      = "%s"
+  network_id  = "%s"
+  enable_dns  = true
+
+  tags = {
+    owner = "tf-acc"
+  }
+  lifecycle {
+    ignore_changes = [enable_dns]
+  }
+}
+
+resource "flexibleengine_vpcep_approval" "approval" {
+  service_id = flexibleengine_vpcep_service.test.id
+  endpoints  = [flexibleengine_vpcep_endpoint.test.id]
+}
+`, testAccVPCEndpointPrecondition(rName), rName, OS_VPC_ID, OS_VPC_ID, OS_NETWORK_ID)
+}
+
+func testAccVPCEndpointApprovalUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpcep_service" "test" {
+  name        = "%s"
+  server_type = "VM"
+  vpc_id      = "%s"
+  port_id     = flexibleengine_compute_instance_v2.instance_1.network[0].port
+  approval    = true
+
+  port_mapping {
+    service_port  = 8080
+    terminal_port = 80
+  }
+  tags = {
+    owner = "tf-acc"
+  }
+}
+
+resource "flexibleengine_vpcep_endpoint" "test" {
+  service_id  = flexibleengine_vpcep_service.test.id
+  vpc_id      = "%s"
+  network_id  = "%s"
+  enable_dns  = true
+
+  tags = {
+    owner = "tf-acc"
+  }
+  lifecycle {
+    ignore_changes = [enable_dns]
+  }
+}
+
+resource "flexibleengine_vpcep_approval" "approval" {
+  service_id = flexibleengine_vpcep_service.test.id
+  endpoints  = []
+}
+`, testAccVPCEndpointPrecondition(rName), rName, OS_VPC_ID, OS_VPC_ID, OS_NETWORK_ID)
+}

--- a/website/docs/r/vpcep_approval.html.md
+++ b/website/docs/r/vpcep_approval.html.md
@@ -1,0 +1,78 @@
+---
+subcategory: "VPC Endpoint"
+layout: "flexibleengine"
+page_title: "FlexibleEngine: flexibleengine_vpcep_approval"
+description: |-
+  Provides a resource to manage the VPC endpoint connections.
+---
+
+# flexibleengine\_vpcep\_approval
+
+Provides a resource to manage the VPC endpoint connections.
+
+## Example Usage
+
+```hcl
+variable "service_vpc_id" {}
+variable "vm_port" {}
+variable "vpc_id" {}
+variable "network_id" {}
+
+resource "flexibleengine_vpcep_service" "demo" {
+  name        = "demo-service"
+  server_type = "VM"
+  vpc_id      = var.service_vpc_id
+  port_id     = var.vm_port
+  approval    = true
+
+  port_mapping {
+    service_port  = 8080
+    terminal_port = 80
+  }
+}
+
+resource "flexibleengine_vpcep_endpoint" "demo" {
+  service_id  = flexibleengine_vpcep_service.demo.id
+  vpc_id      = var.vpc_id
+  network_id  = var.network_id
+  enable_dns  = true
+
+  lifecycle {
+    # enable_dns and ip_address are not assigned until connecting to the service
+    ignore_changes = [enable_dns, ip_address]
+  }
+}
+
+resource "flexibleengine_vpcep_approval" "approval" {
+  service_id = flexibleengine_vpcep_service.demo.id
+  endpoints  = [flexibleengine_vpcep_endpoint.demo.id]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `service_id` (Required) - Specifies the ID of the VPC endpoint service. Changing this creates a new resource.
+
+* `endpoints` (Required) - Specifies the list of VPC endpoint IDs which accepted to connect to VPC endpoint service.
+    The VPC endpoints will be rejected when the resource was destroyed.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The unique ID in UUID format which equals to the ID of the VPC endpoint service.
+
+* `region` - The region in which to obtain the VPC endpoint service.
+
+* `connections` - An array of VPC endpoints connect to the VPC endpoint service. Structure is documented below.
+    - `endpoint_id` - The unique ID of the VPC endpoint.
+    - `packet_id` - The packet ID of the VPC endpoint.
+    - `domain_id` - The user's domain ID.
+    - `status` - The connection status of the VPC endpoint.
+
+## Timeouts
+This resource provides the following timeouts configuration options:
+- `create` - Default is 10 minute.
+- `delete` - Default is 3 minute.

--- a/website/flexibleengine.erb
+++ b/website/flexibleengine.erb
@@ -664,6 +664,9 @@
         <li<%= sidebar_current("docs-flexibleengine-resource-vpc-endpoint") %>>
           <a href="#">VPC Endpoint Resources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-flexibleengine-resource-vpcep-approval") %>>
+              <a href="/docs/providers/flexibleengine/r/vpcep_approval.html">flexibleengine_vpcep_approval</a>
+            </li>
             <li<%= sidebar_current("docs-flexibleengine-resource-vpcep-endpoint") %>>
               <a href="/docs/providers/flexibleengine/r/vpcep_endpoint.html">flexibleengine_vpcep_endpoint</a>
             </li>


### PR DESCRIPTION
reference to #334

add a new resource named `flexibleengine_vpcep_approval` to manage VPC endpoint connections. The testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccVPCEndpointApproval'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccVPCEndpointApproval -timeout 720m
=== RUN   TestAccVPCEndpointApproval
=== PAUSE TestAccVPCEndpointApproval
=== CONT  TestAccVPCEndpointApproval
--- PASS: TestAccVPCEndpointApproval (264.17s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 264.177s
```