### PR TITLE
support tags for rds instance and read replica

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210107071541-9c863834030e
+	github.com/huaweicloud/golangsdk v0.0.0-20210112080918-53b7963e5a05
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20210105091610-2bcf49579b5d h1:MfYVRow1D
 github.com/huaweicloud/golangsdk v0.0.0-20210105091610-2bcf49579b5d/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/huaweicloud/golangsdk v0.0.0-20210107071541-9c863834030e h1:Tu2c737YvXBuKejxgXMOlngYaa5uTM+c4cIRt6Er1hI=
 github.com/huaweicloud/golangsdk v0.0.0-20210107071541-9c863834030e/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
+github.com/huaweicloud/golangsdk v0.0.0-20210112080918-53b7963e5a05 h1:dJ53GZpNz8qZMHoTC6RT5zfJYK3tCRoF3fBcwT9K+5M=
+github.com/huaweicloud/golangsdk v0.0.0-20210112080918-53b7963e5a05/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/instances/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/rds/v3/instances/results.go
@@ -2,6 +2,7 @@ package instances
 
 import (
 	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/common/tags"
 	"github.com/huaweicloud/golangsdk/pagination"
 )
 
@@ -126,32 +127,33 @@ type ListRdsResponse struct {
 }
 
 type RdsInstanceResponse struct {
-	Id                  string            `json:"id"`
-	Name                string            `json:"name"`
-	Status              string            `json:"status"`
-	PrivateIps          []string          `json:"private_ips"`
-	PublicIps           []string          `json:"public_ips"`
-	Port                int               `json:"port"`
-	Type                string            `json:"type"`
-	Ha                  Ha                `json:"ha"`
-	Region              string            `json:"region"`
-	DataStore           Datastore         `json:"datastore"`
-	Created             string            `json:"created"`
-	Updated             string            `json:"updated"`
-	DbUserName          string            `json:"db_user_name"`
-	VpcId               string            `json:"vpc_id"`
-	SubnetId            string            `json:"subnet_id"`
-	SecurityGroupId     string            `json:"security_group_id"`
-	FlavorRef           string            `json:"flavor_ref"`
-	Volume              Volume            `json:"volume"`
-	SwitchStrategy      string            `json:"switch_strategy"`
-	BackupStrategy      BackupStrategy    `json:"backup_strategy"`
-	MaintenanceWindow   string            `json:"maintenance_window"`
-	Nodes               []Nodes           `json:"nodes"`
-	RelatedInstance     []RelatedInstance `json:"related_instance"`
-	DiskEncryptionId    string            `json:"disk_encryption_id"`
-	EnterpriseProjectId string            `json:"enterprise_project_id"`
-	TimeZone            string            `json:"time_zone"`
+	Id                  string             `json:"id"`
+	Name                string             `json:"name"`
+	Status              string             `json:"status"`
+	PrivateIps          []string           `json:"private_ips"`
+	PublicIps           []string           `json:"public_ips"`
+	Port                int                `json:"port"`
+	Type                string             `json:"type"`
+	Ha                  Ha                 `json:"ha"`
+	Region              string             `json:"region"`
+	DataStore           Datastore          `json:"datastore"`
+	Created             string             `json:"created"`
+	Updated             string             `json:"updated"`
+	DbUserName          string             `json:"db_user_name"`
+	VpcId               string             `json:"vpc_id"`
+	SubnetId            string             `json:"subnet_id"`
+	SecurityGroupId     string             `json:"security_group_id"`
+	FlavorRef           string             `json:"flavor_ref"`
+	Volume              Volume             `json:"volume"`
+	SwitchStrategy      string             `json:"switch_strategy"`
+	BackupStrategy      BackupStrategy     `json:"backup_strategy"`
+	MaintenanceWindow   string             `json:"maintenance_window"`
+	Nodes               []Nodes            `json:"nodes"`
+	RelatedInstance     []RelatedInstance  `json:"related_instance"`
+	DiskEncryptionId    string             `json:"disk_encryption_id"`
+	EnterpriseProjectId string             `json:"enterprise_project_id"`
+	TimeZone            string             `json:"time_zone"`
+	Tags                []tags.ResourceTag `json:"tags"`
 }
 
 type Nodes struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -183,7 +183,7 @@ github.com/hashicorp/terraform-plugin-sdk/plugin
 github.com/hashicorp/terraform-plugin-sdk/terraform
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210107071541-9c863834030e
+# github.com/huaweicloud/golangsdk v0.0.0-20210112080918-53b7963e5a05
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal

--- a/website/docs/r/rds_instance_v3.html.markdown
+++ b/website/docs/r/rds_instance_v3.html.markdown
@@ -3,12 +3,12 @@ layout: "flexibleengine"
 page_title: "FlexibleEngine: flexibleengine_rds_instance_v3"
 sidebar_current: "docs-flexibleengine-resource-rds-instance-v3"
 description: |-
-  instance management
+  RDS instance management
 ---
 
 # flexibleengine\_rds\_instance\_v3
 
-instance management
+RDS instance management
 
 ## Example Usage
 
@@ -16,30 +16,31 @@ instance management
 
 ```hcl
 resource "flexibleengine_networking_secgroup_v2" "secgroup" {
-  name = "terraform_test_security_group"
+  name        = "terraform_test_security_group"
   description = "terraform security group acceptance test"
 }
 
 resource "flexibleengine_rds_instance_v3" "instance" {
-  availability_zone = ["{{ availability_zone }}"]
+  name              = "terraform_test_rds_instance"
+  flavor            = "rds.pg.s1.medium"
+  availability_zone = [var.primary_az]
+  security_group_id = flexibleengine_networking_secgroup_v2.secgroup.id
+  vpc_id            = var.vpc_id
+  subnet_id         = var.subnet_id
+
   db {
-    password = "Huangwei!120521"
-    type = "PostgreSQL"
-    version = "9.5"
-    port = "8635"
+    password = var.db_password
+    type     = "PostgreSQL"
+    version  = "11"
+    port     = "8635"
   }
-  name = "terraform_test_rds_instance"
-  security_group_id = "${flexibleengine_networking_secgroup_v2.secgroup.id}"
-  subnet_id = "{{ subnet_id }}"
-  vpc_id = "{{ vpc_id }}"
   volume {
     type = "COMMON"
     size = 100
   }
-  flavor = "rds.pg.s1.medium"
   backup_strategy {
     start_time = "08:00-09:00"
-    keep_days = 1
+    keep_days  = 1
   }
 }
 ```
@@ -48,31 +49,32 @@ resource "flexibleengine_rds_instance_v3" "instance" {
 
 ```hcl
 resource "flexibleengine_networking_secgroup_v2" "secgroup" {
-  name = "terraform_test_security_group"
+  name        = "terraform_test_security_group"
   description = "terraform security group acceptance test"
 }
 
 resource "flexibleengine_rds_instance_v3" "instance" {
-  availability_zone = ["{{ availability_zone_1 }}", "{{ availability_zone_2 }}"]
+  name                = "terraform_test_rds_instance"
+  flavor              = "rds.pg.s1.medium.ha"
+  ha_replication_mode = "async"
+  availability_zone   = [var.primary_az, var.standby_az]
+  security_group_id   = flexibleengine_networking_secgroup_v2.secgroup.id
+  vpc_id              = var.vpc_id
+  subnet_id           = var.subnet_id
+
   db {
-    password = "Huangwei!120521"
-    type = "PostgreSQL"
-    version = "9.5"
-    port = "8635"
+    password = var.db_password
+    type     = "PostgreSQL"
+    version  = "11"
+    port     = "8635"
   }
-  name = "terraform_test_rds_instance"
-  security_group_id = "${flexibleengine_networking_secgroup_v2.secgroup.id}"
-  subnet_id = "{{ subnet_id }}"
-  vpc_id = "{{ vpc_id }}" 
   volume {
     type = "COMMON"
     size = 100
   }
-  flavor = "rds.pg.s1.medium.ha"
-  ha_replication_mode = "async"
   backup_strategy {
     start_time = "08:00-09:00"
-    keep_days = 1
+    keep_days  = 1
   }
 }
 ```
@@ -87,31 +89,32 @@ resource "flexibleengine_kms_key_v1" "key" {
 }
 
 resource "flexibleengine_networking_secgroup_v2" "secgroup" {
-  name = "terraform_test_security_group"
+  name        = "terraform_test_security_group"
   description = "terraform security group acceptance test"
 }
 
 resource "flexibleengine_rds_instance_v3" "instance" {
-  availability_zone = ["{{ availability_zone }}"]
+  name              = "terraform_test_rds_instance"
+  flavor            = "rds.pg.s1.medium"
+  availability_zone = [var.primary_az]
+  security_group_id = flexibleengine_networking_secgroup_v2.secgroup.id
+  vpc_id            = var.vpc_id
+  subnet_id         = var.subnet_id
+
   db {
-    password = "Huangwei!120521"
-    type = "PostgreSQL"
-    version = "9.5"
-    port = "8635"
+    password = var.db_password
+    type     = "PostgreSQL"
+    version  = "11"
+    port     = "8635"
   }
-  name = "terraform_test_rds_instance"
-  security_group_id = "${flexibleengine_networking_secgroup_v2.secgroup.id}"
-  subnet_id = "{{ subnet_id }}"
-  vpc_id = "{{ vpc_id }}"
   volume {
-    disk_encryption_id = "${flexibleengine_kms_key_v1.key.id}"
-    type = "COMMON"
-    size = 100
+    disk_encryption_id = flexibleengine_kms_key_v1.key.id
+    type               = "COMMON"
+    size               = 100
   }
-  flavor = "rds.pg.s1.medium"
   backup_strategy {
     start_time = "08:00-09:00"
-    keep_days = 1
+    keep_days  = 1
   }
 }
 ```
@@ -145,6 +148,10 @@ The following arguments are supported:
   Specifies the security group which the RDS DB instance belongs to.
   Changing this parameter will create a new resource.
 
+* `vpc_id` -
+  (Required)
+  Specifies the VPC ID. Changing this parameter will create a new resource.
+
 * `subnet_id` -
   (Required)
   Specifies the subnet id. Changing this parameter will create a new resource.
@@ -152,10 +159,6 @@ The following arguments are supported:
 * `volume` -
   (Required)
   Specifies the volume information. Structure is documented below. Changing this parameter will create a new resource.
-
-* `vpc_id` -
-  (Required)
-  Specifies the VPC ID. Changing this parameter will create a new resource.
 
 * `backup_strategy` -
   (Optional)
@@ -174,6 +177,9 @@ The following arguments are supported:
   (Optional)
   Specifies the parameter group ID. Changing this parameter will create a new resource.
 
+* `tags` - (Optional) A mapping of tags to assign to the RDS instance.
+  Each tag is represented by one key-value pair.
+
 The `db` block supports:
 
 * `password` -
@@ -184,18 +190,6 @@ The `db` block supports:
   characters: ~!@#%^*-_=+? You are advised to enter a strong
   password to improve security, preventing security risks such as
   brute force cracking.  Changing this parameter will create a new resource.
-
-* `port` -
-  (Optional)
-  Specifies the database port information. The MySQL database port
-  ranges from 1024 to 65535 (excluding 12017 and 33071, which are
-  occupied by the RDS system and cannot be used). The PostgreSQL
-  database port ranges from 2100 to 9500. The Microsoft SQL Server
-  database port can be 1433 or ranges from 2100 to 9500, excluding
-  5355 and 5985. If this parameter is not set, the default value is
-  as follows: For MySQL, the default value is 3306. For PostgreSQL,
-  the default value is 5432. For Microsoft SQL Server, the default
-  value is 1433.  Changing this parameter will create a new resource.
 
 * `type` -
   (Required)
@@ -208,6 +202,18 @@ The `db` block supports:
   PostgreSQL 9.5, 9.6, 10 and 11, example values: "9.5", "9.6", "10", "11". Microsoft SQL Server
   databases support 2014 SE and 2014 EE, example values: "2014_SE", "2014_EE".
   Changing this parameter will create a new resource.
+
+* `port` -
+  (Optional)
+  Specifies the database port information. The MySQL database port
+  ranges from 1024 to 65535 (excluding 12017 and 33071, which are
+  occupied by the RDS system and cannot be used). The PostgreSQL
+  database port ranges from 2100 to 9500. The Microsoft SQL Server
+  database port can be 1433 or ranges from 2100 to 9500, excluding
+  5355 and 5985. If this parameter is not set, the default value is
+  as follows: For MySQL, the default value is 3306. For PostgreSQL,
+  the default value is 5432. For Microsoft SQL Server, the default
+  value is 1433.  Changing this parameter will create a new resource.
 
 The `volume` block supports:
 
@@ -249,18 +255,18 @@ The `backup_strategy` block supports:
 
 In addition to the arguments listed above, the following computed attributes are exported:
 
-* `created` -
-  Indicates the creation time.
+* `id` - Specifies a resource ID in UUID format.
 
-* `nodes` -
-  Indicates the instance nodes information. Structure is documented below.
+* `status` - Indicates the DB instance status.
 
-* `private_ips` -
-  Indicates the private IP address list. It is a blank string until an
-  ECS is created.
+* `created` - Indicates the creation time.
 
-* `public_ips` -
-  Indicates the public IP address list.
+* `nodes` - Indicates the instance nodes information. Structure is documented below.
+
+* `private_ips` - Indicates the private IP address list.
+  It is a blank string until an ECS is created.
+
+* `public_ips` - Indicates the public IP address list.
 
 * `db` - See Argument Reference above. The `db` block also contains:
 
@@ -268,20 +274,16 @@ In addition to the arguments listed above, the following computed attributes are
 
 The `nodes` block contains:
 
-* `availability_zone` -
-  Indicates the AZ.
+* `availability_zone` - Indicates the AZ.
 
-* `id` -
-  Indicates the node ID.
+* `id` - Indicates the node ID.
 
-* `name` -
-  Indicates the node name.
+* `name` - Indicates the node name.
 
-* `role` -
-  Indicates the node type. The value can be master or slave, indicating the primary node or standby node respectively.
+* `role` - Indicates the node type. The value can be master or slave,
+  indicating the primary node or standby node respectively.
 
-* `status` -
-  Indicates the node status.
+* `status` - Indicates the node status.
 
 ## Timeouts
 

--- a/website/docs/r/rds_read_replica_v3.html.markdown
+++ b/website/docs/r/rds_read_replica_v3.html.markdown
@@ -3,34 +3,34 @@ layout: "flexibleengine"
 page_title: "FlexibleEngine: flexibleengine_rds_read_replica_v3"
 sidebar_current: "docs-flexibleengine-resource-rds-read-replica-v3"
 description: |-
-  read replica management
+  RDS read replica management
 ---
 
 # flexibleengine\_rds\_read\_replica\_v3
 
-read replica management
+RDS read replica management
 
 ## Example Usage
 
 ```hcl
 resource "flexibleengine_networking_secgroup_v2" "secgroup" {
-  name = "test_security_group"
+  name        = "test_security_group"
   description = "security group acceptance test"
 }
 
 resource "flexibleengine_rds_instance_v3" "instance_1" {
-  name = "test_rds_instance"
-  flavor = "rds.pg.c2.large"
-  availability_zone = ["{{ availability_zone }}"]
-  vpc_id = "{{ vpc_id }}"
-  subnet_id = "{{ subnet_id }}"
+  name              = "terraform_test_rds_instance"
+  flavor            = "rds.pg.s1.medium"
+  availability_zone = [var.primary_az]
   security_group_id = flexibleengine_networking_secgroup_v2.secgroup.id
+  vpc_id            = var.vpc_id
+  subnet_id         = var.subnet_id
 
   db {
-    password = "Huangwei!120521"
-    type = "PostgreSQL"
-    version = "9.5"
-    port = "8635"
+    password = var.db_password
+    type     = "PostgreSQL"
+    version  = "11"
+    port     = "8635"
   }
   volume {
     type = "ULTRAHIGH"
@@ -38,15 +38,15 @@ resource "flexibleengine_rds_instance_v3" "instance_1" {
   }
   backup_strategy {
     start_time = "08:00-09:00"
-    keep_days = 1
+    keep_days  = 1
   }
 }
 
 resource "flexibleengine_rds_read_replica_v3" "instance_2" {
-  name = "replica_instance"
-  flavor = "rds.pg.c2.large.rr"
-  replica_of_id = flexibleengine_rds_instance_v3.instance_1.id
-  availability_zone = "{{ availability_zone }}"
+  name              = "replica_instance"
+  flavor            = "rds.pg.c2.large.rr"
+  replica_of_id     = flexibleengine_rds_instance_v3.instance_1.id
+  availability_zone = var.primary_az
 
   volume {
     type = "ULTRAHIGH"
@@ -76,6 +76,9 @@ The following arguments are supported:
 
 * `availability_zone` - (Required) Specifies the AZ name.
     Changing this parameter will create a new resource.
+
+* `tags` - (Optional) A mapping of tags to assign to the RDS read replica instance.
+    Each tag is represented by one key-value pair.
 
 * `region` - (Optional) The region in which to create the instance. If omitted,
     the `region` argument of the provider is used. Currently, read replicas can


### PR DESCRIPTION
This PR is related to #427
The testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccRdsInstanceV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccRdsInstanceV3_basic -timeout 720m
=== RUN   TestAccRdsInstanceV3_basic
--- PASS: TestAccRdsInstanceV3_basic (617.40s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 617.415s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccRdsReplicaInstanceV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccRdsReplicaInstanceV3_basic -timeout 720m
=== RUN   TestAccRdsReplicaInstanceV3_basic
--- PASS: TestAccRdsReplicaInstanceV3_basic (1083.66s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 1083.671s

```