### PR TITLE
support tags for as group and lb resources

### DIFF
--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -665,7 +665,17 @@ func (c *Config) vpcepV1Client(region string) (*golangsdk.ServiceClient, error) 
 	sc, err := c.sdkClient(region, "network")
 	if err == nil {
 		sc.Endpoint = strings.Replace(sc.Endpoint, "vpc", "vpcep", 1)
-		sc.ResourceBase = fmt.Sprintf("%sv1/%s/", sc.Endpoint, c.HwClient.ProjectID)
+		sc.ResourceBase = sc.Endpoint + fmt.Sprintf("v1/%s/", c.HwClient.ProjectID)
+	}
+
+	return sc, err
+}
+
+func (c *Config) elbV2Client(region string) (*golangsdk.ServiceClient, error) {
+	sc, err := c.sdkClient(region, "network")
+	if err == nil {
+		sc.Endpoint = strings.Replace(sc.Endpoint, "vpc", "elb", 1)
+		sc.ResourceBase = sc.Endpoint + fmt.Sprintf("v2.0/%s/", c.HwClient.ProjectID)
 	}
 
 	return sc, err

--- a/flexibleengine/resource_flexibleengine_as_group_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_as_group_v1_test.go
@@ -2,17 +2,18 @@ package flexibleengine
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
 	"github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/groups"
-	"log"
 )
 
 func TestAccASV1Group_basic(t *testing.T) {
 	var asGroup groups.Group
+	resourceName := "flexibleengine_as_group_v1.hth_as_group"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,9 +23,11 @@ func TestAccASV1Group_basic(t *testing.T) {
 			{
 				Config: testASV1Group_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckASV1GroupExists("flexibleengine_as_group_v1.hth_as_group", &asGroup),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_as_group_v1.hth_as_group", "lbaas_listeners.0.protocol_port", "8080"),
+					testAccCheckASV1GroupExists(resourceName, &asGroup),
+					resource.TestCheckResourceAttr(resourceName, "lbaas_listeners.0.protocol_port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "status", "INSERVICE"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),
 			},
 		},
@@ -93,55 +96,60 @@ resource "flexibleengine_networking_secgroup_v2" "secgroup" {
 }
 
 resource "flexibleengine_compute_keypair_v2" "hth_key" {
-  name = "hth_key"
+  name       = "hth_key"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
 }
 
 resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
-  name = "loadbalancer_1"
-  vip_subnet_id = "2c0a74a9-4395-4e62-a17b-e3e86fbf66b7"
+  name          = "loadbalancer_1"
+  vip_subnet_id = "%s"
 }
 
 resource "flexibleengine_lb_listener_v2" "listener_1" {
-  name = "listener_1"
-  protocol = "HTTP"
-  protocol_port = 8080
-  loadbalancer_id = "${flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id}"
+  name            = "listener_1"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
 }
 
 resource "flexibleengine_lb_pool_v2" "pool_1" {
-  name = "pool_1"
-  protocol = "HTTP"
-  lb_method = "ROUND_ROBIN"
-  listener_id = "${flexibleengine_lb_listener_v2.listener_1.id}"
+  name        = "pool_1"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = flexibleengine_lb_listener_v2.listener_1.id
 }
 
 resource "flexibleengine_as_configuration_v1" "hth_as_config"{
   scaling_configuration_name = "hth_as_config"
   instance_config {
-    image = "%s"
+	image    = "%s"
+	key_name = flexibleengine_compute_keypair_v2.hth_key.id
     disk {
-      size = 40
+      size        = 40
       volume_type = "SATA"
-      disk_type = "SYS"
+      disk_type   = "SYS"
     }
-    key_name = "${flexibleengine_compute_keypair_v2.hth_key.id}"
   }
 }
 
 resource "flexibleengine_as_group_v1" "hth_as_group"{
-  scaling_group_name = "hth_as_group"
-  scaling_configuration_id = "${flexibleengine_as_configuration_v1.hth_as_config.id}"
+  scaling_group_name       = "hth_as_group"
+  scaling_configuration_id = flexibleengine_as_configuration_v1.hth_as_config.id
+  vpc_id                   = "%s"
+
   networks {
     id = "%s"
   }
   security_groups {
-    id = "${flexibleengine_networking_secgroup_v2.secgroup.id}"
+    id = flexibleengine_networking_secgroup_v2.secgroup.id
   }
   lbaas_listeners {
-    pool_id = "${flexibleengine_lb_pool_v2.pool_1.id}"
-    protocol_port = "${flexibleengine_lb_listener_v2.listener_1.protocol_port}"
+    pool_id       = flexibleengine_lb_pool_v2.pool_1.id
+    protocol_port = flexibleengine_lb_listener_v2.listener_1.protocol_port
   }
-  vpc_id = "%s"
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
 }
-`, OS_IMAGE_ID, OS_NETWORK_ID, OS_VPC_ID)
+`, OS_SUBNET_ID, OS_IMAGE_ID, OS_VPC_ID, OS_NETWORK_ID)

--- a/website/docs/r/lb_listener_v2.html.markdown
+++ b/website/docs/r/lb_listener_v2.html.markdown
@@ -17,6 +17,10 @@ resource "flexibleengine_lb_listener_v2" "listener_1" {
   protocol        = "HTTP"
   protocol_port   = 8080
   loadbalancer_id = "d9415786-5f1a-428b-b35f-2f1523e146d2"
+
+  tags = {
+    key = "value"
+  }
 }
 ```
 
@@ -24,13 +28,13 @@ resource "flexibleengine_lb_listener_v2" "listener_1" {
 
 ```hcl
 resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
-  name = "loadbalancer_cert"
+  name          = "loadbalancer_cert"
   vip_subnet_id = "2c0a74a9-4395-4e62-a17b-e3e86fbf66b7"
 }
 
 resource "flexibleengine_lb_certificate_v2" "certificate_1" {
-  name = "cert"
-  domain = "www.elb.com"
+  name        = "cert"
+  domain      = "www.elb.com"
   private_key = <<EOT
 -----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN2s8tZ/6LC3X82fajpVsYqF1x
@@ -88,11 +92,11 @@ EOT
 }
 
 resource "flexibleengine_lb_listener_v2" "listener_1" {
-  name = "listener_cert"
-  protocol = "TERMINATED_HTTPS"
-  protocol_port = 8080
-  loadbalancer_id = "${flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id}"
-  default_tls_container_ref = "${flexibleengine_lb_certificate_v2.certificate_1.id}"
+  name                      = "listener_cert"
+  protocol                  = "TERMINATED_HTTPS"
+  protocol_port             = 8080
+  loadbalancer_id           = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
+  default_tls_container_ref = flexibleengine_lb_certificate_v2.certificate_1.id
 }
 ```
 
@@ -100,31 +104,30 @@ resource "flexibleengine_lb_listener_v2" "listener_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to obtain the V2 Networking client.
-    A Networking client is needed to create an . If omitted, the
-    `region` argument of the provider is used. Changing this creates a new
-    Listener.
+* `region` - (Optional) The region in which to create the listener resource.
+    If omitted, the `region` argument of the provider is used.
+    Changing this creates a new listener.
 
 * `protocol` - (Required) The protocol - can either be TCP, UDP, HTTP or TERMINATED_HTTPS.
-    Changing this creates a new Listener.
+    Changing this creates a new listener.
 
 * `protocol_port` - (Required) The port on which to listen for client traffic.
-    Changing this creates a new Listener.
+    Changing this creates a new listener.
 
 * `tenant_id` - (Optional) Required for admins. The UUID of the tenant who owns
-    the Listener.  Only administrative users can specify a tenant UUID
-    other than their own. Changing this creates a new Listener.
+    the listener.  Only administrative users can specify a tenant UUID
+    other than their own. Changing this creates a new listener.
 
 * `loadbalancer_id` - (Required) The load balancer on which to provision this
-    Listener. Changing this creates a new Listener.
+    listener. Changing this creates a new listener.
 
-* `name` - (Optional) Human-readable name for the Listener. Does not have
+* `name` - (Optional) Human-readable name for the listener. Does not have
     to be unique.
 
 * `default_pool_id` - (Optional) The ID of the default pool with which the
-    Listener is associated. Changing this creates a new Listener.
+    listener is associated. Changing this creates a new listener.
 
-* `description` - (Optional) Human-readable description for the Listener.
+* `description` - (Optional) Human-readable description for the listener.
 
 * `default_tls_container_ref` - (Optional) A reference to a Barbican Secrets
     container which stores TLS information. This is required if the protocol
@@ -168,14 +171,16 @@ The following arguments are supported:
   </tr>
 </table>
 
-* `admin_state_up` - (Optional) The administrative state of the Listener.
+* `admin_state_up` - (Optional) The administrative state of the listener.
     A valid value is true (UP) or false (DOWN).
+
+* `tags` - (Optional) The key/value pairs to associate with the listener.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - The unique ID for the Listener.
+* `id` - The unique ID for the listener.
 * `protocol` - See Argument Reference above.
 * `protocol_port` - See Argument Reference above.
 * `tenant_id` - See Argument Reference above.
@@ -187,3 +192,4 @@ The following attributes are exported:
 * `sni_container_refs` - See Argument Reference above.
 * `tls_ciphers_policy` - See Argument Reference above.
 * `admin_state_up` - See Argument Reference above.
+* `tags` - See Argument Reference above.

--- a/website/docs/r/lb_loadbalancer_v2.html.markdown
+++ b/website/docs/r/lb_loadbalancer_v2.html.markdown
@@ -15,6 +15,10 @@ Manages a V2 loadbalancer resource within FlexibleEngine.
 ```hcl
 resource "flexibleengine_lb_loadbalancer_v2" "lb_1" {
   vip_subnet_id = "d9415786-5f1a-428b-b35f-2f1523e146d2"
+
+  tags = {
+    key = "value"
+  }
 }
 ```
 
@@ -22,30 +26,31 @@ resource "flexibleengine_lb_loadbalancer_v2" "lb_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to obtain the V2 Networking client.
-    A Networking client is needed to create an LB member. If omitted, the
-    `region` argument of the provider is used. Changing this creates a new
-    LB member.
+* `region` - (Optional) The region in which to create the loadbalancer resource.
+    If omitted, the `region` argument of the provider is used.
+    Changing this creates a new loadbalancer.
 
 * `vip_subnet_id` - (Required) The network on which to allocate the
-    Loadbalancer's address. A tenant can only create Loadbalancers on networks
+    loadbalancer's address. A tenant can only create Loadbalancers on networks
     authorized by policy (e.g. networks that belong to them or networks that
     are shared).  Changing this creates a new loadbalancer.
 
-* `name` - (Optional) Human-readable name for the Loadbalancer. Does not have
+* `name` - (Optional) Human-readable name for the loadbalancer. Does not have
     to be unique.
 
-* `description` - (Optional) Human-readable description for the Loadbalancer.
+* `description` - (Optional) Human-readable description for the loadbalancer.
 
 * `tenant_id` - (Optional) Required for admins. The UUID of the tenant who owns
-    the Loadbalancer.  Only administrative users can specify a tenant UUID
+    the loadbalancer.  Only administrative users can specify a tenant UUID
     other than their own.  Changing this creates a new loadbalancer.
 
 * `vip_address` - (Optional) The ip address of the load balancer.
     Changing this creates a new loadbalancer.
 
-* `admin_state_up` - (Optional) The administrative state of the Loadbalancer.
+* `admin_state_up` - (Optional) The administrative state of the loadbalancer.
     A valid value is true (UP) or false (DOWN).
+
+* `tags` - (Optional) The key/value pairs to associate with the loadbalancer.
 
 * `flavor` - (Optional) The UUID of a flavor. Currently, this is not supported.
     Changing this creates a new loadbalancer.
@@ -68,6 +73,7 @@ The following attributes are exported:
 * `tenant_id` - See Argument Reference above.
 * `vip_address` - See Argument Reference above.
 * `admin_state_up` - See Argument Reference above.
+* `tags` - See Argument Reference above.
 * `flavor` - See Argument Reference above.
 * `loadbalancer_provider` - See Argument Reference above.
 * `security_group_ids` - See Argument Reference above.


### PR DESCRIPTION
This PR is related to #427
The testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccASV1Group_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccASV1Group_basic -timeout 720m
=== RUN   TestAccASV1Group_basic
--- PASS: TestAccASV1Group_basic (79.82s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 79.830s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLBV2LoadBalancer_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLBV2LoadBalancer_basic -timeout 720m
=== RUN   TestAccLBV2LoadBalancer_basic
--- PASS: TestAccLBV2LoadBalancer_basic (47.61s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 47.618s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLBV2Listener_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLBV2Listener_basic -timeout 720m
=== RUN   TestAccLBV2Listener_basic
--- PASS: TestAccLBV2Listener_basic (80.90s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 80.909s
```