### PR TITLE
add time_zome to rds instance v3

### DIFF
--- a/flexibleengine/resource_flexibleengine_rds_instance_v3.go
+++ b/flexibleengine/resource_flexibleengine_rds_instance_v3.go
@@ -176,13 +176,17 @@ func resourceRdsInstanceV3() *schema.Resource {
 			},
 
 			"tags": tagsSchema(),
-
 			"param_group_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-
+			"time_zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 			"nodes": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -254,6 +258,7 @@ func resourceRdsInstanceV3UserInputParams(d *schema.ResourceData) map[string]int
 		"subnet_id":               d.Get("subnet_id"),
 		"volume":                  d.Get("volume"),
 		"vpc_id":                  d.Get("vpc_id"),
+		"time_zone":               d.Get("time_zone"),
 	}
 }
 
@@ -547,6 +552,16 @@ func buildRdsInstanceV3CreateParameters(opts map[string]interface{}, arrayIndex 
 		return nil, err
 	} else if !e {
 		params["vpc_id"] = v
+	}
+
+	v, err = navigateValue(opts, []string{"time_zone"}, arrayIndex)
+	if err != nil {
+		return nil, err
+	}
+	if e, err := isEmptyValue(reflect.ValueOf(v)); err != nil {
+		return nil, err
+	} else if !e {
+		params["time_zone"] = v
 	}
 
 	return params, nil
@@ -922,6 +937,14 @@ func setRdsInstanceV3Properties(d *schema.ResourceData, response map[string]inte
 	}
 	if err = d.Set("subnet_id", v); err != nil {
 		return fmt.Errorf("Error setting Instance:subnet_id, err: %s", err)
+	}
+
+	v, err = navigateValue(response, []string{"list", "time_zone"}, nil)
+	if err != nil {
+		return fmt.Errorf("Error reading Instance:time_zone, err: %s", err)
+	}
+	if err = d.Set("time_zone", v); err != nil {
+		return fmt.Errorf("Error setting Instance:time_zone, err: %s", err)
 	}
 
 	v, _ = opts["volume"]

--- a/flexibleengine/resource_flexibleengine_rds_instance_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_rds_instance_v3_test.go
@@ -39,6 +39,7 @@ func TestAccRdsInstanceV3_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRdsInstanceV3Exists(),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("rds_acc_instance-%s", name)),
+					resource.TestCheckResourceAttr(resourceName, "time_zone", "UTC+01:00"),
 					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "1"),
 					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "100"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
@@ -133,6 +134,7 @@ resource "flexibleengine_rds_instance_v3" "instance" {
   security_group_id = flexibleengine_networking_secgroup_v2.secgroup.id
   vpc_id            = "%s"
   subnet_id         = "%s"
+  time_zone         = "UTC+01:00"
 
   db {
     password = "Huangwei!120521"

--- a/website/docs/r/rds_instance_v3.html.markdown
+++ b/website/docs/r/rds_instance_v3.html.markdown
@@ -177,6 +177,9 @@ The following arguments are supported:
   (Optional)
   Specifies the parameter group ID. Changing this parameter will create a new resource.
 
+* `time_zone` - (Optional) Specifies the UTC time zone. The value ranges from
+  UTC-12:00 to UTC+12:00 at the full hour, and defaults to *UTC*.
+
 * `tags` - (Optional) A mapping of tags to assign to the RDS instance.
   Each tag is represented by one key-value pair.
 


### PR DESCRIPTION
fixes #389 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccRdsInstanceV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccRdsInstanceV3_basic -timeout 720m
=== RUN   TestAccRdsInstanceV3_basic
--- PASS: TestAccRdsInstanceV3_basic (625.80s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine (625.86s)
```