### PR TITLE
add volume_attached/type to compute instance and update docs for import section

### DIFF
--- a/flexibleengine/resource_flexibleengine_compute_instance_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_compute_instance_v2_test.go
@@ -32,6 +32,14 @@ func TestAccComputeV2Instance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"stop_before_destroy",
+				},
+			},
 		},
 	})
 }

--- a/website/docs/d/compute_instance_v2.html.md
+++ b/website/docs/d/compute_instance_v2.html.md
@@ -54,7 +54,8 @@ In addition to all arguments above, the following attributes are exported:
     The block_device object structure is documented below.
 * `scheduler_hints` - The scheduler with hints on how the instance should be launched.
     The available hints are described below.
-* `tags` - The key/value pairs to associate with the instance.
+* `tags` - The tags of the instance in key/value format.
+* `metadata` - The metadata of the instance in key/value format.
 * `status` - The status of the instance.
 
 The `network` block supports:
@@ -70,6 +71,7 @@ The `block_device` block supports:
 * `uuid` - The volume id on that attachment.
 * `boot_index` - The volume boot index on that attachment.
 * `size` - The volume size on that attachment.
+* `type` - The volume type on that attachment.
 * `pci_address` - The volume pci address on that attachment.
 
 The `scheduler_hints` block supports:

--- a/website/docs/r/compute_instance_v2.html.markdown
+++ b/website/docs/r/compute_instance_v2.html.markdown
@@ -300,8 +300,8 @@ The following arguments are supported:
 * `user_data` - (Optional) The user data to provide when launching the instance.
     Changing this creates a new server.
 
-* `metadata` - (Optional) Metadata key/value pairs to make available from
-    within the instance. Changing this updates the existing server metadata.
+* `metadata` - (Optional) The key/value pairs to associate with the instance.
+    Changing this updates the existing server metadata.
 
 * `config_drive` - (Optional) Whether to use the config_drive feature to
     configure the instance. Changing this creates a new server.
@@ -407,8 +407,7 @@ The following attributes are exported:
 
 * `region` - See Argument Reference above.
 * `name` - See Argument Reference above.
-* `access_ip_v4` - The first detected Fixed IPv4 address _or_ the
-    Floating IP.
+* `access_ip_v4` - The first detected Fixed IPv4 address _or_ the Floating IP.
 * `access_ip_v6` - The first detected Fixed IPv6 address.
 * `metadata` - See Argument Reference above.
 * `security_groups` - See Argument Reference above.
@@ -417,10 +416,8 @@ The following attributes are exported:
 * `network/uuid` - See Argument Reference above.
 * `network/name` - See Argument Reference above.
 * `network/port` - See Argument Reference above.
-* `network/fixed_ip_v4` - The Fixed IPv4 address of the Instance on that
-    network.
-* `network/fixed_ip_v6` - The Fixed IPv6 address of the Instance on that
-    network.
+* `network/fixed_ip_v4` - The Fixed IPv4 address of the Instance on that network.
+* `network/fixed_ip_v6` - The Fixed IPv6 address of the Instance on that network.
 * `network/mac` - The MAC address of the NIC on that network.
 * `all_metadata` - Contains all instance metadata, even metadata not set
     by Terraform.
@@ -437,6 +434,7 @@ The `volume_attached` block supports:
 * `uuid` - The volume id on that attachment.
 * `boot_index` - The volume boot index on that attachment.
 * `size` - The volume size on that attachment.
+* `type` - The volume type on that attachment.
 * `pci_address` - The volume pci address on that attachment.
 
 ## Import
@@ -445,12 +443,24 @@ Instances can be imported by their `id`. For example,
 ```
 terraform import flexibleengine_compute_instance_v2.my_instance b11b407c-e604-4e8d-8bc4-92398320b847
 ```
-Note that the imported state may not be identical to your resource definition, which
-could be because of a different network interface attachment order, missing ephemeral
-disk configuration, or some other reason. It is generally recommended running
+Note that the imported state may not be identical to your resource definition, due to some attrubutes
+missing from the API response, security or some other reason. The missing attributes include:
+`admin_pass`, `config_drive`, `user_data`, `block_device`, `scheduler_hints`, `stop_before_destroy`,
+`network/access_network` and arguments for pre-paid. It is generally recommended running
 `terraform plan` after importing an instance. You can then decide if changes should
 be applied to the instance, or the resource definition should be updated to align
-with the instance.
+with the instance. Also you can ignore changes as below.
+```
+resource "flexibleengine_compute_instance_v2" "my_instance" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      user_data, block_device,
+    ]
+  }
+}
+```
 
 ## Notes
 


### PR DESCRIPTION
the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccComputeV2Instance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccComputeV2Instance_basic -timeout 720m
=== RUN   TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (225.38s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 225.397s
```