### PR TITLE
add data_source_flexibleengine_identity_custom_role_v3

### DIFF
--- a/flexibleengine/data_source_flexibleengine_identity_custom_role_v3.go
+++ b/flexibleengine/data_source_flexibleengine_identity_custom_role_v3.go
@@ -1,0 +1,156 @@
+package flexibleengine
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk/openstack/identity/v3.0/policies"
+)
+
+func dataSourceIdentityCustomRoleV3() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceIdentityCustomRoleRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"domain_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"references": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"catalog": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"policy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceIdentityCustomRoleRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
+	}
+
+	identityClient.Endpoint = strings.Replace(identityClient.Endpoint, "v3", "v3.0", 1)
+
+	allPages, err := policies.List(identityClient).AllPages()
+	if err != nil {
+		return fmt.Errorf("Unable to query roles: %s", err)
+	}
+
+	roles, err := policies.ExtractPageRoles(allPages)
+
+	conditions := map[string]interface{}{}
+
+	if v, ok := d.GetOk("name"); ok {
+		conditions["name"] = v.(string)
+	}
+	if v, ok := d.GetOk("id"); ok {
+		conditions["id"] = v.(string)
+	}
+	if v, ok := d.GetOk("domain_id"); ok {
+		conditions["domain_id"] = v.(string)
+	}
+	if v, ok := d.GetOk("references"); ok {
+		conditions["references"] = v.(int)
+	}
+	if v, ok := d.GetOk("description"); ok {
+		conditions["description"] = v.(string)
+	}
+	if v, ok := d.GetOk("type"); ok {
+		conditions["type"] = v.(string)
+	}
+
+	var allRoles []policies.Role
+
+	for _, role := range roles {
+		if rolesFilter(role, conditions) {
+			allRoles = append(allRoles, role)
+		}
+	}
+
+	if len(allRoles) < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	if len(allRoles) > 1 {
+		log.Printf("[DEBUG] Multiple results found: %#v", allRoles)
+		return fmt.Errorf("Your query returned more than one result. Please try a more " +
+			"specific search criteria.")
+	}
+	role := allRoles[0]
+
+	return dataSourceIdentityCustomRoleAttributes(d, config, &role)
+}
+
+// dataSourceIdentityRoleV3Attributes populates the fields of an Role resource.
+func dataSourceIdentityCustomRoleAttributes(d *schema.ResourceData, config *Config, role *policies.Role) error {
+	log.Printf("[DEBUG] flexibleengine_identity_role details: %#v", role)
+
+	d.SetId(role.ID)
+	d.Set("name", role.Name)
+	d.Set("domain_id", role.DomainId)
+	d.Set("references", role.References)
+	d.Set("catalog", role.Catalog)
+	d.Set("description", role.Description)
+	d.Set("type", role.Type)
+
+	policy, err := json.Marshal(role.Policy)
+	if err != nil {
+		return fmt.Errorf("Error marshalling policy: %s", err)
+	}
+
+	d.Set("policy", string(policy))
+
+	return nil
+}
+
+func rolesFilter(role policies.Role, conditions map[string]interface{}) bool {
+	if v, ok := conditions["name"]; ok && v != role.Name {
+		return false
+	}
+	if v, ok := conditions["id"]; ok && v != role.ID {
+		return false
+	}
+	if v, ok := conditions["domain_id"]; ok && v != role.DomainId {
+		return false
+	}
+	if v, ok := conditions["references"]; ok && v != role.References {
+		return false
+	}
+	if v, ok := conditions["description"]; ok && v != role.Description {
+		return false
+	}
+	if v, ok := conditions["type"]; ok && v != role.Type {
+		return false
+	}
+	return true
+}

--- a/flexibleengine/data_source_flexibleengine_identity_custom_role_v3_test.go
+++ b/flexibleengine/data_source_flexibleengine_identity_custom_role_v3_test.go
@@ -1,0 +1,77 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccFlexibleEngineIdentityCustomRoleV3DataSource_basic(t *testing.T) {
+	var rName = fmt.Sprintf("ACCPTTEST-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFlexibleEngineIdentityCustomRoleDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityCustomDataSourceID("data.flexibleengine_identity_custom_role_v3.role_1"),
+					resource.TestCheckResourceAttr(
+						"data.flexibleengine_identity_custom_role_v3.role_1", "name", rName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIdentityCustomDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find role data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Role data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+func testAccFlexibleEngineIdentityCustomRoleDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_identity_role_v3" test {
+  name        = "%s"
+  description = "created by terraform"
+  type        = "AX"
+  policy      = <<EOF
+{
+  "Version": "1.1",
+  "Statement": [
+    {
+      "Action": [
+        "obs:bucket:GetBucketAcl"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "obs:*:*:bucket:*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+data "flexibleengine_identity_custom_role_v3" "role_1" {
+  name = flexibleengine_identity_role_v3.test.name
+}
+`, rName)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -205,6 +205,7 @@ func Provider() terraform.ResourceProvider {
 			"flexibleengine_sdrs_domain_v1":                     dataSourceSdrsDomainV1(),
 			"flexibleengine_identity_project_v3":                dataSourceIdentityProjectV3(),
 			"flexibleengine_identity_role_v3":                   dataSourceIdentityRoleV3(),
+			"flexibleengine_identity_custom_role_v3":            dataSourceIdentityCustomRoleV3(),
 			"flexibleengine_vpcep_public_services":              dataSourceVPCEPPublicServices(),
 		},
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210114023537-fe395bc023d0
+	github.com/huaweicloud/golangsdk v0.0.0-20210116064948-5bfe83790eb2
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/huaweicloud/golangsdk v0.0.0-20210114023537-fe395bc023d0 h1:xwFz9Kv4jJynCL5ovksg/rlPHXYwjFY5MBL4W/7yyzg=
-github.com/huaweicloud/golangsdk v0.0.0-20210114023537-fe395bc023d0/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
+github.com/huaweicloud/golangsdk v0.0.0-20210116064948-5bfe83790eb2 h1:S1zh1Z7JafcX/oU/zxVHEHHec5NmTi9a4pZcUgkrVks=
+github.com/huaweicloud/golangsdk v0.0.0-20210116064948-5bfe83790eb2/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/identity/v3.0/policies/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/identity/v3.0/policies/requests.go
@@ -2,6 +2,7 @@ package policies
 
 import (
 	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
 )
 
 // Get retrieves details on a single policy, by ID.
@@ -11,6 +12,15 @@ func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
 		MoreHeaders: map[string]string{"Content-Type": "application/json"},
 	})
 	return
+}
+
+func List(client *golangsdk.ServiceClient) pagination.Pager {
+	pager := pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
+		return RolePage{pagination.LinkedPageBase{PageResult: r}}
+	})
+	pager.Headers = map[string]string{"Content-Type": "application/json;charset=utf8"}
+
+	return pager
 }
 
 // CreateOptsBuilder allows extensions to add additional parameters to

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/identity/v3.0/policies/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/identity/v3.0/policies/results.go
@@ -2,6 +2,7 @@ package policies
 
 import (
 	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
 )
 
 type Role struct {
@@ -43,6 +44,10 @@ type DeleteResult struct {
 	golangsdk.ErrResult
 }
 
+type RolePage struct {
+	pagination.LinkedPageBase
+}
+
 // Extract interprets any roleResults as a Role.
 func (r roleResult) Extract() (*Role, error) {
 	var s struct {
@@ -50,4 +55,31 @@ func (r roleResult) Extract() (*Role, error) {
 	}
 	err := r.ExtractInto(&s)
 	return s.Role, err
+}
+
+func (r RolePage) IsEmpty() (bool, error) {
+	is, err := ExtractPageRoles(r)
+	return len(is) == 0, err
+}
+
+func (r RolePage) NextPageURL() (string, error) {
+	var s struct {
+		Links struct {
+			Next     string `json:"next"`
+			Previous string `json:"previous"`
+		} `json:"links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return s.Links.Next, err
+}
+
+func ExtractPageRoles(r pagination.Page) ([]Role, error) {
+	var s struct {
+		Roles []Role `json:"roles"`
+	}
+	err := (r.(RolePage)).ExtractInto(&s)
+	return s.Roles, err
 }

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/identity/v3.0/policies/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/identity/v3.0/policies/urls.go
@@ -14,3 +14,7 @@ func rootURL(client *golangsdk.ServiceClient) string {
 func resourceURL(client *golangsdk.ServiceClient, roleID string) string {
 	return client.ServiceURL(rootPath, rolePath, roleID)
 }
+
+func listURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL(rootPath, rolePath)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -183,7 +183,7 @@ github.com/hashicorp/terraform-plugin-sdk/plugin
 github.com/hashicorp/terraform-plugin-sdk/terraform
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210114023537-fe395bc023d0
+# github.com/huaweicloud/golangsdk v0.0.0-20210116064948-5bfe83790eb2
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal

--- a/website/docs/d/identity_custom_role_v3.html.markdown
+++ b/website/docs/d/identity_custom_role_v3.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "flexibleengine"
+page_title: "FlexibleEngine: flexibleengine_identity_custom_role_v3"
+sidebar_current: "docs-flexibleengine-datasource-identity-custom-role-v3"
+description: |-
+  Get information on a FlexibleEngine Custom Role.
+---
+
+# flexibleengine\_identity\_custom\_role\_v3
+
+Use this data source to get the ID of a FlexibleEngine custom role.
+
+The Role in Terraform is the same as Policy on console. however,
+The policy name is the display name of Role, the Role name cannot
+be found on Console.
+
+```hcl
+data "flexibleengine_identity_custom_role_v3" "role" {
+  name = "custom_role"
+}
+```
+
+## Argument Reference
+
+* `name` - (Optional) Name of the custom policy. 
+
+* `id` - (Optional) ID of the custom policy.
+
+* `domain_id` - (Optional) The domain the policy belongs to.
+
+* `references` - (Optional) The number of citations for the custom policy.
+
+* `description` - (Optional) Description of the custom policy.
+
+* `type` - (Optional) Display mode. Valid options are AX: Account level and XA: Project level.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `policy` - Document of the custom policy.
+
+* `catalog` - The catalog of the custom policy.
+

--- a/website/flexibleengine.erb
+++ b/website/flexibleengine.erb
@@ -76,6 +76,9 @@
             <li<%= sidebar_current("docs-flexibleengine-datasource-identity-role-v3") %>>
               <a href="/docs/providers/flexibleengine/d/identity_role_v3.html">flexibleengine_identity_role_v3</a>
             </li>
+            <li<%= sidebar_current("docs-flexibleengine-datasource-identity-custom-role-v3") %>>
+              <a href="/docs/providers/flexibleengine/d/identity_custom_role_v3.html">flexibleengine_identity_custom_role_v3</a>
+            </li>
             <li<%= sidebar_current("docs-flexibleengine-datasource-images-image-v2") %>>
               <a href="/docs/providers/flexibleengine/d/images_image_v2.html">flexibleengine_images_image_v2</a>
             </li>


### PR DESCRIPTION
fixes #422 

Test result:
```bash
 make testacc TEST='./flexibleengine' TESTARGS='-run TestAccFlexibleEngineIdentityCustomRoleV3DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccFlexibleEngineIdentityCustomRoleV3DataSource_basic -timeout 720m
=== RUN   TestAccFlexibleEngineIdentityCustomRoleV3DataSource_basic
=== PAUSE TestAccFlexibleEngineIdentityCustomRoleV3DataSource_basic
=== CONT  TestAccFlexibleEngineIdentityCustomRoleV3DataSource_basic
--- PASS: TestAccFlexibleEngineIdentityCustomRoleV3DataSource_basic (43.33s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 43.360s
```