### PR TITLE
Add http2_enable parameter in lb_listener_v2 resource

### DIFF
--- a/flexibleengine/diff_suppress_funcs.go
+++ b/flexibleengine/diff_suppress_funcs.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/jen20/awspolicyequivalence"
+	awspolicy "github.com/jen20/awspolicyequivalence"
 )
 
 func suppressEquivalentAwsPolicyDiffs(k, old, new string, d *schema.ResourceData) bool {
@@ -144,4 +144,9 @@ func suppressLBWhitelistDiffs(k, old, new string, d *schema.ResourceData) bool {
 	sort.Strings(new_array)
 
 	return reflect.DeepEqual(old_array, new_array)
+}
+
+// Suppress changes if we get a string with or without new line
+func suppressNewLineDiffs(k, old, new string, d *schema.ResourceData) bool {
+	return strings.Trim(old, "\n") == strings.Trim(new, "\n")
 }

--- a/flexibleengine/resource_flexibleengine_lb_certificate_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_certificate_v2.go
@@ -48,13 +48,15 @@ func resourceCertificateV2() *schema.Resource {
 			},
 
 			"private_key": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: suppressNewLineDiffs,
 			},
 
 			"certificate": {
-				Type:     schema.TypeString,
-				Required: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: suppressNewLineDiffs,
 			},
 
 			"update_time": {

--- a/flexibleengine/resource_flexibleengine_lb_listener_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_listener_v2.go
@@ -87,6 +87,12 @@ func resourceListenerV2() *schema.Resource {
 				ForceNew: true,
 			}, */
 
+			"http2_enable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
 			"default_tls_container_ref": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -101,6 +107,7 @@ func resourceListenerV2() *schema.Resource {
 			"tls_ciphers_policy": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 			"admin_state_up": {
@@ -122,6 +129,7 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	adminStateUp := d.Get("admin_state_up").(bool)
+	http2Enable := d.Get("http2_enable").(bool)
 	var sniContainerRefs []string
 	if raw, ok := d.GetOk("sni_container_refs"); ok {
 		for _, v := range raw.([]interface{}) {
@@ -139,6 +147,7 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 		DefaultTlsContainerRef: d.Get("default_tls_container_ref").(string),
 		SniContainerRefs:       sniContainerRefs,
 		TlsCiphersPolicy:       d.Get("tls_ciphers_policy").(string),
+		Http2Enable:            &http2Enable,
 		AdminStateUp:           &adminStateUp,
 	}
 
@@ -216,6 +225,7 @@ func resourceListenerV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("description", listener.Description)
 	d.Set("protocol_port", listener.ProtocolPort)
 	d.Set("admin_state_up", listener.AdminStateUp)
+	d.Set("http2_enable", listener.Http2Enable)
 	d.Set("default_pool_id", listener.DefaultPoolID)
 	//d.Set("connection_limit", listener.ConnLimit)
 	if err := d.Set("sni_container_refs", listener.SniContainerRefs); err != nil {
@@ -276,6 +286,10 @@ func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("admin_state_up") {
 		asu := d.Get("admin_state_up").(bool)
 		updateOpts.AdminStateUp = &asu
+	}
+	if d.HasChange("http2_enable") {
+		http2 := d.Get("http2_enable").(bool)
+		updateOpts.Http2Enable = &http2
 	}
 
 	// Wait for LoadBalancer to become active before continuing

--- a/flexibleengine/resource_flexibleengine_lb_listener_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_lb_listener_v2_test.go
@@ -41,6 +41,7 @@ func TestAccLBV2Listener_basic(t *testing.T) {
 
 func TestAccLBV2Listener_withCert(t *testing.T) {
 	var listener listeners.Listener
+	resourceName := "flexibleengine_lb_listener_v2.listener_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -50,7 +51,8 @@ func TestAccLBV2Listener_withCert(t *testing.T) {
 			{
 				Config: TestAccLBV2ListenerConfig_cert,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLBV2ListenerExists("flexibleengine_lb_listener_v2.listener_1", &listener),
+					testAccCheckLBV2ListenerExists(resourceName, &listener),
+					resource.TestCheckResourceAttr(resourceName, "http2_enable", "true"),
 				),
 			},
 		},
@@ -218,6 +220,7 @@ resource "flexibleengine_lb_listener_v2" "listener_1" {
   name                      = "listener_cert"
   protocol                  = "TERMINATED_HTTPS"
   protocol_port             = 8080
+  http2_enable              = true
   loadbalancer_id           = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
   default_tls_container_ref = flexibleengine_lb_certificate_v2.certificate_1.id
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210116064948-5bfe83790eb2
+	github.com/huaweicloud/golangsdk v0.0.0-20210205050659-642d3daa3d9f
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huaweicloud/golangsdk v0.0.0-20210116064948-5bfe83790eb2 h1:S1zh1Z7JafcX/oU/zxVHEHHec5NmTi9a4pZcUgkrVks=
 github.com/huaweicloud/golangsdk v0.0.0-20210116064948-5bfe83790eb2/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
+github.com/huaweicloud/golangsdk v0.0.0-20210205050659-642d3daa3d9f h1:Ru5t1Mf0JLu0KzlDQ0V9grsBhf0BqxBgoEDIij3sa38=
+github.com/huaweicloud/golangsdk v0.0.0-20210205050659-642d3daa3d9f/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/certificates/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/certificates/requests.go
@@ -58,7 +58,7 @@ type CreateOpts struct {
 	Description string `json:"description,omitempty"`
 	Type        string `json:"type,omitempty"`
 	Domain      string `json:"domain,omitempty"`
-	PrivateKey  string `json:"private_key" required:"true"`
+	PrivateKey  string `json:"private_key,omitempty"`
 	Certificate string `json:"certificate" required:"true"`
 }
 

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
@@ -106,11 +106,17 @@ type CreateOpts struct {
 	// The maximum number of connections allowed for the Listener.
 	ConnLimit *int `json:"connection_limit,omitempty"`
 
+	// whether to use HTTP2.
+	Http2Enable *bool `json:"http2_enable,omitempty"`
+
 	// A reference to a Barbican container of TLS secrets.
 	DefaultTlsContainerRef string `json:"default_tls_container_ref,omitempty"`
 
 	// A list of references to TLS secrets.
 	SniContainerRefs []string `json:"sni_container_refs,omitempty"`
+
+	// the ID of the CA certificate used by the listener.
+	CAContainerRef string `json:"client_ca_tls_container_ref,omitempty"`
 
 	// Specifies the security policy used by the listener.
 	TlsCiphersPolicy string `json:"tls_ciphers_policy,omitempty"`
@@ -165,11 +171,17 @@ type UpdateOpts struct {
 	// The maximum number of connections allowed for the Listener.
 	ConnLimit *int `json:"connection_limit,omitempty"`
 
+	// whether to use HTTP2.
+	Http2Enable *bool `json:"http2_enable,omitempty"`
+
 	// A reference to a Barbican container of TLS secrets.
 	DefaultTlsContainerRef string `json:"default_tls_container_ref,omitempty"`
 
 	// A list of references to TLS secrets.
 	SniContainerRefs []string `json:"sni_container_refs,omitempty"`
+
+	// the ID of the CA certificate used by the listener.
+	CAContainerRef string `json:"client_ca_tls_container_ref,omitempty"`
 
 	// Specifies the security policy used by the listener.
 	TlsCiphersPolicy string `json:"tls_ciphers_policy,omitempty"`

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners/results.go
@@ -44,8 +44,14 @@ type Listener struct {
 	// Default is -1, meaning no limit.
 	ConnLimit int `json:"connection_limit"`
 
+	// whether to use HTTP2.
+	Http2Enable bool `json:"http2_enable"`
+
 	// The list of references to TLS secrets.
 	SniContainerRefs []string `json:"sni_container_refs"`
+
+	// the ID of the CA certificate used by the listener.
+	CAContainerRef string `json:"client_ca_tls_container_ref"`
 
 	// A reference to a Barbican container of TLS secrets.
 	DefaultTlsContainerRef string `json:"default_tls_container_ref"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -183,7 +183,7 @@ github.com/hashicorp/terraform-plugin-sdk/plugin
 github.com/hashicorp/terraform-plugin-sdk/terraform
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210116064948-5bfe83790eb2
+# github.com/huaweicloud/golangsdk v0.0.0-20210205050659-642d3daa3d9f
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal

--- a/website/docs/r/lb_listener_v2.html.markdown
+++ b/website/docs/r/lb_listener_v2.html.markdown
@@ -129,6 +129,9 @@ The following arguments are supported:
 
 * `description` - (Optional) Human-readable description for the listener.
 
+* `http2_enable` - (Optional, Bool) Specifies whether to use HTTP/2. The default value is false.
+    This parameter is valid only when the protocol is set to *TERMINATED_HTTPS*.
+
 * `default_tls_container_ref` - (Optional) A reference to a Barbican Secrets
     container which stores TLS information. This is required if the protocol
     is `TERMINATED_HTTPS`. See
@@ -187,7 +190,7 @@ The following attributes are exported:
 * `name` - See Argument Reference above.
 * `default_port_id` - See Argument Reference above.
 * `description` - See Argument Reference above.
-* `connection_limit` - See Argument Reference above.
+* `http2_enable` - See Argument Reference above.
 * `default_tls_container_ref` - See Argument Reference above.
 * `sni_container_refs` - See Argument Reference above.
 * `tls_ciphers_policy` - See Argument Reference above.


### PR DESCRIPTION
the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLBV2Listener_withCert'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLBV2Listener_withCert -timeout 720m
=== RUN   TestAccLBV2Listener_withCert
--- PASS: TestAccLBV2Listener_withCert (59.03s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 59.046s
```