### PR TITLE
Make access_type and access_level to be computed in sfs

### DIFF
--- a/flexibleengine/resource_flexibleengine_sfs_file_system_v2.go
+++ b/flexibleengine/resource_flexibleengine_sfs_file_system_v2.go
@@ -70,10 +70,12 @@ func resourceSFSFileSystemV2() *schema.Resource {
 			"access_level": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"access_type": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"access_to": {
 				Type:     schema.TypeString,
@@ -325,11 +327,20 @@ func resourceSFSFileSystemV2Update(d *schema.ResourceData, meta interface{}) err
 			d.Set("share_access_id", "")
 		}
 
-		if _, ok := d.GetOk("access_to"); ok {
+		if v, ok := d.GetOk("access_to"); ok {
 			grantAccessOpts := shares.GrantAccessOpts{
-				AccessLevel: d.Get("access_level").(string),
-				AccessType:  d.Get("access_type").(string),
-				AccessTo:    d.Get("access_to").(string),
+				AccessTo: v.(string),
+			}
+
+			if v, ok := d.GetOk("access_level"); ok {
+				grantAccessOpts.AccessLevel = v.(string)
+			} else {
+				grantAccessOpts.AccessLevel = "rw"
+			}
+			if v, ok := d.GetOk("access_type"); ok {
+				grantAccessOpts.AccessType = v.(string)
+			} else {
+				grantAccessOpts.AccessType = "cert"
 			}
 
 			log.Printf("[DEBUG] Grant Access Rules: %#v", grantAccessOpts)

--- a/flexibleengine/resource_flexibleengine_sfs_file_system_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_sfs_file_system_v2_test.go
@@ -132,7 +132,6 @@ resource "flexibleengine_sfs_file_system_v2" "sfs_1" {
   name         = "sfs-test1"
   description  = "sfs_c2c_test-file"
   access_to    = "%s"
-  access_type  = "cert"
   access_level = "rw"
   availability_zone = "%s"
 }
@@ -140,13 +139,12 @@ resource "flexibleengine_sfs_file_system_v2" "sfs_1" {
 
 var testAccSFSFileSystemV2_update = fmt.Sprintf(`
 resource "flexibleengine_sfs_file_system_v2" "sfs_1" {
-  share_proto  = "NFS"
-  size         = 20
-  name         = "sfs-test2"
-  description  = "sfs_c2c_test-file"
-  access_to    = "%s"
-  access_type  = "cert"
-  access_level = "rw"
+  share_proto = "NFS"
+  size        = 20
+  name        = "sfs-test2"
+  description = "sfs_c2c_test-file"
+  access_to   = "%s"
+  access_type = "cert"
   availability_zone = "%s"
 }
 `, OS_VPC_ID, OS_AVAILABILITY_ZONE)


### PR DESCRIPTION
if `access_type` and `access_level` are empty in configure, the provider
will set to the default value, so we make them to be computed.

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccSFSFileSystemV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccSFSFileSystemV2_basic -timeout 720m
=== RUN   TestAccSFSFileSystemV2_basic
--- PASS: TestAccSFSFileSystemV2_basic (59.46s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 59.470s
```