### PR TITLE
support fixed_ip into rds instance v3

### DIFF
--- a/flexibleengine/resource_flexibleengine_rds_instance_v3.go
+++ b/flexibleengine/resource_flexibleengine_rds_instance_v3.go
@@ -187,6 +187,12 @@ func resourceRdsInstanceV3() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
+			"fixed_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 			"nodes": {
 				Type:     schema.TypeList,
 				Computed: true,
@@ -259,6 +265,7 @@ func resourceRdsInstanceV3UserInputParams(d *schema.ResourceData) map[string]int
 		"volume":                  d.Get("volume"),
 		"vpc_id":                  d.Get("vpc_id"),
 		"time_zone":               d.Get("time_zone"),
+		"data_vip":                d.Get("fixed_ip"),
 	}
 }
 
@@ -562,6 +569,16 @@ func buildRdsInstanceV3CreateParameters(opts map[string]interface{}, arrayIndex 
 		return nil, err
 	} else if !e {
 		params["time_zone"] = v
+	}
+
+	v, err = navigateValue(opts, []string{"data_vip"}, arrayIndex)
+	if err != nil {
+		return nil, err
+	}
+	if e, err := isEmptyValue(reflect.ValueOf(v)); err != nil {
+		return nil, err
+	} else if !e {
+		params["data_vip"] = v
 	}
 
 	return params, nil
@@ -905,6 +922,11 @@ func setRdsInstanceV3Properties(d *schema.ResourceData, response map[string]inte
 	}
 	if err = d.Set("private_ips", v); err != nil {
 		return fmt.Errorf("Error setting Instance:private_ips, err: %s", err)
+	}
+	if len(v.([]interface{})) != 0 {
+		if err = d.Set("fixed_ip", v.([]interface{})[0]); err != nil {
+			return fmt.Errorf("Error setting Instance:fixed_ip, err: %s", err)
+		}
 	}
 
 	v, err = navigateValue(response, []string{"list", "public_ips"}, nil)

--- a/flexibleengine/resource_flexibleengine_rds_instance_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_rds_instance_v3_test.go
@@ -44,6 +44,7 @@ func TestAccRdsInstanceV3_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "100"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttrSet(resourceName, "fixed_ip"),
 				),
 			},
 			{

--- a/website/docs/r/rds_instance_v3.html.markdown
+++ b/website/docs/r/rds_instance_v3.html.markdown
@@ -177,6 +177,9 @@ The following arguments are supported:
   (Optional)
   Specifies the parameter group ID. Changing this parameter will create a new resource.
 
+* `fixed_ip` - (Optional) Specifies an intranet floating IP address of the RDS instance.
+  Changing this parameter will create a new resource.
+
 * `time_zone` - (Optional) Specifies the UTC time zone. The value ranges from
   UTC-12:00 to UTC+12:00 at the full hour, and defaults to *UTC*.
 


### PR DESCRIPTION
fixes #158 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccRdsInstanceV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccRdsInstanceV3_basic -timeout 720m
=== RUN   TestAccRdsInstanceV3_basic
--- PASS: TestAccRdsInstanceV3_basic (598.25s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 598.257s
```
