### PR TITLE
support delegated_service_name param in iam agency

### DIFF
--- a/flexibleengine/provider_test.go
+++ b/flexibleengine/provider_test.go
@@ -30,6 +30,7 @@ var (
 	OS_BMS_FLAVOR_NAME        = os.Getenv("OS_BMS_FLAVOR_NAME")
 	OS_MRS_ENVIRONMENT        = os.Getenv("OS_MRS_ENVIRONMENT")
 	OS_SDRS_ENVIRONMENT       = os.Getenv("OS_SDRS_ENVIRONMENT")
+	OS_DELEGATED_DOMAIN_NAME  = os.Getenv("OS_DELEGATED_DOMAIN_NAME")
 	OS_TENANT_NAME            = getTenantName()
 )
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210220061802-7797ab3df699
+	github.com/huaweicloud/golangsdk v0.0.0-20210301092521-06fa98868773
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20210207050553-158e5bc3ef64 h1:CHIzZqEyY
 github.com/huaweicloud/golangsdk v0.0.0-20210207050553-158e5bc3ef64/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/huaweicloud/golangsdk v0.0.0-20210220061802-7797ab3df699 h1:TiX463o5pOU58a5OtTO30NgO1N9Ppek/wWwVySDhRV0=
 github.com/huaweicloud/golangsdk v0.0.0-20210220061802-7797ab3df699/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
+github.com/huaweicloud/golangsdk v0.0.0-20210301092521-06fa98868773 h1:q7SBNILDyuyq3dgEaeGQ6T+7qHhn4aQBNvJpn1HKhCQ=
+github.com/huaweicloud/golangsdk v0.0.0-20210301092521-06fa98868773/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/identity/v3/agency/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/identity/v3/agency/requests.go
@@ -9,6 +9,7 @@ type CreateOpts struct {
 	DomainID        string `json:"domain_id" required:"true"`
 	DelegatedDomain string `json:"trust_domain_name" required:"true"`
 	Description     string `json:"description,omitempty"`
+	Duration        string `json:"duration,omitempty"`
 }
 
 type CreateOptsBuilder interface {
@@ -33,6 +34,7 @@ func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult)
 type UpdateOpts struct {
 	DelegatedDomain string `json:"trust_domain_name,omitempty"`
 	Description     string `json:"description,omitempty"`
+	Duration        string `json:"duration,omitempty"`
 }
 
 type UpdateOptsBuilder interface {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -183,7 +183,7 @@ github.com/hashicorp/terraform-plugin-sdk/plugin
 github.com/hashicorp/terraform-plugin-sdk/terraform
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210220061802-7797ab3df699
+# github.com/huaweicloud/golangsdk v0.0.0-20210301092521-06fa98868773
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal

--- a/website/docs/r/identity_agency_v3.html.markdown
+++ b/website/docs/r/identity_agency_v3.html.markdown
@@ -11,12 +11,13 @@ description: |-
 Manages an agency resource within FlexibleEngine.
 
 ## Example Usage
-
+### Delegate another account to perform operations on your resources
 ```hcl
 resource "flexibleengine_identity_agency_v3" "agency" {
-  name = "test_agency"
-  description = "test agency"
+  name                  = "test_agency"
+  description           = "this is a domain test agency"
   delegated_domain_name = "***"
+
   project_role {
     project = "eu-west-0"
     roles = [
@@ -29,48 +30,69 @@ resource "flexibleengine_identity_agency_v3" "agency" {
 }
 ```
 
-**Note**: It can not set `tenant_name` in `provider "flexibleengine"` when
-   using this resource.
+### Delegate a cloud service to access your resources in other cloud services
+```hcl
+resource "flexibleengine_identity_agency_v3" "agency" {
+  name                   = "test_agency"
+  description            = "this is a service test agency"
+  delegated_service_name = "op_svc_evs"
+
+  project_role {
+    project = "eu-west-0"
+    roles = [
+      "Tenant Administrator",
+    ]
+  }
+  domain_roles = [
+    "OBS OperateAccess",
+  ]
+}
+```
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `name` - (Required) The name of agency. The name is a string of 1 to 64
-    characters.
+* `name` - (Required) Specifies the name of agency. The name is a string of 1 to 64 characters.
+    Changing this will create a new agency.
 
-* `description` - (Optional) Provides supplementary information about the
-    agency. The value is a string of 0 to 255 characters.
+* `description` - (Optional) Specifies the supplementary information about the agency.
+    The value is a string of 0 to 255 characters.
 
-* `delegated_domain_name` - (Required) The name of delegated domain.
+* `delegated_domain_name` - (Optional) Specifies the name of delegated user domain.
+    This parameter and `delegated_service_name` are alternative.
 
-* `project_role` - (Optional) An array of roles and projects which are used to
-    grant permissions to agency on project. The structure is documented below.
+* `delegated_service_name` - (Optional) Specifies the name of delegated cloud service.
+    This parameter and `delegated_domain_name` are alternative.
 
-* `domain_roles` - (optional) An array of role names which stand for the
-    permissionis to be granted to agency on domain.
+* `duration` - (Optional) Specifies the validity period of an agency.
+    The valid value are *ONEDAY* and *FOREVER*, defaults to *FOREVER*.
+
+* `project_role` - (Optional) Specifies an array of one or more roles and projects which are used to grant
+    permissions to agency on project. The structure is documented below.
+
+* `domain_roles` - (optional) Specifies an array of one or more role names which stand for the permissionis to
+    be granted to agency on domain.
 
 The `project_role` block supports:
 
-* `project` - (Required) The name of project
+* `project` - (Required) Specifies the name of project.
 
-* `roles` - (Required) An array of role names
+* `roles` - (Required) Specifies an array of role names.
 
-**note**:
-    one or both of `project_role` and `domain_roles` must be input when
-creating an agency.
+**note**: one or both of `project_role` and `domain_roles` must be input when creating an agency.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - The agency ID.
-* `name` - See Argument Reference above.
-* `description` - See Argument Reference above.
-* `delegated_domain_name` - See Argument Reference above.
-* `project_role` - See Argument Reference above.
-* `domain_roles` - See Argument Reference above.
-* `duration` - Validity period of an agency. The default value is null,
-    indicating that the agency is permanently valid.
-* `expire_time` - The expiration time of agency
+* `expire_time` - The expiration time of agency.
 * `create_time` - The time when the agency was created.
+
+## Import
+
+Agencies can be imported using the `id`, e.g.
+```
+$ terraform import flexibleengine_identity_agency_v3.agency 0b97661f9900f23f4fc2c00971ea4dc0
+```


### PR DESCRIPTION
fixes #409 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccIdentityV3Agency'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccIdentityV3Agency -timeout 720m
=== RUN   TestAccIdentityV3Agency_basic
--- PASS: TestAccIdentityV3Agency_basic (81.68s)
=== RUN   TestAccIdentityV3Agency_domain
--- PASS: TestAccIdentityV3Agency_domain (69.93s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 151.627s
```