### PR TITLE
support authenticating_proxy_ca and kube_proxy_mode for cce cluster

### DIFF
--- a/flexibleengine/resource_flexibleengine_cce_cluster_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_cce_cluster_v3_test.go
@@ -14,6 +14,7 @@ import (
 func TestAccCCEClusterV3_basic(t *testing.T) {
 	var cluster clusters.Clusters
 	var cceName = fmt.Sprintf("terra-test-%s", acctest.RandString(5))
+	resourceName := "flexibleengine_cce_cluster_v3.cluster_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -23,49 +24,26 @@ func TestAccCCEClusterV3_basic(t *testing.T) {
 			{
 				Config: testAccCCEClusterV3_basic(cceName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCEClusterV3Exists("flexibleengine_cce_cluster_v3.cluster_1", &cluster),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_cce_cluster_v3.cluster_1", "name", cceName),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_cce_cluster_v3.cluster_1", "status", "Available"),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_cce_cluster_v3.cluster_1", "cluster_type", "VirtualMachine"),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_cce_cluster_v3.cluster_1", "flavor_id", "cce.s1.small"),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_cce_cluster_v3.cluster_1", "cluster_version", "v1.11.7-r2"),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_cce_cluster_v3.cluster_1", "container_network_type", "overlay_l2"),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_cce_cluster_v3.cluster_1", "authentication_mode", "rbac"),
+					testAccCheckCCEClusterV3Exists(resourceName, &cluster),
+					resource.TestCheckResourceAttr(resourceName, "name", cceName),
+					resource.TestCheckResourceAttr(resourceName, "description", "a description"),
+					resource.TestCheckResourceAttr(resourceName, "status", "Available"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_type", "VirtualMachine"),
+					resource.TestCheckResourceAttr(resourceName, "flavor_id", "cce.s1.small"),
+					resource.TestCheckResourceAttr(resourceName, "cluster_version", "v1.11.7-r2"),
+					resource.TestCheckResourceAttr(resourceName, "container_network_type", "overlay_l2"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode", "rbac"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccCCEClusterV3_update(cceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"flexibleengine_cce_cluster_v3.cluster_1", "description", "new description"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccCCEClusterV3_timeout(t *testing.T) {
-	var cluster clusters.Clusters
-	var cceName = fmt.Sprintf("terra-test-%s", acctest.RandString(5))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCEClusterV3Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCCEClusterV3_timeout(cceName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCEClusterV3Exists("flexibleengine_cce_cluster_v3.cluster_1", &cluster),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_cce_cluster_v3.cluster_1", "authentication_mode", "rbac"),
+					resource.TestCheckResourceAttr(resourceName, "description", "a updated description"),
 				),
 			},
 		},
@@ -128,48 +106,27 @@ func testAccCheckCCEClusterV3Exists(n string, cluster *clusters.Clusters) resour
 func testAccCCEClusterV3_basic(cceName string) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_cce_cluster_v3" "cluster_1" {
-  name = "%s"
-  cluster_type="VirtualMachine"
-  flavor_id="cce.s1.small"
+  name            = "%s"
+  description     = "a description"
+  cluster_type    = "VirtualMachine"
   cluster_version = "v1.11.7-r2"
-  vpc_id="%s"
-  subnet_id="%s"
-  container_network_type="overlay_l2"
+  flavor_id       = "cce.s1.small"
+  vpc_id          = "%s"
+  subnet_id       = "%s"
+  container_network_type = "overlay_l2"
 }`, cceName, OS_VPC_ID, OS_NETWORK_ID)
 }
 
 func testAccCCEClusterV3_update(cceName string) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_cce_cluster_v3" "cluster_1" {
-  name = "%s"
-  cluster_type="VirtualMachine"
-  flavor_id="cce.s1.small"
+  name            = "%s"
+  description     = "a updated description"
+  cluster_type    = "VirtualMachine"
   cluster_version = "v1.11.7-r2"
-  vpc_id="%s"
-  subnet_id="%s"
-  container_network_type="overlay_l2"
-  description="new description"
+  flavor_id       = "cce.s1.small"
+  vpc_id          = "%s"
+  subnet_id       = "%s"
+  container_network_type = "overlay_l2"
 }`, cceName, OS_VPC_ID, OS_NETWORK_ID)
-}
-
-func testAccCCEClusterV3_timeout(cceName string) string {
-	return fmt.Sprintf(`
-resource "flexibleengine_networking_floatingip_v2" "fip_1" {
-}
-
-resource "flexibleengine_cce_cluster_v3" "cluster_1" {
-  name = "%s"
-  cluster_type="VirtualMachine"
-  flavor_id="cce.s1.small"
-  vpc_id="%s"
-  subnet_id="%s"
-  eip="${flexibleengine_networking_floatingip_v2.fip_1.address}"
-  authentication_mode = "rbac"
-  container_network_type="overlay_l2"
-    timeouts {
-    create = "10m"
-    delete = "10m"
-  }
-}
-`, cceName, OS_VPC_ID, OS_NETWORK_ID)
 }

--- a/website/docs/r/cce_cluster_v3.html.md
+++ b/website/docs/r/cce_cluster_v3.html.md
@@ -13,26 +13,25 @@ Provides a cluster resource (CCE).
 ## Example Usage
 
  ```hcl
-    variable "flavor_id" { }
-    variable "vpc_id" { }
-    variable "subnet_id" { }
+variable "flavor_id" { }
+variable "vpc_id" { }
+variable "subnet_id" { }
 	
-    resource "flexibleengine_cce_cluster_v3" "cluster_1" {
-     name = "cluster"
-     cluster_type= "VirtualMachine"
-     flavor_id= "${var.flavor_id}"
-     vpc_id= "${var.vpc_id}"
-     subnet_id= "${var.subnet_id}"
-     container_network_type= "overlay_l2"
-     authentication_mode = "rbac"
-     description= "Create cluster"
-    }
+resource "flexibleengine_cce_cluster_v3" "cluster_1" {
+  name                   = "cluster"
+  cluster_type           = "VirtualMachine"
+  authentication_mode    = "rbac"
+  description            = "new cluster"
+  flavor_id              = var.flavor_id
+  vpc_id                 = var.vpc_id
+  subnet_id              = var.subnet_id
+  container_network_type = "overlay_l2"
+}
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
-
 
 * `name` - (Required) Cluster name. Changing this parameter will create a new cluster resource.
 
@@ -42,18 +41,18 @@ The following arguments are supported:
 
 * `flavor_id` - (Required) Cluster specifications. Changing this parameter will create a new cluster resource.
 
-	* `cce.s1.small` - small-scale single cluster (up to 50 nodes).
-	* `cce.s1.medium` - medium-scale single cluster (up to 200 nodes).
-	* `cce.s1.large` - large-scale single cluster (up to 1000 nodes).
-	* `cce.s2.small` - small-scale HA cluster (up to 50 nodes).
-	* `cce.s2.medium` - medium-scale HA cluster (up to 200 nodes).
-	* `cce.s2.large` - large-scale HA cluster (up to 1000 nodes).
-	* `cce.t1.small` - small-scale single physical machine cluster (up to 10 nodes).
-	* `cce.t1.medium` - medium-scale single physical machine cluster (up to 100 nodes).
-	* `cce.t1.large` - large-scale single physical machine cluster (up to 500 nodes).
-	* `cce.t2.small` - small-scale HA physical machine cluster (up to 10 nodes).
-	* `cce.t2.medium` - medium-scale HA physical machine cluster (up to 100 nodes).
-	* `cce.t2.large` - large-scale HA physical machine cluster (up to 500 nodes).
+  * `cce.s1.small` - small-scale single cluster (up to 50 nodes).
+  * `cce.s1.medium` - medium-scale single cluster (up to 200 nodes).
+  * `cce.s1.large` - large-scale single cluster (up to 1000 nodes).
+  * `cce.s2.small` - small-scale HA cluster (up to 50 nodes).
+  * `cce.s2.medium` - medium-scale HA cluster (up to 200 nodes).
+  * `cce.s2.large` - large-scale HA cluster (up to 1000 nodes).
+  * `cce.t1.small` - small-scale single physical machine cluster (up to 10 nodes).
+  * `cce.t1.medium` - medium-scale single physical machine cluster (up to 100 nodes).
+  * `cce.t1.large` - large-scale single physical machine cluster (up to 500 nodes).
+  * `cce.t2.small` - small-scale HA physical machine cluster (up to 10 nodes).
+  * `cce.t2.medium` - medium-scale HA physical machine cluster (up to 100 nodes).
+  * `cce.t2.large` - large-scale HA physical machine cluster (up to 500 nodes).
 
 * `cluster_version` - (Optional) For the cluster version, possible values are listed on the [CCE Cluster Version Release Notes](https://docs.prod-cloud-ocb.orange-business.com/usermanual2/cce/cce_01_0068.html). If this parameter is not set, the latest available version will be used.
 
@@ -69,23 +68,34 @@ The following arguments are supported:
 
 * `subnet_id` - (Required) The NETWORK ID of the subnet used to create the node. Changing this parameter will create a new cluster resource.
 
-* `highway_subnet_id` - (Optional) The ID of the high speed network used to create bare metal nodes. Changing this parameter will create a new cluster resource.
+* `highway_subnet_id` - (Optional) The ID of the high speed network used to create bare metal nodes.
+    Changing this parameter will create a new cluster resource.
 
 * `container_network_type` - (Required) Container network parameters. Possible values:
 
-	* `overlay_l2` - An overlay_l2 network built for containers by using Open vSwitch(OVS)
-	* `underlay_ipvlan` - An underlay_ipvlan network built for bare metal servers by using ipvlan.
-	* `vpc-router` - An vpc-router network built for containers by using ipvlan and custom VPC routes.
+  * `overlay_l2` - An overlay_l2 network built for containers by using Open vSwitch(OVS)
+  * `underlay_ipvlan` - An underlay_ipvlan network built for bare metal servers by using ipvlan.
+  * `vpc-router` - An vpc-router network built for containers by using ipvlan and custom VPC routes.
 
 * `container_network_cidr` - (Optional) Container network segment. Changing this parameter will create a new cluster resource.
 
-* `authentication_mode` - (Optional) Authentication mode of the cluster, possible values are x509 and rbac. Defaults to x509.
+* `authentication_mode` - (Optional) Authentication mode of the cluster, possible values are x509 and rbac. Defaults to *rbac*.
     Changing this parameter will create a new cluster resource.
+
+* `authenticating_proxy_ca` - (Optional) CA root certificate provided in the authenticating_proxy mode. The CA root certificate
+    is encoded to the Base64 format. Changing this parameter will create a new cluster resource.
 
 * `eip` - (Optional) EIP address of the cluster. Changing this parameter will create a new cluster resource.
 
-* `masters` - (Optional, List, ForceNew) Advanced configuration of master nodes. Changing this creates a new cluster.
+* `kube_proxy_mode` - (Optional, String, ForceNew) Service forwarding mode. Two modes are available:
 
+  - iptables: Traditional kube-proxy uses iptables rules to implement service load balancing. In this mode, too many iptables rules
+    will be generated when many services are deployed. In addition, non-incremental updates will cause a latency and even obvious
+    performance issues in the case of heavy service traffic.
+  - ipvs: Optimized kube-proxy mode with higher throughput and faster speed. This mode supports incremental updates and
+    can keep connections uninterrupted during service updates. It is suitable for large-sized clusters.
+
+* `masters` - (Optional, List, ForceNew) Advanced configuration of master nodes. Changing this creates a new cluster.
 
 The `masters` block supports:
 
@@ -95,34 +105,34 @@ The `masters` block supports:
 
 All above argument parameters can be exported as attribute parameters along with attribute reference.
 
-  * `id` -  Id of the cluster resource.
+* `id` -  Id of the cluster resource.
 
-  * `status` -  Cluster status information.
+* `status` -  Cluster status information.
 
-  * `internal_endpoint` - The internal network address.
+* `internal_endpoint` - The internal network address.
 
-  * `external_endpoint` - The external network address.
+* `external_endpoint` - The external network address.
 
-  * `external_apig_endpoint` - The endpoint of the cluster to be accessed through API Gateway.
+* `external_apig_endpoint` - The endpoint of the cluster to be accessed through API Gateway.
 
-  * `security_group_id` - Security group ID of the cluster.
+* `security_group_id` - Security group ID of the cluster.
 
-  * `certificate_clusters.name` - The cluster name.
+* `certificate_clusters.name` - The cluster name.
 
-  * `certificate_clusters.server` - The server IP address.
+* `certificate_clusters.server` - The server IP address.
 
-  * `certificate_clusters.certificate_authority_data` - The certificate data.
+* `certificate_clusters.certificate_authority_data` - The certificate data.
 
-  * `certificate_users.name` - The user name.
+* `certificate_users.name` - The user name.
 
-  * `certificate_users.client_certificate_data` - The client certificate data.
+* `certificate_users.client_certificate_data` - The client certificate data.
 
-  * `certificate_users.client_key_data` - The client key data.
+* `certificate_users.client_key_data` - The client key data.
 
 ## Import
 
- Cluster can be imported using the cluster id, e.g.
+Cluster can be imported using the cluster id, e.g.
 
- ```
- $ terraform import flexibleengine_cce_cluster_v3.cluster_1 4779ab1c-7c1a-44b1-a02e-93dfc361b32d  
+```
+$ terraform import flexibleengine_cce_cluster_v3.cluster_1 4779ab1c-7c1a-44b1-a02e-93dfc361b32d  
 ```


### PR DESCRIPTION
fixes #257 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCCEClusterV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCCEClusterV3_basic -timeout 720m
=== RUN   TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (1832.13s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine (1832.13s)
```