### PR TITLE
add extend_param to specify agency name for cce node

### DIFF
--- a/flexibleengine/resource_flexibleengine_cce_node_pool.go
+++ b/flexibleengine/resource_flexibleengine_cce_node_pool.go
@@ -177,6 +177,12 @@ func resourceCCENodePool() *schema.Resource {
 					}
 				},
 			},
+			"extend_param": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"subnet_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -229,14 +235,6 @@ func resourceCCENodePoolCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	var base64PreInstall, base64PostInstall string
-	if v, ok := d.GetOk("preinstall"); ok {
-		base64PreInstall = installScriptEncode(v.(string))
-	}
-	if v, ok := d.GetOk("postinstall"); ok {
-		base64PostInstall = installScriptEncode(v.(string))
-	}
-
 	initialNodeCount := d.Get("initial_node_count").(int)
 
 	createOpts := nodepools.CreateOpts{
@@ -262,11 +260,8 @@ func resourceCCENodePoolCreate(d *schema.ResourceData, meta interface{}) error {
 						SubnetId: d.Get("subnet_id").(string),
 					},
 				},
-				ExtendParam: nodes.ExtendParam{
-					PreInstall:  base64PreInstall,
-					PostInstall: base64PostInstall,
-				},
-				Taints: resourceCCETaint(d),
+				ExtendParam: resourceCCEExtendParam(d),
+				Taints:      resourceCCETaint(d),
 			},
 			Autoscaling: nodepools.AutoscalingSpec{
 				Enable:                d.Get("scall_enable").(bool),

--- a/flexibleengine/resource_flexibleengine_cce_node_pool.go
+++ b/flexibleengine/resource_flexibleengine_cce_node_pool.go
@@ -75,9 +75,10 @@ func resourceCCENodePool() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"extend_param": {
-							Type:     schema.TypeString,
+						"extend_params": {
+							Type:     schema.TypeMap,
 							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					}},
 			},
@@ -95,9 +96,10 @@ func resourceCCENodePool() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"extend_param": {
-							Type:     schema.TypeString,
+						"extend_params": {
+							Type:     schema.TypeMap,
 							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
 						},
 					}},
 			},
@@ -369,7 +371,7 @@ func resourceCCENodePoolRead(d *schema.ResourceData, meta interface{}) error {
 		volume := make(map[string]interface{})
 		volume["size"] = pairObject.Size
 		volume["volumetype"] = pairObject.VolumeType
-		volume["extend_param"] = pairObject.ExtendParam
+		volume["extend_params"] = pairObject.ExtendParam
 		volumes = append(volumes, volume)
 	}
 	if err := d.Set("data_volumes", volumes); err != nil {
@@ -378,9 +380,9 @@ func resourceCCENodePoolRead(d *schema.ResourceData, meta interface{}) error {
 
 	rootVolume := []map[string]interface{}{
 		{
-			"size":         s.Spec.NodeTemplate.RootVolume.Size,
-			"volumetype":   s.Spec.NodeTemplate.RootVolume.VolumeType,
-			"extend_param": s.Spec.NodeTemplate.RootVolume.ExtendParam,
+			"size":          s.Spec.NodeTemplate.RootVolume.Size,
+			"volumetype":    s.Spec.NodeTemplate.RootVolume.VolumeType,
+			"extend_params": s.Spec.NodeTemplate.RootVolume.ExtendParam,
 		},
 	}
 	if err := d.Set("root_volume", rootVolume); err != nil {

--- a/flexibleengine/resource_flexibleengine_cce_node_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_cce_node_v3_test.go
@@ -14,6 +14,7 @@ import (
 func TestAccCCENodesV3_basic(t *testing.T) {
 	var node nodes.Nodes
 	var cceName = fmt.Sprintf("terra-test-%s", acctest.RandString(5))
+	resourceName := "flexibleengine_cce_node_v3.node_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccCCEKeyPairPreCheck(t) },
@@ -24,38 +25,14 @@ func TestAccCCENodesV3_basic(t *testing.T) {
 				Config: testAccCCENodeV3_basic(cceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodeV3Exists("flexibleengine_cce_node_v3.node_1", "flexibleengine_cce_cluster_v3.cluster_1", &node),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_cce_node_v3.node_1", "name", "test-node"),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_cce_node_v3.node_1", "flavor_id", "s1.medium"),
+					resource.TestCheckResourceAttr(resourceName, "name", "test-node"),
+					resource.TestCheckResourceAttr(resourceName, "flavor_id", "s1.medium"),
 				),
 			},
 			{
 				Config: testAccCCENodeV3_update(cceName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"flexibleengine_cce_node_v3.node_1", "name", "test-node2"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccCCENodesV3_timeout(t *testing.T) {
-	var node nodes.Nodes
-	var cceName = fmt.Sprintf("terra-test-%s", acctest.RandString(5))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccCCEKeyPairPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCCENodeV3Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCCENodeV3_timeout(cceName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCCENodeV3Exists("flexibleengine_cce_node_v3.node_1", "flexibleengine_cce_cluster_v3.cluster_1", &node),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_cce_node_v3.node_1", "os", "CentOS 7.6"),
+					resource.TestCheckResourceAttr(resourceName, "name", "test-node2"),
 				),
 			},
 		},
@@ -69,18 +46,23 @@ func testAccCheckCCENodeV3Destroy(s *terraform.State) error {
 		return fmt.Errorf("Error creating flexibleengine CCE client: %s", err)
 	}
 
-	var clusterId string
-
+	var clusterID string
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type == "flexibleengine_cce_cluster_v3" {
-			clusterId = rs.Primary.ID
+			clusterID = rs.Primary.ID
+			break
 		}
+	}
+	if clusterID == "" {
+		return fmt.Errorf("cce cluster not found")
+	}
 
+	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "flexibleengine_cce_node_v3" {
 			continue
 		}
 
-		_, err := nodes.Get(cceClient, clusterId, rs.Primary.ID).Extract()
+		_, err := nodes.Get(cceClient, clusterID, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("Node still exists")
 		}
@@ -131,27 +113,27 @@ func testAccCheckCCENodeV3Exists(n string, cluster string, node *nodes.Nodes) re
 func testAccCCENodeV3_basic(cceName string) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_cce_cluster_v3" "cluster_1" {
-  name = "%s"
-  cluster_type="VirtualMachine"
-  flavor_id="cce.s1.small"
-  vpc_id="%s"
-  subnet_id="%s"
-  container_network_type="overlay_l2"
+  name         = "%s"
+  cluster_type = "VirtualMachine"
+  flavor_id    = "cce.s1.small"
+  vpc_id       = "%s"
+  subnet_id    = "%s"
+  container_network_type = "overlay_l2"
 }
 
 resource "flexibleengine_cce_node_v3" "node_1" {
-cluster_id = "${flexibleengine_cce_cluster_v3.cluster_1.id}"
-  name = "test-node"
-  flavor_id="s1.medium"
-  availability_zone= "%s"
-  key_pair="%s"
+  cluster_id        = flexibleengine_cce_cluster_v3.cluster_1.id
+  name              = "test-node"
+  flavor_id         = "s1.medium"
+  availability_zone = "%s"
+  key_pair          = "%s"
   root_volume {
-    size= 40
-    volumetype= "SATA"
+    size       = 40
+    volumetype = "SATA"
   }
   data_volumes {
-    size= 100
-    volumetype= "SATA"
+    size       = 100
+    volumetype = "SATA"
   }
 }`, cceName, OS_VPC_ID, OS_NETWORK_ID, OS_AVAILABILITY_ZONE, OS_KEYPAIR_NAME)
 }
@@ -159,62 +141,27 @@ cluster_id = "${flexibleengine_cce_cluster_v3.cluster_1.id}"
 func testAccCCENodeV3_update(cceName string) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_cce_cluster_v3" "cluster_1" {
-  name = "%s"
-  cluster_type="VirtualMachine"
-  flavor_id="cce.s1.small"
-  vpc_id="%s"
-  subnet_id="%s"
-  container_network_type="overlay_l2"
+  name         = "%s"
+  cluster_type = "VirtualMachine"
+  flavor_id    = "cce.s1.small"
+  vpc_id       = "%s"
+  subnet_id    = "%s"
+  container_network_type = "overlay_l2"
 }
 
 resource "flexibleengine_cce_node_v3" "node_1" {
-cluster_id = "${flexibleengine_cce_cluster_v3.cluster_1.id}"
-  name = "test-node2"
-  flavor_id="s1.medium"
-  availability_zone= "%s"
-  key_pair="%s"
+  cluster_id        = flexibleengine_cce_cluster_v3.cluster_1.id
+  name              = "test-node2"
+  flavor_id         = "s1.medium"
+  availability_zone = "%s"
+  key_pair          = "%s"
   root_volume {
-    size= 40
-    volumetype= "SATA"
+    size       = 40
+    volumetype = "SATA"
   }
   data_volumes {
-    size= 100
-    volumetype= "SATA"
+    size       = 100
+    volumetype = "SATA"
   }
 }`, cceName, OS_VPC_ID, OS_NETWORK_ID, OS_AVAILABILITY_ZONE, OS_KEYPAIR_NAME)
-}
-
-func testAccCCENodeV3_timeout(cceName string) string {
-	return fmt.Sprintf(`
-resource "flexibleengine_cce_cluster_v3" "cluster_1" {
-  name = "%s"
-  cluster_type="VirtualMachine"
-  flavor_id="cce.s1.small"
-  vpc_id="%s"
-  subnet_id="%s"
-  container_network_type="overlay_l2"
-  authentication_mode = "rbac"
-}
-
-resource "flexibleengine_cce_node_v3" "node_1" {
-  cluster_id = "${flexibleengine_cce_cluster_v3.cluster_1.id}"
-  name = "test-node2"
-  flavor_id="s1.medium"
-  availability_zone= "%s"
-  os = "CentOS 7.6"
-  key_pair="%s"
-  root_volume {
-    size= 40
-    volumetype= "SATA"
-  }
-  data_volumes {
-    size= 100
-    volumetype= "SATA"
-  }
-timeouts {
-create = "10m"
-delete = "10m"
-} 
-}
-`, cceName, OS_VPC_ID, OS_NETWORK_ID, OS_AVAILABILITY_ZONE, OS_KEYPAIR_NAME)
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210301092521-06fa98868773
+	github.com/huaweicloud/golangsdk v0.0.0-20210302064636-d5178f8b52dd
 	github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20210220061802-7797ab3df699 h1:TiX463o5p
 github.com/huaweicloud/golangsdk v0.0.0-20210220061802-7797ab3df699/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/huaweicloud/golangsdk v0.0.0-20210301092521-06fa98868773 h1:q7SBNILDyuyq3dgEaeGQ6T+7qHhn4aQBNvJpn1HKhCQ=
 github.com/huaweicloud/golangsdk v0.0.0-20210301092521-06fa98868773/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
+github.com/huaweicloud/golangsdk v0.0.0-20210302064636-d5178f8b52dd h1:6cMRETkcaqNovnOiyU8NwZnUGtqZgA/0ZiNGg6hMrZs=
+github.com/huaweicloud/golangsdk v0.0.0-20210302064636-d5178f8b52dd/go.mod h1:WQBcHRNX9shz3928lWEvstQJtAtYI7ks6XlgtRT9Tcw=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a h1:FyS/ubzBR5xJlnJGRTwe7GUHpJOR4ukYK3y+LFNffuA=
 github.com/jen20/awspolicyequivalence v0.0.0-20170831201602-3d48364a137a/go.mod h1:uoIMjNxUfXi48Ci40IXkPRbghZ1vbti6v9LCbNqRgHY=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/clusters/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/clusters/results.go
@@ -62,6 +62,8 @@ type Spec struct {
 	ExtendParam map[string]string `json:"extendParam,omitempty"`
 	//Advanced configuration of master node
 	Masters []MasterSpec `json:"masters,omitempty"`
+	//Range of kubernetes clusterIp
+	KubernetesSvcIPRange string `json:"kubernetesSvcIpRange,omitempty"`
 }
 
 // Node network parameters

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/nodes/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cce/v3/nodes/results.go
@@ -66,7 +66,7 @@ type Spec struct {
 	// The node nic spec
 	NodeNicSpec NodeNicSpec `json:"nodeNicSpec,omitempty"`
 	// Extended parameter
-	ExtendParam ExtendParam `json:"extendParam,omitempty"`
+	ExtendParam map[string]interface{} `json:"extendParam,omitempty"`
 	// UUID of an ECS group
 	EcsGroupID string `json:"ecsGroupId,omitempty"`
 	// Tag of a VM, key value pair format
@@ -87,6 +87,8 @@ type NodeNicSpec struct {
 type PrimaryNic struct {
 	// The Subnet ID of the primary Nic
 	SubnetId string `json:"subnetId,omitempty"`
+	// Fixed ips of the primary Nic
+	FixedIps []string `json:"fixedIps,omitempty"`
 }
 
 // TaintSpec to created nodes to configure anti-affinity
@@ -134,27 +136,10 @@ type VolumeSpec struct {
 	Size int `json:"size" required:"true"`
 	// Disk type
 	VolumeType string `json:"volumetype" required:"true"`
+	//hw:passthrough
+	HwPassthrough bool `json:"hw:passthrough,omitempty"`
 	// Disk extension parameter
-	ExtendParam string `json:"extendParam,omitempty"`
-}
-
-type ExtendParam struct {
-	// Node charging mode, 0 is on-demand charging.
-	ChargingMode int `json:"chargingMode,omitempty"`
-	// Classification of cloud server specifications.
-	EcsPerformanceType string `json:"ecs:performancetype,omitempty"`
-	// Order ID, mandatory when the node payment type is the automatic payment package period type.
-	OrderID string `json:"orderID,omitempty"`
-	// The Product ID.
-	ProductID string `json:"productID,omitempty"`
-	// The Public Key.
-	PublicKey string `json:"publicKey,omitempty"`
-	// The maximum number of instances a node is allowed to create.
-	MaxPods int `json:"maxPods,omitempty"`
-	// Script required before the installation.
-	PreInstall string `json:"alpha.cce/preInstall,omitempty"`
-	// Script required after the installation.
-	PostInstall string `json:"alpha.cce/postInstall,omitempty"`
+	ExtendParam map[string]interface{} `json:"extendParam,omitempty"`
 }
 
 type PublicIPSpec struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -183,7 +183,7 @@ github.com/hashicorp/terraform-plugin-sdk/plugin
 github.com/hashicorp/terraform-plugin-sdk/terraform
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210301092521-06fa98868773
+# github.com/huaweicloud/golangsdk v0.0.0-20210302064636-d5178f8b52dd
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal

--- a/website/docs/r/cce_node_pool_v3.html.md
+++ b/website/docs/r/cce_node_pool_v3.html.md
@@ -105,7 +105,7 @@ The `root_volume` block supports:
     
 * `volumetype` - (Required, String) Disk type.
     
-* `extend_param` - (Optional, String) Disk expansion parameters. 
+* `extend_params` - (Optional, Map) Disk expansion parameters in key/value pair format.
 
 The `data_volumes` block supports:
     
@@ -113,7 +113,7 @@ The `data_volumes` block supports:
     
 * `volumetype` - (Required, String) Disk type.
     
-* `extend_param` - (Optional, String) Disk expansion parameters. 
+* `extend_params` - (Optional, Map) Disk expansion parameters in key/value pair format.
 
 The `taints` block supports:
     

--- a/website/docs/r/cce_nodes_v3.html.md
+++ b/website/docs/r/cce_nodes_v3.html.md
@@ -99,7 +99,7 @@ If the eip_ids parameter is configured, you do not need to configure the eip_cou
     
 * `volumetype` - (Required) Disk type.
     
-* `extend_param` - (Optional) Disk expansion parameters. 
+* `extend_params` - (Optional) Disk expansion parameters in key/value pair format.
 
 **data_volumes** **- (Required)** Represents the data disk to be created. Changing this parameter will create a new resource.
     
@@ -107,7 +107,7 @@ If the eip_ids parameter is configured, you do not need to configure the eip_cou
     
 * `volumetype` - (Required) Disk type.
     
-* `extend_param` - (Optional) Disk expansion parameters. 
+* `extend_params` - (Optional) Disk expansion parameters in key/value pair format.
 
 
 **taints** **- (Optional)** You can add taints to created nodes to configure anti-affinity. Each taint contains the following parameters:

--- a/website/docs/r/cce_nodes_v3.html.md
+++ b/website/docs/r/cce_nodes_v3.html.md
@@ -12,28 +12,29 @@ Add a node to a container cluster.
 ## Example Usage
 
  ```hcl
-   variable "cluster_id" { }
-   variable "ssh_key" { }
-   variable "availability_zone" { }
+variable "cluster_id" { }
+variable "ssh_key" { }
+variable "availability_zone" { }
 
-   resource "flexibleengine_cce_node_v3" "node_1" {
-     cluster_id="${var.cluster_id}"
-     name = "node1"
-     flavor_id="s1.medium"
-     iptype="5_bgp"
-     availability_zone= "${var.availability_zone}"
-     key_pair="${var.ssh_key}"
-     root_volume {
-       size= 40
-       volumetype= "SATA"
-     }
-     sharetype= "PER"
-     bandwidth_size= 100
-     data_volumes {
-       size= 100
-       volumetype= "SATA"
-     }
+resource "flexibleengine_cce_node_v3" "node_1" {
+  cluster_id        = var.cluster_id
+  name              = "node1"
+  flavor_id         = "s1.medium"
+  availability_zone = var.availability_zone
+  key_pair          = var.ssh_key
+  iptype            = "5_bgp"
+  sharetype         = "PER"
+  bandwidth_size    = 100
+
+  root_volume {
+    size= 40
+    volumetype= "SATA"
   }
+  data_volumes {
+    size= 100
+    volumetype= "SATA"
+  }
+}
  ```    
 
 ## Argument Reference
@@ -41,29 +42,28 @@ The following arguments are supported:
 
 * `cluster_id` - (Required) ID of the cluster. Changing this parameter will create a new resource.
 
-* `billing_mode` - (Optional) Node's billing mode: The value is 0 (on demand). Changing this parameter will create a new resource.
-
 * `name` - (Optional) Node Name.
+
+* `flavor_id` - (Required) Specifies the flavor id. Changing this parameter will create a new resource.
+    
+* `availability_zone` - (Required) specify the name of the available partition (AZ). Changing this parameter will create a new resource.
+
+* `key_pair` - (Required) Key pair name when logging in to select the key pair mode. Changing this parameter will create a new resource.
+
+* `os` - (Optional) Operating System of the node, possible values are EulerOS 2.2 and CentOS 7.6. Defaults to EulerOS 2.2.
+    Changing this parameter will create a new resource.
 
 * `labels` - (Optional) Tags of a Kubernetes node, key/value pair format. Changing this parameter will create a new resource.
 
 * `tags` - (Optional) VM tag, key/value pair format.
 
 * `annotations` - (Optional) Node annotation, key/value pair format. Changing this parameter will create a new resource.
-    
-* `flavor_id` - (Required) Specifies the flavor id. Changing this parameter will create a new resource.
-    
-* `availability_zone` - (Required) specify the name of the available partition (AZ). Changing this parameter will create a new resource.
-
-* `os` - (Optional) Operating System of the node, possible values are EulerOS 2.2 and CentOS 7.6. Defaults to EulerOS 2.2.
-    Changing this parameter will create a new resource.
-
-* `key_pair` - (Required) Key pair name when logging in to select the key pair mode. Changing this parameter will create a new resource.
 
 * `eip_ids` - (Optional) List of existing elastic IP IDs. Changing this parameter will create a new resource.
 
 **Note:**
-If the eip_ids parameter is configured, you do not need to configure the eip_count and bandwidth parameters: iptype, charge_mode, bandwidth_size and share_type.
+If the `eip_ids` parameter is configured, you do not need to configure the `eip_count` and bandwidth parameters:
+`iptype`, `bandwidth_charge_mode`, `bandwidth_size` and `share_type`.
 
 * `eip_count` - (Optional) Number of elastic IPs to be dynamically created. Changing this parameter will create a new resource.
 
@@ -75,11 +75,15 @@ If the eip_ids parameter is configured, you do not need to configure the eip_cou
 
 * `bandwidth_size` - (Required) Bandwidth size. Changing this parameter will create a new resource.
 
+
+* `billing_mode` - (Optional) Node's billing mode: The value is 0 (on demand). Changing this parameter will create a new resource.
+
 * `extend_param_charging_mode` - (Optional) Node charging mode, 0 is on-demand charging. Changing this parameter will create a new cluster resource.
 
 * `ecs_performance_type` - (Optional) Classification of cloud server specifications. Changing this parameter will create a new cluster resource.
 
-* `order_id` - (Optional) Order ID, mandatory when the node payment type is the automatic payment package period type. Changing this parameter will create a new cluster resource.
+* `order_id` - (Optional) Order ID, mandatory when the node payment type is the automatic payment package period type.
+    Changing this parameter will create a new cluster resource.
 
 * `product_id` - (Optional) The Product ID. Changing this parameter will create a new cluster resource.
 
@@ -92,6 +96,18 @@ If the eip_ids parameter is configured, you do not need to configure the eip_cou
 
 * `postinstall` - (Optional) Script required after installation. The input value can be a Base64 encoded string or not.
    Changing this parameter will create a new resource.
+
+* `extend_param` - (Optional, Map, ForceNew) Extended parameter. Changing this parameter will create a new resource. Availiable keys :
+
+    * `agency_name` - Specifies the agency name to provide temporary credentials for CCE node to access other cloud services.
+    * `dockerBaseSize` - The available disk space of a single docker container on the node in device mapper mode.
+    * `DockerLVMConfigOverride` - Docker data disk configurations. The following is an example default configuration:
+
+```hcl
+  extend_param = {
+    DockerLVMConfigOverride = "dockerThinpool=vgpaas/90%VG;kubernetesLV=vgpaas/10%VG;diskType=evs;lvType=linear"
+  }
+```
 
 **root_volume** **- (Required)** It corresponds to the system disk related configuration. Changing this parameter will create a new resource.
 


### PR DESCRIPTION
fixes #406 

we can specifies the agency name to provide temporary credentials for CCE node to access other cloud services.
```hcl
  extend_param = {
    agency_name = "your iam agency name"
  }

```

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCCENodesV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCCENodesV3_basic -timeout 720m
=== RUN   TestAccCCENodesV3_basic
--- PASS: TestAccCCENodesV3_basic (2167.30s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine (2167.30s)
```