### PR TITLE
update available values of protocol in lb listener and pol

### DIFF
--- a/flexibleengine/resource_flexibleengine_lb_listener_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_listener_v2.go
@@ -39,7 +39,7 @@ func resourceListenerV2() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				ValidateFunc: validation.StringInSlice([]string{
-					"TCP", "UDP", "HTTP", "HTTPS", "TERMINATED_HTTPS",
+					"TCP", "UDP", "HTTP", "TERMINATED_HTTPS",
 				}, false),
 			},
 

--- a/flexibleengine/resource_flexibleengine_lb_pool_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_pool_v2.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/pools"
 )
@@ -53,14 +54,9 @@ func resourcePoolV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if value != "TCP" && value != "HTTP" && value != "HTTPS" {
-						errors = append(errors, fmt.Errorf(
-							"Only 'TCP', 'HTTP', and 'HTTPS' are supported values for 'protocol'"))
-					}
-					return
-				},
+				ValidateFunc: validation.StringInSlice([]string{
+					"TCP", "UDP", "HTTP",
+				}, false),
 			},
 
 			// One of loadbalancer_id or listener_id must be provided
@@ -80,14 +76,9 @@ func resourcePoolV2() *schema.Resource {
 			"lb_method": {
 				Type:     schema.TypeString,
 				Required: true,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					if value != "ROUND_ROBIN" && value != "LEAST_CONNECTIONS" && value != "SOURCE_IP" {
-						errors = append(errors, fmt.Errorf(
-							"Only 'ROUND_ROBIN', 'LEAST_CONNECTIONS', and 'SOURCE_IP' are supported values for 'lb_method'"))
-					}
-					return
-				},
+				ValidateFunc: validation.StringInSlice([]string{
+					"ROUND_ROBIN", "LEAST_CONNECTIONS", "SOURCE_IP",
+				}, false),
 			},
 
 			"persistence": {
@@ -100,14 +91,9 @@ func resourcePoolV2() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
-							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-								value := v.(string)
-								if value != "SOURCE_IP" && value != "HTTP_COOKIE" && value != "APP_COOKIE" {
-									errors = append(errors, fmt.Errorf(
-										"Only 'SOURCE_IP', 'HTTP_COOKIE', and 'APP_COOKIE' are supported values for 'persistence'"))
-								}
-								return
-							},
+							ValidateFunc: validation.StringInSlice([]string{
+								"SOURCE_IP", "HTTP_COOKIE", "APP_COOKIE",
+							}, false),
 						},
 
 						"cookie_name": {
@@ -147,14 +133,13 @@ func resourcePoolV2Create(d *schema.ResourceData, meta interface{}) error {
 		if persistence.Type == "APP_COOKIE" {
 			if pV["cookie_name"].(string) == "" {
 				return fmt.Errorf(
-					"Persistence cookie_name needs to be set if using 'APP_COOKIE' persistence type.")
-			} else {
-				persistence.CookieName = pV["cookie_name"].(string)
+					"Persistence cookie_name needs to be set if using 'APP_COOKIE' persistence type")
 			}
+			persistence.CookieName = pV["cookie_name"].(string)
 		} else {
 			if pV["cookie_name"].(string) != "" {
 				return fmt.Errorf(
-					"Persistence cookie_name can only be set if using 'APP_COOKIE' persistence type.")
+					"Persistence cookie_name can only be set if using 'APP_COOKIE' persistence type")
 			}
 		}
 	}

--- a/website/docs/r/lb_pool_v2.html.markdown
+++ b/website/docs/r/lb_pool_v2.html.markdown
@@ -42,7 +42,12 @@ The following arguments are supported:
 
 * `description` - (Optional) Human-readable description for the pool.
 
-* `protocol` = (Required) The protocol - can either be TCP, HTTP or HTTPS.
+* `protocol` = (Required) The protocol - can either be TCP, UDP or HTTP.
+
+    - When the protocol used by the listener is UDP, the protocol of the backend pool must be UDP.
+    - When the protocol used by the listener is TCP, the protocol of the backend pool must be TCP.
+    - When the protocol used by the listener is HTTP or TERMINATED_HTTPS, the protocol of the backend pool must be HTTP.
+
     Changing this creates a new pool.
 
 * `loadbalancer_id` - (Optional) The load balancer on which to provision this


### PR DESCRIPTION
fixes #487 

the testing resulting as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLBV2Pool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLBV2Pool_basic -timeout 720m
=== RUN   TestAccLBV2Pool_basic
--- PASS: TestAccLBV2Pool_basic (110.30s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 110.308s
```