### PR TITLE
update endpoint of obs client

### DIFF
--- a/flexibleengine/resource_flexibleengine_s3_bucket_test.go
+++ b/flexibleengine/resource_flexibleengine_s3_bucket_test.go
@@ -37,9 +37,9 @@ func TestAccS3Bucket_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr(
 						"flexibleengine_s3_bucket.bucket", "website_endpoint"),
 					resource.TestCheckResourceAttr(
-						"flexibleengine_s3_bucket.bucket", "bucket", testAccBucketName(rInt)),
+						"flexibleengine_s3_bucket.bucket", "bucket", testAccObsBucketName(rInt)),
 					resource.TestCheckResourceAttr(
-						"flexibleengine_s3_bucket.bucket", "bucket_domain_name", testAccBucketDomainName(rInt)),
+						"flexibleengine_s3_bucket.bucket", "bucket_domain_name", testAccObsBucketDomainName(rInt)),
 				),
 			},
 		},
@@ -880,16 +880,6 @@ func testAccCheckS3BucketLogging(n, b, p string) resource.TestCheckFunc {
 
 		return nil
 	}
-}
-
-// These need a bit of randomness as the name can only be used once globally
-// within AWS
-func testAccBucketName(randInt int) string {
-	return fmt.Sprintf("tf-test-bucket-%d", randInt)
-}
-
-func testAccBucketDomainName(randInt int) string {
-	return fmt.Sprintf("tf-test-bucket-%d.s3.amazonaws.com", randInt)
 }
 
 func testAccWebsiteEndpoint(randInt int) string {


### PR DESCRIPTION
we can assemble the obs endpoit directly.

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccObsBucket_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccObsBucket_basic -timeout 720m
=== RUN   TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (20.46s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 20.476s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccS3Bucket_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccS3Bucket_basic -timeout 720m
=== RUN   TestAccS3Bucket_basic
--- PASS: TestAccS3Bucket_basic (13.91s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 13.928s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccS3Bucket_Website_Simple'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccS3Bucket_Website_Simple -timeout 720m
=== RUN   TestAccS3Bucket_Website_Simple
--- PASS: TestAccS3Bucket_Website_Simple (39.60s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 39.618s
```