### PR TITLE
add validation check for endpoint_type

### DIFF
--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -33,25 +33,8 @@ type Config struct {
 }
 
 func (c *Config) LoadAndValidate() error {
-	validEndpoint := false
-	validEndpoints := []string{
-		"internal", "internalURL",
-		"admin", "adminURL",
-		"public", "publicURL",
-		"",
-	}
-
-	for _, endpoint := range validEndpoints {
-		if c.EndpointType == endpoint {
-			validEndpoint = true
-		}
-	}
-
-	if !validEndpoint {
-		return fmt.Errorf("Invalid endpoint type provided")
-	}
-
 	err := fmt.Errorf("Must config token or aksk or username password to be authorized")
+
 	if c.Token != "" {
 		err = buildClientByToken(c)
 	} else if c.Password != "" {

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
@@ -154,8 +155,11 @@ func Provider() terraform.ResourceProvider {
 			"endpoint_type": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("OS_ENDPOINT_TYPE", ""),
+				DefaultFunc: schema.EnvDefaultFunc("OS_ENDPOINT_TYPE", nil),
 				Deprecated:  "endpoint_type is deprecated",
+				ValidateFunc: validation.StringInSlice([]string{
+					"public", "publicURL", "admin", "adminURL", "internal", "internalURL",
+				}, false),
 			},
 		},
 


### PR DESCRIPTION
if `endpoint_type` is invalid, the error message as follows:
```
Error: expected endpoint_type to be one of [public publicURL admin adminURL internal internalURL], got xxx
```

```bash
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccFlexibleEngineVpcV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccFlexibleEngineVpcV1_basic -timeout 720m
=== RUN   TestAccFlexibleEngineVpcV1_basic
--- PASS: TestAccFlexibleEngineVpcV1_basic (43.41s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 43.422s
```