### PR TITLE
[dns] change records type to set

### DIFF
--- a/flexibleengine/resource_flexibleengine_dns_recordset_v2.go
+++ b/flexibleengine/resource_flexibleengine_dns_recordset_v2.go
@@ -55,10 +55,9 @@ func resourceDNSRecordSetV2() *schema.Resource {
 				ValidateFunc: validation.StringLenBetween(0, 255),
 			},
 			"records": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				MinItems: 1,
 			},
 			"ttl": {
 				Type:         schema.TypeInt,
@@ -98,7 +97,7 @@ func resourceDNSRecordSetV2Create(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error retrieving DNS zone %s: %s", zoneID, err)
 	}
 
-	recordsraw := d.Get("records").([]interface{})
+	recordsraw := d.Get("records").(*schema.Set).List()
 	records := make([]string, len(recordsraw))
 	for i, recordraw := range recordsraw {
 		records[i] = recordraw.(string)
@@ -223,7 +222,7 @@ func resourceDNSRecordSetV2Update(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if d.HasChange("records") {
-		recordsraw := d.Get("records").([]interface{})
+		recordsraw := d.Get("records").(*schema.Set).List()
 		records := make([]string, len(recordsraw))
 		for i, recordraw := range recordsraw {
 			records[i] = recordraw.(string)

--- a/flexibleengine/resource_flexibleengine_dns_recordset_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_dns_recordset_v2_test.go
@@ -34,9 +34,9 @@ func TestAccDNSV2RecordSet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "a record set"),
 					resource.TestCheckResourceAttr(resourceName, "type", "A"),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "3000"),
+					resource.TestCheckResourceAttr(resourceName, "records.#", "2"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
-					resource.TestCheckResourceAttr(resourceName, "records.0", "10.1.0.0"),
 				),
 			},
 			{
@@ -50,7 +50,6 @@ func TestAccDNSV2RecordSet_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "an updated record set"),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "6000"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_updated"),
-					resource.TestCheckResourceAttr(resourceName, "records.0", "10.1.0.1"),
 				),
 			},
 		},
@@ -96,9 +95,9 @@ func TestAccDNSV2RecordSet_private(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "description", "a private record set"),
 					resource.TestCheckResourceAttr(resourceName, "type", "A"),
 					resource.TestCheckResourceAttr(resourceName, "ttl", "3000"),
+					resource.TestCheckResourceAttr(resourceName, "records.#", "3"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
-					resource.TestCheckResourceAttr(resourceName, "records.0", "10.1.0.3"),
 				),
 			},
 		},
@@ -183,7 +182,7 @@ resource "flexibleengine_dns_recordset_v2" "recordset_1" {
   type        = "A"
   description = "a record set"
   ttl         = 3000
-  records     = ["10.1.0.0"]
+  records     = ["10.1.0.0", "10.1.0.1"]
 
   tags = {
     foo = "bar"
@@ -208,7 +207,7 @@ resource "flexibleengine_dns_recordset_v2" "recordset_1" {
   type        = "A"
   description = "an updated record set"
   ttl         = 6000
-  records     = ["10.1.0.1"]
+  records     = ["10.1.0.2", "10.1.0.1"]
 
   tags = {
     foo = "bar"
@@ -231,7 +230,7 @@ resource "flexibleengine_dns_recordset_v2" "recordset_1" {
   zone_id = flexibleengine_dns_zone_v2.zone_1.id
   name    = "%s"
   type    = "A"
-  records = ["10.1.0.2"]
+  records = [ "10.1.0.1", "10.1.0.2"]
 }
 `, zoneName, zoneName)
 }
@@ -260,7 +259,7 @@ resource "flexibleengine_dns_recordset_v2" "recordset_1" {
   type        = "A"
   description = "a private record set"
   ttl         = 3000
-  records     = ["10.1.0.3"]
+  records     = ["10.1.0.3", "10.1.0.2", "10.1.0.1"]
 
   tags = {
     foo = "bar"


### PR DESCRIPTION
fixes #492 

chang the type of records to Set which can ignore the order of records, the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDNSV2RecordSet'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDNSV2RecordSet -timeout 720m
=== RUN   TestAccDNSV2RecordSet_basic
=== PAUSE TestAccDNSV2RecordSet_basic
=== RUN   TestAccDNSV2RecordSet_readTTL
=== PAUSE TestAccDNSV2RecordSet_readTTL
=== RUN   TestAccDNSV2RecordSet_private
=== PAUSE TestAccDNSV2RecordSet_private
=== CONT  TestAccDNSV2RecordSet_basic
=== CONT  TestAccDNSV2RecordSet_private
=== CONT  TestAccDNSV2RecordSet_readTTL
--- PASS: TestAccDNSV2RecordSet_readTTL (52.10s)
--- PASS: TestAccDNSV2RecordSet_private (80.78s)
--- PASS: TestAccDNSV2RecordSet_basic (84.68s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 84.694s
```