### PR TITLE
resolve lb monitor crashing in http(s) type

### DIFF
--- a/flexibleengine/resource_flexibleengine_lb_monitor_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_monitor_v2.go
@@ -136,6 +136,10 @@ func resourceMonitorV2Create(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	})
 
+	if err != nil {
+		return fmt.Errorf("Unable to create monitor: %s", err)
+	}
+
 	err = waitForLBV2viaPool(networkingClient, poolID, "ACTIVE", timeout)
 	if err != nil {
 		return err

--- a/flexibleengine/resource_flexibleengine_lb_monitor_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_lb_monitor_v2_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/monitors"
@@ -11,6 +12,8 @@ import (
 
 func TestAccLBV2Monitor_basic(t *testing.T) {
 	var monitor monitors.Monitor
+	rand := acctest.RandString(5)
+	resourceName := "flexibleengine_lb_monitor_v2.monitor_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -18,20 +21,24 @@ func TestAccLBV2Monitor_basic(t *testing.T) {
 		CheckDestroy: testAccCheckLBV2MonitorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: TestAccLBV2MonitorConfig_basic,
+				Config: testAccLBV2MonitorConfig_basic(rand),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLBV2MonitorExists(t, "flexibleengine_lb_monitor_v2.monitor_1", &monitor),
-					resource.TestCheckResourceAttr("flexibleengine_lb_monitor_v2.monitor_1", "port", "8888"),
+					testAccCheckLBV2MonitorExists(t, resourceName, &monitor),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("monitor_%s", rand)),
+					resource.TestCheckResourceAttr(resourceName, "delay", "20"),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "10"),
+					resource.TestCheckResourceAttr(resourceName, "max_retries", "5"),
+					resource.TestCheckResourceAttr(resourceName, "port", "8888"),
 				),
 			},
 			{
-				Config: TestAccLBV2MonitorConfig_update,
+				Config: testAccLBV2MonitorConfig_update(rand),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"flexibleengine_lb_monitor_v2.monitor_1", "name", "monitor_1_updated"),
-					resource.TestCheckResourceAttr("flexibleengine_lb_monitor_v2.monitor_1", "delay", "30"),
-					resource.TestCheckResourceAttr("flexibleengine_lb_monitor_v2.monitor_1", "timeout", "15"),
-					resource.TestCheckResourceAttr("flexibleengine_lb_monitor_v2.monitor_1", "port", "9999"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("monitor_%s_updated", rand)),
+					resource.TestCheckResourceAttr(resourceName, "delay", "30"),
+					resource.TestCheckResourceAttr(resourceName, "timeout", "15"),
+					resource.TestCheckResourceAttr(resourceName, "max_retries", "10"),
+					resource.TestCheckResourceAttr(resourceName, "port", "9999"),
 				),
 			},
 		},
@@ -91,77 +98,69 @@ func testAccCheckLBV2MonitorExists(t *testing.T, n string, monitor *monitors.Mon
 	}
 }
 
-const TestAccLBV2MonitorConfig_basic = `
+func testAccLBV2MonitorConfig_basic(rand string) string {
+	return fmt.Sprintf(`
 resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
-  name = "loadbalancer_1"
-  vip_subnet_id = "2c0a74a9-4395-4e62-a17b-e3e86fbf66b7"
+  name          = "loadbalancer_%s"
+  vip_subnet_id = "%s"
 }
 
 resource "flexibleengine_lb_listener_v2" "listener_1" {
-  name = "listener_1"
-  protocol = "HTTP"
-  protocol_port = 8080
-  loadbalancer_id = "${flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id}"
+  name            = "listener_%s"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
 }
 
 resource "flexibleengine_lb_pool_v2" "pool_1" {
-  name = "pool_1"
-  protocol = "HTTP"
-  lb_method = "ROUND_ROBIN"
-  listener_id = "${flexibleengine_lb_listener_v2.listener_1.id}"
+  name        = "pool_%s"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = flexibleengine_lb_listener_v2.listener_1.id
 }
 
 resource "flexibleengine_lb_monitor_v2" "monitor_1" {
-  name = "monitor_1"
-  type = "PING"
-  delay = 20
-  timeout = 10
+  name        = "monitor_%s"
+  type        = "PING"
+  delay       = 20
+  timeout     = 10
   max_retries = 5
-  pool_id = "${flexibleengine_lb_pool_v2.pool_1.id}"
-  port = 8888
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
+  pool_id     = flexibleengine_lb_pool_v2.pool_1.id
+  port        = 8888
 }
-`
+`, rand, OS_SUBNET_ID, rand, rand, rand)
+}
 
-const TestAccLBV2MonitorConfig_update = `
+func testAccLBV2MonitorConfig_update(rand string) string {
+	return fmt.Sprintf(`
 resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
-  name = "loadbalancer_1"
-  vip_subnet_id = "2c0a74a9-4395-4e62-a17b-e3e86fbf66b7"
+  name          = "loadbalancer_%s"
+  vip_subnet_id = "%s"
 }
 
 resource "flexibleengine_lb_listener_v2" "listener_1" {
-  name = "listener_1"
-  protocol = "HTTP"
-  protocol_port = 8080
-  loadbalancer_id = "${flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id}"
+  name            = "listener_%s"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
 }
 
 resource "flexibleengine_lb_pool_v2" "pool_1" {
-  name = "pool_1"
-  protocol = "HTTP"
-  lb_method = "ROUND_ROBIN"
-  listener_id = "${flexibleengine_lb_listener_v2.listener_1.id}"
+  name        = "pool_%s"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = flexibleengine_lb_listener_v2.listener_1.id
 }
 
 resource "flexibleengine_lb_monitor_v2" "monitor_1" {
-  name = "monitor_1_updated"
-  type = "PING"
-  delay = 30
-  timeout = 15
-  max_retries = 10
+  name           = "monitor_%s_updated"
+  type           = "PING"
+  delay          = 30
+  timeout        = 15
+  max_retries    = 10
   admin_state_up = "true"
-  pool_id = "${flexibleengine_lb_pool_v2.pool_1.id}"
-  port = 9999
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
+  pool_id        = flexibleengine_lb_pool_v2.pool_1.id
+  port           = 9999
 }
-`
+`, rand, OS_SUBNET_ID, rand, rand, rand)
+}


### PR DESCRIPTION
fixes #517 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLBV2Monitor_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLBV2Monitor_basic -timeout 720m
=== RUN   TestAccLBV2Monitor_basic
--- PASS: TestAccLBV2Monitor_basic (133.44s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 133.457s
```