### PR TITLE
upgrade huaweicloud/golangsdk

### DIFF
--- a/flexibleengine/resource_flexibleengine_dds_instance_v3.go
+++ b/flexibleengine/resource_flexibleengine_dds_instance_v3.go
@@ -264,14 +264,15 @@ func resourceDdsFlavors(d *schema.ResourceData) []instances.Flavor {
 func resourceDdsBackupStrategy(d *schema.ResourceData) instances.BackupStrategy {
 	var backupStrategy instances.BackupStrategy
 	backupStrategyRaw := d.Get("backup_strategy").([]interface{})
-	log.Printf("[DEBUG] backupStrategyRaw: %+v", backupStrategyRaw)
+
+	startTime := "00:00-01:00"
+	keepDays := 7
 	if len(backupStrategyRaw) == 1 {
-		backupStrategy.StartTime = backupStrategyRaw[0].(map[string]interface{})["start_time"].(string)
-		backupStrategy.KeepDays = backupStrategyRaw[0].(map[string]interface{})["keep_days"].(int)
-	} else {
-		backupStrategy.StartTime = "00:00-01:00"
-		backupStrategy.KeepDays = 7
+		startTime = backupStrategyRaw[0].(map[string]interface{})["start_time"].(string)
+		keepDays = backupStrategyRaw[0].(map[string]interface{})["keep_days"].(int)
 	}
+	backupStrategy.StartTime = startTime
+	backupStrategy.KeepDays = &keepDays
 	log.Printf("[DEBUG] backupStrategy: %+v", backupStrategy)
 	return backupStrategy
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210402075152-aba310c2a950
+	github.com/huaweicloud/golangsdk v0.0.0-20210408110332-c61d9b336da5
 	github.com/huaweicloud/terraform-provider-huaweicloud v1.23.1-0.20210406030556-c63d7fdb3533
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jtolds/gls v4.20.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -225,6 +225,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huaweicloud/golangsdk v0.0.0-20210402075152-aba310c2a950 h1:Ys3DRL6qJGYL/9mX8gvzSQade5TOJi8COrPyG58HOQs=
 github.com/huaweicloud/golangsdk v0.0.0-20210402075152-aba310c2a950/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210408110332-c61d9b336da5 h1:qsDthJ6oyB3Jexl1NTK/d8LePQL+zM7dIVyeeSpSmBs=
+github.com/huaweicloud/golangsdk v0.0.0-20210408110332-c61d9b336da5/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.23.1-0.20210406030556-c63d7fdb3533 h1:T1XFVhGzVwLMahLUK8/ww//Mls8fZ1BXTi2CpJswL0k=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.23.1-0.20210406030556-c63d7fdb3533/go.mod h1:GJUvfnw1G3LjHIXsYO+quUH86842c06MvVaeIFqingk=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/dds/v3/instances/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/dds/v3/instances/requests.go
@@ -39,7 +39,8 @@ type Flavor struct {
 
 type BackupStrategy struct {
 	StartTime string `json:"start_time" required:"true"`
-	KeepDays  int    `json:"keep_days,omitempty"`
+	KeepDays  *int   `json:"keep_days,omitempty"`
+	Period    string `json:"period,omitempty"`
 }
 
 type CreateInstanceBuilder interface {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/dns/v2/ptrrecords/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/dns/v2/ptrrecords/requests.go
@@ -29,6 +29,9 @@ type CreateOpts struct {
 
 	// Tags of the ptr.
 	Tags []Tag `json:"tags,omitempty"`
+
+	// Enterprise project id
+	EnterpriseProjectID string `json:"enterprise_project_id,omitempty"`
 }
 
 // Tag is a structure of key value pair.

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/dns/v2/ptrrecords/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/dns/v2/ptrrecords/results.go
@@ -53,4 +53,7 @@ type Ptr struct {
 
 	// Status of the PTR.
 	Status string `json:"status"`
+
+	// Enterprise project id
+	EnterpriseProjectID string `json:"enterprise_project_id"`
 }

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/dns/v2/zones/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/dns/v2/zones/requests.go
@@ -87,6 +87,9 @@ type CreateOpts struct {
 
 	// Type specifies if this is a primary or secondary zone.
 	Type string `json:"type,omitempty"`
+
+	// Enterprise project id
+	EnterpriseProjectID string `json:"enterprise_project_id,omitempty"`
 }
 
 // ToZoneCreateMap formats an CreateOpts structure into a request body.

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/dns/v2/zones/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/dns/v2/zones/results.go
@@ -129,6 +129,9 @@ type Zone struct {
 
 	// Routers associate with the Zone
 	Routers []RouterResult `json:"routers"`
+
+	// Enterprise project id
+	EnterpriseProjectID string `json:"enterprise_project_id"`
 }
 
 type RouterResult struct {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/monitors/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/monitors/requests.go
@@ -112,12 +112,11 @@ type CreateOpts struct {
 	URLPath string `json:"url_path,omitempty"`
 
 	// The HTTP method used for requests by the Monitor. If this attribute
-	// is not specified, it defaults to "GET". Required for HTTP(S) types.
+	// is not specified, it defaults to "GET".
 	HTTPMethod string `json:"http_method,omitempty"`
 
 	// Expected HTTP codes for a passing HTTP(S) Monitor. You can either specify
-	// a single status like "200", or a range like "200-202". Required for HTTP(S)
-	// types.
+	// a single status like "200", or a range like "200-202".
 	ExpectedCodes string `json:"expected_codes,omitempty"`
 
 	// TenantID is the UUID of the project who owns the Monitor.
@@ -141,21 +140,15 @@ type CreateOpts struct {
 
 // ToMonitorCreateMap builds a request body from CreateOpts.
 func (opts CreateOpts) ToMonitorCreateMap() (map[string]interface{}, error) {
+	if opts.Type == TypeHTTP || opts.Type == TypeHTTPS {
+		if opts.URLPath == "" {
+			return nil, fmt.Errorf("url_path must be provided for HTTP and HTTPS")
+		}
+	}
+
 	b, err := golangsdk.BuildRequestBody(opts, "healthmonitor")
 	if err != nil {
 		return nil, err
-	}
-
-	switch opts.Type {
-	case TypeHTTP, TypeHTTPS:
-		switch opts.URLPath {
-		case "":
-			return nil, fmt.Errorf("URLPath must be provided for HTTP and HTTPS")
-		}
-		switch opts.ExpectedCodes {
-		case "":
-			return nil, fmt.Errorf("ExpectedCodes must be provided for HTTP and HTTPS")
-		}
 	}
 
 	return b, nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -261,7 +261,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210402075152-aba310c2a950
+# github.com/huaweicloud/golangsdk v0.0.0-20210408110332-c61d9b336da5
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
* [dds] change type of KeepDays to *int
* [lbaas_v2/monitors] make expected_codes be optional for HTTP(S) types

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDDSV3Instance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDDSV3Instance_basic -timeout 720m
=== RUN   TestAccDDSV3Instance_basic
--- PASS: TestAccDDSV3Instance_basic (677.77s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine (677.823s)
```