### PR TITLE
improve on ces alarm rule resource

### DIFF
--- a/docs/resources/ces_alarmrule.md
+++ b/docs/resources/ces_alarmrule.md
@@ -4,15 +4,16 @@ subcategory: "Cloud Eye (CES)"
 
 # flexibleengine\_ces\_alarmrule
 
-Manages a V2 topic resource within FlexibleEngine.
+Manages a Cloud Eye alarm rule resource within FlexibleEngine.
 
 ## Example Usage
 
 ```hcl
 resource "flexibleengine_ces_alarmrule" "alarm_rule" {
   alarm_name = "alarm_rule"
+
   metric {
-    namespace = "SYS.ECS"
+    namespace   = "SYS.ECS"
     metric_name = "network_outgoing_bytes_rate_inband"
     dimensions {
         name  = "instance_id"
@@ -20,12 +21,12 @@ resource "flexibleengine_ces_alarmrule" "alarm_rule" {
     }
   }
   condition  {
-    period = 300
-    filter = "average"
+    period              = 300
+    filter              = "average"
     comparison_operator = ">"
-    value = 6
-    unit = "B/s"
-    count = 1
+    value               = 6
+    unit                = "B/s"
+    count               = 1
   }
   alarm_actions {
     type = "notification"
@@ -40,136 +41,127 @@ resource "flexibleengine_ces_alarmrule" "alarm_rule" {
 
 The following arguments are supported:
 
-* `alarm_name` - (Required) Specifies the name of an alarm rule. The value can
+* `alarm_name` - (Required, String) Specifies the name of an alarm rule. The value can
     be a string of 1 to 128 characters that can consist of numbers, lowercase letters,
     uppercase letters, underscores (_), or hyphens (-).
 
-* `alarm_description` - (Optional) The value can be a string of 0 to 256 characters.
-
-* `metric` - (Required) Specifies the alarm metrics. The structure is described
+* `metric` - (Required, List) Specifies the alarm metrics. The structure is described
     below.
 
-* `condition` - (Required) Specifies the alarm triggering condition. The structure
+* `condition` - (Required, List) Specifies the alarm triggering condition. The structure
     is described below.
 
-* `alarm_actions` - (Optional) Specifies the action list triggered by an alarm. The
-    structure is described below.
+* `alarm_description` - (Optional, String) The value can be a string of 0 to 256 characters.
 
-* `insufficientdata_actions` - (Optional) Specifies the action list triggered by
-    data insufficiency. The structure is described below.
-
-* `ok_actions` - (Optional) Specifies the action list triggered by the clearing of
-    an alarm. The structure is described below.
-
-* `alarm_enabled` - (Optional) Specifies whether to enable the alarm. The default
+* `alarm_enabled` - (Optional, Bool) Specifies whether to enable the alarm. The default
     value is true.
 
-* `alarm_action_enabled` - (Optional) Specifies whether to enable the action
+* `alarm_type` - (Optional, Int, ForceNew) Specifies the alarm severity. The value can be
+    1, 2, 3 or 4, which indicates *critical*, *major*, *minor*, and *informational*, respectively.
+    The default value is 2. Changing this creates a new resource.
+
+* `alarm_actions` - (Optional, List) Specifies the action triggered by an alarm. The
+    structure is described below.
+
+* `ok_actions` - (Optional, List) Specifies the action triggered by the clearing of
+    an alarm. The structure is described below.
+
+* `alarm_action_enabled` - (Optional, Bool) Specifies whether to enable the action
     to be triggered by an alarm. The default value is true.
-    Note: If alarm_action_enabled is set to true, at least one of the following
-    parameters alarm_actions, insufficientdata_actions, and ok_actions cannot
-    be empty. If alarm_actions, insufficientdata_actions, and ok_actions coexist,
-    their corresponding notification_list must be of the same value.
+
+    -> **Note** If alarm_action_enabled is set to true, either alarm_actions or
+    ok_actions cannot be empty. If alarm_actions and ok_actions coexist, their
+    corresponding notification_list must be of the same value.
 
 The `metric` block supports:
 
-* `namespace` - (Required) Specifies the namespace in service.item format. service.item
-    can be a string of 3 to 32 characters that must start with a letter and can
-    consists of uppercase letters, lowercase letters, numbers, or underscores (_).
+* `namespace` - (Required, String) Specifies the namespace in **service.item** format.
+    service.item can be a string of 3 to 32 characters that must start with a letter and
+    can consists of uppercase letters, lowercase letters, numbers, or underscores (_).
+    For details, see [Services Interconnected with Cloud Eye](https://docs.prod-cloud-ocb.orange-business.com/en-us/api/ces/ces_03_0059.html).
 
-* `metric_name` - (Required) Specifies the metric name. The value can be a string
+* `metric_name` - (Required, String) Specifies the metric name. The value can be a string
     of 1 to 64 characters that must start with a letter and can consists of uppercase
     letters, lowercase letters, numbers, or underscores (_).
 
-* `dimensions` - (Required) Specifies the list of metric dimensions. Currently,
+* `dimensions` - (Required, List) Specifies the list of metric dimensions. Currently,
     the maximum length of the dimesion list that are supported is 3. The structure
     is described below.
 
 The `dimensions` block supports:
 
-* `name` - (Required) Specifies the dimension name. The value can be a string
+* `name` - (Required, String) Specifies the dimension name. The value can be a string
     of 1 to 32 characters that must start with a letter and can consists of uppercase
     letters, lowercase letters, numbers, underscores (_), or hyphens (-).
 
-* `value` - (Required) Specifies the dimension value. The value can be a string
+* `value` - (Required, String) Specifies the dimension value. The value can be a string
     of 1 to 64 characters that must start with a letter or a number and can consists
     of uppercase letters, lowercase letters, numbers, underscores (_), or hyphens
     (-).
 
 The `condition` block supports:
 
-* `period` - (Required) Specifies the alarm checking period in seconds. The
+* `period` - (Required, Int) Specifies the alarm checking period in seconds. The
     value can be 1, 300, 1200, 3600, 14400, and 86400.
     Note: If period is set to 1, the raw metric data is used to determine
     whether to generate an alarm.
 
-* `filter` - (Required) Specifies the data rollup methods. The value can be
+* `filter` - (Required, String) Specifies the data rollup methods. The value can be
     max, min, average, sum, and vaiance.
 
-* `comparison_operator` - (Required) Specifies the comparison condition of alarm
+* `comparison_operator` - (Required, String) Specifies the comparison condition of alarm
     thresholds. The value can be >, =, <, >=, or <=.
 
-* `value` - (Required) Specifies the alarm threshold. The value ranges from
+* `value` - (Required, String) Specifies the alarm threshold. The value ranges from
     0 to Number of 1.7976931348623157e+308.
 
-* `unit` - (Optional) Specifies the data unit.
-
-* `count` - (Required) Specifies the number of consecutive occurrence times.
+* `count` - (Required, Int) Specifies the number of consecutive occurrence times.
     The value ranges from 1 to 5.
+
+* `unit` - (Optional, String) Specifies the data unit.
 
 the `alarm_actions` block supports:
 
-* `type` - (Optional) specifies the type of action triggered by an alarm. the
+* `type` - (Optional, String) specifies the type of action triggered by an alarm. the
     value can be *notification* or *autoscaling*.
     - notification: indicates that a notification will be sent to the user.
     - autoscaling: indicates that a scaling action will be triggered.
 
-* `notification_list` - (Required) specifies the topic urn list of the target
-    notification objects. the maximum length is 5. the topic urn list can be
-    obtained from simple message notification (smn) and in the following format:
-    urn: smn:([a-z]|[a-z]|[0-9]|\-){1,32}:([a-z]|[a-z]|[0-9]){32}:([a-z]|[a-z]|[0-9]|\-|\_){1,256}.
-    if type is set to notification, the value of notification_list cannot be
-    empty. if type is set to autoscaling, the value of notification_list must
-    be [] and the value of namespace must be sys.as.
-    Note: to enable the as alarm rules take effect, you must bind scaling
-    policies. for details, see the auto scaling api reference.
-
-the `insufficientdata_actions` block supports:
-
-* `type` - (Optional) specifies the type of action triggered by an alarm. the
-    value is notification.
-    notification: indicates that a notification will be sent to the user.
-
-* `notification_list` - (Optional) indicates the list of objects to be notified
-    if the alarm status changes. the maximum length is 5.
+* `notification_list` - (Optional, List) specifies the list of objects to be notified
+    if the alarm status changes, the maximum length is 5.
+    if type is set to *notification*, the value of notification_list cannot be empty.
+    if type is set to *autoscaling*, the value of notification_list must be **[]**
+    and the value of namespace must be *SYS.AS*.
+    Note: to enable the autoscaling alarm rules take effect, you must bind scaling
+    policies.
 
 the `ok_actions` block supports:
 
-* `type` - (Optional) specifies the type of action triggered by an alarm. the
+* `type` - (Optional, String) specifies the type of action triggered by an alarm. the
     value is notification.
     notification: indicates that a notification will be sent to the user.
 
-* `notification_list` - (Optional) indicates the list of objects to be notified
-    if the alarm status changes. the maximum length is 5.
+* `notification_list` - (Optional, List) specifies the list of objects to be notified
+    if the alarm status changes, the maximum length is 5.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
-* `alarm_name` - See Argument Reference above.
-* `alarm_description` - See Argument Reference above.
-* `metric` - See Argument Reference above.
-* `condition` - See Argument Reference above.
-* `alarm_actions` - See Argument Reference above.
-* `insufficientdata_actions` - See Argument Reference above.
-* `ok_actions` - See Argument Reference above.
-* `alarm_enabled` - See Argument Reference above.
-* `alarm_action_enabled` - See Argument Reference above.
-* `id` - Specifies the alarm rule ID.
-* `update_time` - Specifies the time when the alarm status changed. The value
-    is a UNIX timestamp and the unit is ms.
-* `alarm_state` - Specifies the alarm status. The value can be:
-    ok: The alarm status is normal,
-    alarm: An alarm is generated,
-    insufficient_data: The required data is insufficient.
+* `id` - Indicates the alarm rule ID.
 
+* `alarm_state` - Indicates the alarm status. The value can be:
+    - ok: The alarm status is normal;
+    - alarm: An alarm is generated;
+    - insufficient_data: The required data is insufficient.
+
+* `update_time` - Indicates the time when the alarm status changed.
+    The value is a UNIX timestamp and the unit is ms.
+
+## Import
+
+CES alarm rules can be imported using the `id`, e.g.
+
+```
+$ terraform import flexibleengine_ces_alarmrule.alarm_rule al1619678242900OxEaaODM2
+```

--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -518,13 +518,6 @@ func (c *Config) orchestrationV1Client(region string) (*golangsdk.ServiceClient,
 	})
 }
 
-func (c *Config) newCESClient(region string) (*golangsdk.ServiceClient, error) {
-	return huaweisdk.NewCESClient(c.HwClient, golangsdk.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: c.getHwEndpointType(),
-	})
-}
-
 func (c *Config) dwsV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return huaweisdk.NewDWSClient(c.HwClient, golangsdk.EndpointOpts{
 		Region:       c.determineRegion(region),

--- a/flexibleengine/config_test.go
+++ b/flexibleengine/config_test.go
@@ -90,7 +90,7 @@ func TestAccServiceEndpoints_Management(t *testing.T) {
 	testCheckServiceURL(t, expectedURL, actualURL, "CTS")
 
 	// test the endpoint of CES service
-	serviceClient, err = config.newCESClient(OS_REGION_NAME)
+	serviceClient, err = config.CesV1Client(OS_REGION_NAME)
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine CES client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_ces_alarmrule.go
+++ b/flexibleengine/resource_flexibleengine_ces_alarmrule.go
@@ -5,12 +5,37 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/huaweicloud/golangsdk/openstack/cloudeyeservice/alarmrule"
 )
 
 const nameCESAR = "CES-AlarmRule"
+
+var cesAlarmActions = schema.Schema{
+	Type:     schema.TypeList,
+	Optional: true,
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"notification", "autoscaling",
+				}, false),
+			},
+
+			"notification_list": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 5,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	},
+}
 
 func resourceAlarmRule() *schema.Resource {
 	return &schema.Resource{
@@ -18,6 +43,9 @@ func resourceAlarmRule() *schema.Resource {
 		Read:   resourceAlarmRuleRead,
 		Update: resourceAlarmRuleUpdate,
 		Delete: resourceAlarmRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
@@ -26,11 +54,17 @@ func resourceAlarmRule() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
 			"alarm_name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
 			"alarm_description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -81,18 +115,25 @@ func resourceAlarmRule() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"period": {
-							Type:     schema.TypeInt,
-							Required: true,
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntInSlice([]int{0, 1, 300, 1200, 3600, 14400, 86400}),
 						},
 
 						"filter": {
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"max", "min", "average", "sum", "variance",
+							}, false),
 						},
 
 						"comparison_operator": {
 							Type:     schema.TypeString,
 							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								">=", ">", "<=", "<", "=",
+							}, false),
 						},
 
 						"value": {
@@ -100,83 +141,35 @@ func resourceAlarmRule() *schema.Resource {
 							Required: true,
 						},
 
+						"count": {
+							Type:         schema.TypeInt,
+							Required:     true,
+							ValidateFunc: validation.IntBetween(1, 5),
+						},
+
 						"unit": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-
-						"count": {
-							Type:     schema.TypeInt,
-							Required: true,
-						},
 					},
 				},
 			},
 
-			"alarm_actions": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-
-						"notification_list": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 5,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-					},
-				},
-			},
-
-			"insufficientdata_actions": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-
-						"notification_list": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 5,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-					},
-				},
-			},
-
-			"ok_actions": {
-				Type:     schema.TypeList,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"type": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
-
-						"notification_list": {
-							Type:     schema.TypeList,
-							Required: true,
-							MaxItems: 5,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-						},
-					},
-				},
-			},
+			"alarm_actions": &cesAlarmActions,
+			"ok_actions":    &cesAlarmActions,
 
 			"alarm_enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
+			},
+
+			"alarm_level": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      2,
+				ForceNew:     true,
+				ValidateFunc: validation.IntBetween(1, 4),
 			},
 
 			"alarm_action_enabled": {
@@ -185,14 +178,35 @@ func resourceAlarmRule() *schema.Resource {
 				Default:  true,
 			},
 
+			"alarm_state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"update_time": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
 
-			"alarm_state": {
-				Type:     schema.TypeString,
-				Computed: true,
+			// deprecated
+			"insufficientdata_actions": {
+				Type:       schema.TypeList,
+				Optional:   true,
+				Deprecated: "insufficientdata_actions is deprecated",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"notification_list": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 5,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -244,9 +258,27 @@ func getAlarmAction(d *schema.ResourceData, name string) []alarmrule.ActionOpts 
 	return opts
 }
 
+func getAlarmCondition(d *schema.ResourceData) alarmrule.ConditionOpts {
+	var opts alarmrule.ConditionOpts
+
+	rawCondition := d.Get("condition").([]interface{})
+	if len(rawCondition) == 1 {
+		condition := rawCondition[0].(map[string]interface{})
+
+		opts.Period = condition["period"].(int)
+		opts.Filter = condition["filter"].(string)
+		opts.ComparisonOperator = condition["comparison_operator"].(string)
+		opts.Value = condition["value"].(int)
+		opts.Unit = condition["unit"].(string)
+		opts.Count = condition["count"].(int)
+	}
+
+	return opts
+}
+
 func resourceAlarmRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.newCESClient(GetRegion(d, config))
+	client, err := config.CesV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating Cloud Eye Service client: %s", err)
 	}
@@ -255,23 +287,16 @@ func resourceAlarmRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	cos := d.Get("condition").([]interface{})
-	co := cos[0].(map[string]interface{})
+
 	createOpts := alarmrule.CreateOpts{
-		AlarmName:        d.Get("alarm_name").(string),
-		AlarmDescription: d.Get("alarm_description").(string),
-		Metric:           metric,
-		Condition: alarmrule.ConditionOpts{
-			Period:             co["period"].(int),
-			Filter:             co["filter"].(string),
-			ComparisonOperator: co["comparison_operator"].(string),
-			Value:              co["value"].(int),
-			Unit:               co["unit"].(string),
-			Count:              co["count"].(int),
-		},
+		AlarmName:               d.Get("alarm_name").(string),
+		AlarmDescription:        d.Get("alarm_description").(string),
+		AlarmLevel:              d.Get("alarm_level").(int),
+		Metric:                  metric,
+		Condition:               getAlarmCondition(d),
 		AlarmActions:            getAlarmAction(d, "alarm_actions"),
-		InsufficientdataActions: getAlarmAction(d, "insufficientdata_actions"),
 		OkActions:               getAlarmAction(d, "ok_actions"),
+		InsufficientdataActions: getAlarmAction(d, "insufficientdata_actions"),
 		AlarmEnabled:            d.Get("alarm_enabled").(bool),
 		AlarmActionEnabled:      d.Get("alarm_action_enabled").(bool),
 	}
@@ -290,7 +315,7 @@ func resourceAlarmRuleCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceAlarmRuleRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.newCESClient(GetRegion(d, config))
+	client, err := config.CesV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating Cloud Eye Service client: %s", err)
 	}
@@ -305,23 +330,35 @@ func resourceAlarmRuleRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	d.Set("alarm_name", m["alarm_name"])
-	d.Set("alarm_description", m["alarm_description"])
-	d.Set("metric", m["metric"])
-	d.Set("condition", m["condition"])
-	d.Set("alarm_actions", m["alarm_actions"])
-	d.Set("insufficientdata_actions", m["insufficientdata_actions"])
-	d.Set("ok_actions", m["ok_actions"])
-	d.Set("alarm_enabled", m["alarm_enabled"])
-	d.Set("alarm_action_enabled", m["alarm_action_enabled"])
-	d.Set("update_time", m["update_time"])
-	d.Set("alarm_state", m["alarm_state"])
+
+	alarmMetric := make([]interface{}, 1)
+	alarmMetric[0] = m["metric"]
+	alarmCondition := make([]interface{}, 1)
+	alarmCondition[0] = m["condition"]
+
+	mErr := multierror.Append(nil,
+		d.Set("alarm_name", m["alarm_name"]),
+		d.Set("alarm_description", m["alarm_description"]),
+		d.Set("alarm_level", m["alarm_level"]),
+		d.Set("metric", alarmMetric),
+		d.Set("condition", alarmCondition),
+		d.Set("alarm_actions", m["alarm_actions"]),
+		d.Set("ok_actions", m["ok_actions"]),
+		d.Set("alarm_enabled", m["alarm_enabled"]),
+		d.Set("alarm_action_enabled", m["alarm_action_enabled"]),
+		d.Set("alarm_state", m["alarm_state"]),
+		d.Set("update_time", m["update_time"]),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return mErr
+	}
+
 	return nil
 }
 
 func resourceAlarmRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.newCESClient(GetRegion(d, config))
+	client, err := config.CesV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating Cloud Eye Service client: %s", err)
 	}
@@ -336,6 +373,7 @@ func resourceAlarmRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Updating %s %s with options: %#v", nameCESAR, arId, updateOpts)
 
 	timeout := d.Timeout(schema.TimeoutUpdate)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err := alarmrule.Update(client, arId, updateOpts).ExtractErr()
 		if err != nil {
@@ -352,7 +390,7 @@ func resourceAlarmRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceAlarmRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.newCESClient(GetRegion(d, config))
+	client, err := config.CesV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating Cloud Eye Service client: %s", err)
 	}
@@ -361,6 +399,7 @@ func resourceAlarmRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Deleting %s %s", nameCESAR, arId)
 
 	timeout := d.Timeout(schema.TimeoutDelete)
+	//lintignore:R006
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		err := alarmrule.Delete(client, arId).ExtractErr()
 		if err != nil {


### PR DESCRIPTION
fixes #526 

- add alarm_level parameter
- add validatition for parameters
- support importing the resource
- mark insufficientdata_actions as deprecated
- use CesV1Client to get the endpoint

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestCESAlarmRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestCESAlarmRule_basic -timeout 720m
=== RUN   TestCESAlarmRule_basic
--- PASS: TestCESAlarmRule_basic (293.41s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 293.426s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccServiceEndpoints_Management'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccServiceEndpoints_Management -timeout 720m
=== RUN   TestAccServiceEndpoints_Management
    TestAccServiceEndpoints_Management: config_test.go:42: CTS endpoint:         https://cts.eu-west-0.prod-cloud-ocb.orange-business.com/v1.0/xxxx/
    TestAccServiceEndpoints_Management: config_test.go:42: CES endpoint:         https://ces.eu-west-0.prod-cloud-ocb.orange-business.com/V1.0/xxxx/
--- PASS: TestAccServiceEndpoints_Management (1.65s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 1.660s
```