### PR TITLE
improve on identity role and agency

### DIFF
--- a/docs/data-sources/identity_custom_role_v3.md
+++ b/docs/data-sources/identity_custom_role_v3.md
@@ -4,11 +4,9 @@ subcategory: "Identity and Access Management (IAM)"
 
 # flexibleengine\_identity\_custom\_role\_v3
 
-Use this data source to get the ID of a FlexibleEngine custom role.
+Use this data source to get the ID of an IAM **custom policy**.
 
-The Role in Terraform is the same as Policy on console. however,
-The policy name is the display name of Role, the Role name cannot
-be found on Console.
+## Example Usage
 
 ```hcl
 data "flexibleengine_identity_custom_role_v3" "role" {
@@ -37,4 +35,3 @@ In addition to all arguments above, the following attributes are exported:
 * `policy` - Document of the custom policy.
 
 * `catalog` - The catalog of the custom policy.
-

--- a/docs/data-sources/identity_role_v3.md
+++ b/docs/data-sources/identity_role_v3.md
@@ -4,7 +4,7 @@ subcategory: "Identity and Access Management (IAM)"
 
 # flexibleengine\_identity\_role\_v3
 
-Use this data source to get the ID of a FlexibleEngine role.
+Use this data source to get the ID of an IAM **system-defined** role or policy.
 
 The Role in Terraform is the same as Policy on console. however,
 The policy name is the display name of Role, the Role name cannot
@@ -76,6 +76,8 @@ te_agency | Agent Operator
 vpc_netadm | VPC Administrator
 vpcep_adm | VPCEndpoint service enables you to privately connect your VPC to supported services
 
+## Example Usage
+
 ```hcl
 data "flexibleengine_identity_role_v3" "security_admin" {
   name = "secu_admin"
@@ -90,8 +92,11 @@ data "flexibleengine_identity_role_v3" "security_admin" {
 
 ## Attributes Reference
 
-`id` is set to the ID of the found role. In addition, the following attributes
-are exported:
+In addition to all arguments above, the following attributes are exported:
 
-* `name` - See Argument Reference above.
-* `domain_id` - See Argument Reference above.
+* `id` - The data source ID in UUID format.
+* `display_name` - The display name of the role displayed on the console.
+* `description` - The description of the policy.
+* `catalog` - The service catalog of the policy.
+* `type` - The display mode of the policy.
+* `policy` - The content of the policy.

--- a/docs/resources/identity_agency_v3.md
+++ b/docs/resources/identity_agency_v3.md
@@ -76,7 +76,11 @@ The `project_role` block supports:
 
 * `roles` - (Required) Specifies an array of role names.
 
-**note**: one or both of `project_role` and `domain_roles` must be input when creating an agency.
+-> **NOTE**
+    - At least one of `project_role` and `domain_roles` must be specified when creating an agency.
+    - We can get all **System-Defined Roles** from
+[FlexibleEngine](https://docs.prod-cloud-ocb.orange-business.com/permissions/index.html) or
+[data.flexibleengine_identity_role_v3](https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/data-sources/identity_role_v3).
 
 ## Attributes Reference
 

--- a/docs/resources/identity_role_v3.md
+++ b/docs/resources/identity_role_v3.md
@@ -12,10 +12,11 @@ custom role management in FlexibleEngine
 
 ```hcl
 resource "flexibleengine_identity_role_v3" "role" {
-  name = "test"
+  name        = "test"
   description = "created by terraform"
-  type = "AX"
-    policy = <<EOF
+  type        = "AX"
+
+  policy = <<EOF
 {
   "Version": "1.1",
   "Statement": [

--- a/flexibleengine/data_source_flexibleengine_identity_custom_role_v3.go
+++ b/flexibleengine/data_source_flexibleengine_identity_custom_role_v3.go
@@ -103,8 +103,8 @@ func dataSourceIdentityCustomRoleRead(d *schema.ResourceData, meta interface{}) 
 
 	if len(allRoles) > 1 {
 		log.Printf("[DEBUG] Multiple results found: %#v", allRoles)
-		return fmt.Errorf("Your query returned more than one result. Please try a more " +
-			"specific search criteria.")
+		return fmt.Errorf("Your query returned more than one result. " +
+			"Please try a more specific search criteria.")
 	}
 	role := allRoles[0]
 

--- a/flexibleengine/data_source_flexibleengine_identity_role_v3_test.go
+++ b/flexibleengine/data_source_flexibleengine_identity_role_v3_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccIdentityV3RoleDataSource_basic(t *testing.T) {
+	resourceName := "data.flexibleengine_identity_role_v3.role_1"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -17,11 +19,11 @@ func TestAccIdentityV3RoleDataSource_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccOpenStackIdentityV3RoleDataSource_basic,
+				Config: testAccIdentityRoleDataSource_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckIdentityV3DataSourceID("data.flexibleengine_identity_role_v3.role_1"),
-					resource.TestCheckResourceAttr(
-						"data.flexibleengine_identity_role_v3.role_1", "name", "rds_adm"),
+					testAccCheckIdentityV3DataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", "rds_adm"),
+					resource.TestCheckResourceAttr(resourceName, "display_name", "RDS Administrator"),
 				),
 			},
 		},
@@ -43,8 +45,8 @@ func testAccCheckIdentityV3DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccOpenStackIdentityV3RoleDataSource_basic = `
+const testAccIdentityRoleDataSource_basic = `
 data "flexibleengine_identity_role_v3" "role_1" {
-    name = "rds_adm"
+  name = "rds_adm"
 }
 `


### PR DESCRIPTION
- add more attributes in data.flexibleengine_identity_role_v3
- update docs

the acceptance testing as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccIdentityV3RoleDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccIdentityV3RoleDataSource_basic -timeout 720m
=== RUN   TestAccIdentityV3RoleDataSource_basic
--- PASS: TestAccIdentityV3RoleDataSource_basic (11.41s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 11.424s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccIdentityV3Agency_basic'  
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccIdentityV3Agency_basic -timeout 720m
=== RUN   TestAccIdentityV3Agency_basic
--- PASS: TestAccIdentityV3Agency_basic (76.25s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 76.261s

make testacc TEST='./flexibleengine' TESTARGS='-run TestAccIdentityV3Agency_domain'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccIdentityV3Agency_domain -timeout 720m
=== RUN   TestAccIdentityV3Agency_domain
--- PASS: TestAccIdentityV3Agency_domain (63.78s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 63.796s
```