### PR TITLE
add lb_loadbalancer_v2 data source

### DIFF
--- a/docs/data-sources/lb_loadbalancer_v2.md
+++ b/docs/data-sources/lb_loadbalancer_v2.md
@@ -1,0 +1,37 @@
+---
+subcategory: "Elastic Load Balance (ELB)"
+---
+
+# flexibleengine\_lb\_loadbalancer\_v2
+
+Use this data source to get a specific elb loadbalancer within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+variable "lb_name" {}
+
+data "flexibleengine_lb_loadbalancer_v2" "test" {
+  name = var.lb_name
+}
+```
+
+## Argument Reference
+
+* `name` - (Optional, String) Specifies the name of the load balancer.
+
+* `id` - (Optional, String) Specifies the data source ID of the load balancer in UUID format.
+
+* `description` - (Optional, String) Specifies the supplementary information about the load balancer.
+
+* `vip_subnet_id` - (Optional, String) Specifies the ID of the subnet where the load balancer works.
+
+* `vip_address` - (Optional, String) Specifies the private IP address of the load balancer.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `vip_port_id` - The ID of the port bound to the private IP address of the load balancer.
+* `status` - The operating status of the load balancer.
+* `tags` - The tags associated with the load balancer.

--- a/flexibleengine/data_source_flexibleengine_lb_loadbalancer_v2.go
+++ b/flexibleengine/data_source_flexibleengine_lb_loadbalancer_v2.go
@@ -1,0 +1,121 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/huaweicloud/golangsdk/openstack/common/tags"
+	"github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/lbaas_v2/loadbalancers"
+)
+
+func dataSourceELBV2Loadbalancer() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceELBV2LoadbalancerRead,
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vip_subnet_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vip_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vip_port_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tags": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceELBV2LoadbalancerRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+	}
+
+	// elb v2.0 client to fetch tags
+	elbClient, err := config.elbV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating elb v2.0 client: %s", err)
+	}
+
+	listOpts := loadbalancers.ListOpts{
+		Name:        d.Get("name").(string),
+		ID:          d.Get("id").(string),
+		Description: d.Get("description").(string),
+		VipSubnetID: d.Get("vip_subnet_id").(string),
+		VipAddress:  d.Get("vip_address").(string),
+	}
+	pages, err := loadbalancers.List(networkingClient, listOpts).AllPages()
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve loadbalancers: %s", err)
+	}
+	lbList, err := loadbalancers.ExtractLoadBalancers(pages)
+	if err != nil {
+		return fmt.Errorf("Unable to extract loadbalancers: %s", err)
+	}
+
+	if len(lbList) < 1 {
+		return fmt.Errorf("Your query returned no results, Please change your search criteria and try again")
+	}
+
+	if len(lbList) > 1 {
+		return fmt.Errorf("Your query returned more than one result, Please try a more specific search criteria")
+	}
+
+	lb := lbList[0]
+	d.SetId(lb.ID)
+
+	mErr := multierror.Append(
+		d.Set("region", GetRegion(d, config)),
+		d.Set("name", lb.Name),
+		d.Set("description", lb.Description),
+		d.Set("status", lb.OperatingStatus),
+		d.Set("vip_address", lb.VipAddress),
+		d.Set("vip_subnet_id", lb.VipSubnetID),
+		d.Set("vip_port_id", lb.VipPortID),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmt.Errorf("Error setting elb loadbalancer fields: %s", err)
+	}
+
+	// Get tags
+	if resourceTags, err := tags.Get(elbClient, "loadbalancers", d.Id()).Extract(); err == nil {
+		tagmap := tagsToMap(resourceTags.Tags)
+		d.Set("tags", tagmap)
+	} else {
+		log.Printf("[WARN] fetching tags of elb loadbalancer failed: %s", err)
+	}
+
+	return nil
+}

--- a/flexibleengine/data_source_flexibleengine_lb_loadbalancer_v2_test.go
+++ b/flexibleengine/data_source_flexibleengine_lb_loadbalancer_v2_test.go
@@ -1,0 +1,71 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccELBV2LoadbalancerDataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLBV2LoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccELBV2LoadbalancerDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckELBV2LoadbalancerDataSourceID("data.flexibleengine_lb_loadbalancer_v2.test_by_name"),
+					testAccCheckELBV2LoadbalancerDataSourceID("data.flexibleengine_lb_loadbalancer_v2.test_by_id"),
+					resource.TestCheckResourceAttr(
+						"data.flexibleengine_lb_loadbalancer_v2.test_by_name", "name", rName),
+					resource.TestCheckResourceAttr(
+						"data.flexibleengine_lb_loadbalancer_v2.test_by_id", "name", rName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckELBV2LoadbalancerDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find elb load balancer data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("load balancer data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+func testAccELBV2LoadbalancerDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_lb_loadbalancer_v2" "test" {
+  name          = "%s"
+  description   = "resource for load balancer data source"
+  vip_subnet_id = "%s"
+
+  tags = {
+    key   = "value"
+    owner = "terraform"
+  }
+}
+
+data "flexibleengine_lb_loadbalancer_v2" "test_by_name" {
+  name = flexibleengine_lb_loadbalancer_v2.test.name
+}
+
+data "flexibleengine_lb_loadbalancer_v2" "test_by_id" {
+  id = flexibleengine_lb_loadbalancer_v2.test.id
+}
+`, rName, OS_SUBNET_ID)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -204,6 +204,7 @@ func Provider() terraform.ResourceProvider {
 			"flexibleengine_dns_zone_v2":                        dataSourceDNSZoneV2(),
 			"flexibleengine_dds_flavor_v3":                      dataSourceDDSFlavorV3(),
 			"flexibleengine_lb_certificate_v2":                  dataSourceCertificateV2(),
+			"flexibleengine_lb_loadbalancer_v2":                 dataSourceELBV2Loadbalancer(),
 			"flexibleengine_sdrs_domain_v1":                     dataSourceSdrsDomainV1(),
 			"flexibleengine_identity_project_v3":                dataSourceIdentityProjectV3(),
 			"flexibleengine_identity_role_v3":                   dataSourceIdentityRoleV3(),


### PR DESCRIPTION
fixes #476 

the acceptance testing result as follows:
```
make testacc TEST='./flexibleengine' TESTARGS='-run TestAccELBV2LoadbalancerDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccELBV2LoadbalancerDataSource_basic -timeout 720m
=== RUN   TestAccELBV2LoadbalancerDataSource_basic
--- PASS: TestAccELBV2LoadbalancerDataSource_basic (34.98s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 34.995s
```