### PR TITLE
improve on cce node and node pool resource

### DIFF
--- a/docs/resources/cce_node_pool_v3.md
+++ b/docs/resources/cce_node_pool_v3.md
@@ -43,8 +43,6 @@ resource "flexibleengine_cce_node_pool_v3" "node_pool" {
 ## Argument Reference
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the cce pool resource. If omitted, the provider-level region will be used. Changing this creates a new cce node pool resource.
-
 * `cluster_id` - (Required, String, ForceNew) ID of the cluster. Changing this parameter will create a new resource.
 
 * `name` - (Required, String) Node Pool Name.
@@ -55,28 +53,33 @@ The following arguments are supported:
 
 *  `type` - (Optional, String, ForceNew) Node Pool type. Possible values are: "vm" and "ElasticBMS".
  
-* `availability_zone` - (Optional, String, ForceNew) specify the name of the available partition (AZ). Default value is random 
-    to create nodes in a random AZ in the node pool.
+* `availability_zone` - (Optional, String, ForceNew) specify the name of the available partition (AZ).
+    Default value is random to create nodes in a random AZ in the node pool.
     Changing this parameter will create a new resource.
 
 * `os` - (Optional, String) Operating System of the node. The value can be EulerOS 2.5 and CentOS 7.6.
     Changing this parameter will create a new resource.
 
-* `key_pair` - (Optional, String, ForceNew) Key pair name when logging in to select the key pair mode. This parameter and `password` are alternative.
+* `key_pair` - (Optional, String, ForceNew) Key pair name when logging in to select the key pair mode.
+    This parameter and `password` are alternative. Changing this parameter will create a new resource.
+
+* `password` - (Optional, String, ForceNew) root password when logging in to select the password mode.
+    This parameter must be **salted** and alternative to `key_pair`. Changing this parameter will create a new resource.
+
+* `subnet_id` - (Optional, String, ForceNew) The ID of the subnet to which the NIC belongs.
     Changing this parameter will create a new resource.
 
-* `password` - (Optional, String, ForceNew) root password when logging in to select the password mode. This parameter must be salted and alternative to `key_pair`.
+* `max_pods` - (Optional, Int, ForceNew) The maximum number of instances a node is allowed to create.
     Changing this parameter will create a new resource.
 
-* `subnet_id` - (Optional, String, ForceNew) The ID of the subnet to which the NIC belongs. Changing this parameter will create a new resource.
+* `preinstall` - (Optional, String, ForceNew) Script required before installation. The input value can be
+    a Base64 encoded string or not. Changing this parameter will create a new resource.
 
-* `preinstall` - (Optional, String, ForceNew) Script required before installation. The input value can be a Base64 encoded string or not.
-    Changing this parameter will create a new resource.
+* `postinstall` - (Optional, String, ForceNew) Script required after the installation. The input value can be
+    a Base64 encoded string or not. Changing this parameter will create a new resource.
 
-* `postinstall` - (Optional, String, ForceNew) Script required after the installation. The input value can be a Base64 encoded string or not.
-    Changing this parameter will create a new resource.
-
-* `scall_enable` - (Optional, Bool) Whether to enable auto scaling. If Autoscaler is enabled, install the autoscaler add-on to use the auto scaling feature.
+* `scall_enable` - (Optional, Bool) Whether to enable auto scaling. If Autoscaler is enabled, install the autoscaler
+    add-on to use the auto scaling feature.
 
 * `min_node_count` - (Optional, Int) Minimum number of nodes allowed if auto scaling is enabled.
 
@@ -86,14 +89,19 @@ The following arguments are supported:
 
 * `priority` - (Optional, Int) Weight of a node pool. A node pool with a higher weight has a higher priority during scaling.
 
-* `labels` - (Optional, Map, ForceNew) Tags of a Kubernetes node, key/value pair format. Changing this parameter will create a new resource.
+* `labels` - (Optional, Map, ForceNew) Tags of a Kubernetes node, key/value pair format.
+    Changing this parameter will create a new resource.
 
-* `root_volume` - (Required, List, ForceNew) It corresponds to the system disk related configuration. Changing this parameter will create a new resource.
+* `tags` - (Optional, Map) Tags of a VM node, key/value pair format.
 
-* `data_volumes` - (Required, List, ForceNew) Represents the data disk to be created. Changing this parameter will create a new resource.
+* `root_volume` - (Required, List, ForceNew) It corresponds to the system disk related configuration.
+    The object structure is documented below. Changing this parameter will create a new resource.
 
-* `taints` - (Optional, List, ForceNew) You can add taints to created nodes to configure anti-affinity. Each taint contains the following parameters:
+* `data_volumes` - (Required, List, ForceNew) Represents the data disk to be created.
+    The object structure is documented below. Changing this parameter will create a new resource.
 
+* `taints` - (Optional, List, ForceNew) You can add taints to created nodes to configure anti-affinity.
+    The object structure is documented below.
 
 The `root_volume` block supports:
 
@@ -113,13 +121,14 @@ The `data_volumes` block supports:
 
 The `taints` block supports:
     
-* `key` - (Required, String, ForceNew) A key must contain 1 to 63 characters starting with a letter or digit. Only letters, digits, hyphens (-), 
-  underscores (_), and periods (.) are allowed. A DNS subdomain name can be used as the prefix of a key.
+* `key` - (Required, String, ForceNew) A key must contain 1 to 63 characters starting with a letter or digit.
+  Only letters, digits, hyphens (-), underscores (_), and periods (.) are allowed.
+  A DNS subdomain name can be used as the prefix of a key.
     
-* `value` - (Required, String) A value must start with a letter or digit and can contain a maximum of 63 characters, including letters, 
-  digits, hyphens (-), underscores (_), and periods (.).
+* `value` - (Required, String) A value must start with a letter or digit and can contain a maximum of 63 characters,
+  including letters, digits, hyphens (-), underscores (_), and periods (.).
     
-* `effect` - (Required, String) Available options are NoSchedule, PreferNoSchedule, and NoExecute. 
+* `effect` - (Required, String) Available options are *NoSchedule*, *PreferNoSchedule* and *NoExecute*.
     
 ## Attributes Reference
 
@@ -135,4 +144,3 @@ In addition to all arguments above, the following attributes are exported:
 This resource provides the following timeouts configuration options:
 - `create` - Default is 20 minute.
 - `delete` - Default is 20 minute.
-

--- a/docs/resources/cce_nodes_v3.md
+++ b/docs/resources/cce_nodes_v3.md
@@ -7,7 +7,7 @@ Add a node to a container cluster.
 
 ## Example Usage
 
- ```hcl
+```hcl
 variable "cluster_id" { }
 variable "ssh_key" { }
 variable "availability_zone" { }
@@ -23,15 +23,15 @@ resource "flexibleengine_cce_node_v3" "node_1" {
   bandwidth_size    = 100
 
   root_volume {
-    size= 40
-    volumetype= "SATA"
+    size       = 40
+    volumetype = "SATA"
   }
   data_volumes {
-    size= 100
-    volumetype= "SATA"
+    size       = 100
+    volumetype = "SATA"
   }
 }
- ```    
+```
 
 ## Argument Reference
 The following arguments are supported:
@@ -57,35 +57,29 @@ The following arguments are supported:
 
 * `eip_ids` - (Optional) List of existing elastic IP IDs. Changing this parameter will create a new resource.
 
-**Note:**
+-> **Note:**
 If the `eip_ids` parameter is configured, you do not need to configure the `eip_count` and bandwidth parameters:
 `iptype`, `bandwidth_charge_mode`, `bandwidth_size` and `share_type`.
 
 * `eip_count` - (Optional) Number of elastic IPs to be dynamically created. Changing this parameter will create a new resource.
 
-* `iptype` - (Required) Elastic IP type. 
+* `iptype` - (Optional) Elastic IP type. 
 
 * `bandwidth_charge_mode` - (Optional) Bandwidth billing type. Changing this parameter will create a new resource.
 
-* `sharetype` - (Required) Bandwidth sharing type. Changing this parameter will create a new resource.
+* `sharetype` - (Optional) Bandwidth sharing type. Changing this parameter will create a new resource.
 
-* `bandwidth_size` - (Required) Bandwidth size. Changing this parameter will create a new resource.
+* `bandwidth_size` - (Optional) Bandwidth size. Changing this parameter will create a new resource.
 
+* `ecs_performance_type` - (Optional) Classification of cloud server specifications.
+    Changing this parameter will create a new resource.
 
-* `billing_mode` - (Optional) Node's billing mode: The value is 0 (on demand). Changing this parameter will create a new resource.
+* `product_id` - (Optional) The Product ID. Changing this parameter will create a new resource.
 
-* `extend_param_charging_mode` - (Optional) Node charging mode, 0 is on-demand charging. Changing this parameter will create a new cluster resource.
+* `max_pods` - (Optional) The maximum number of instances a node is allowed to create.
+    Changing this parameter will create a new resource.
 
-* `ecs_performance_type` - (Optional) Classification of cloud server specifications. Changing this parameter will create a new cluster resource.
-
-* `order_id` - (Optional) Order ID, mandatory when the node payment type is the automatic payment package period type.
-    Changing this parameter will create a new cluster resource.
-
-* `product_id` - (Optional) The Product ID. Changing this parameter will create a new cluster resource.
-
-* `max_pods` - (Optional) The maximum number of instances a node is allowed to create. Changing this parameter will create a new cluster resource.
-
-* `public_key` - (Optional) The Public key. Changing this parameter will create a new cluster resource.
+* `public_key` - (Optional) The Public key. Changing this parameter will create a new resource.
 
 * `preinstall` - (Optional) Script required before installation. The input value can be a Base64 encoded string or not.
     Changing this parameter will create a new resource.
@@ -99,30 +93,28 @@ If the `eip_ids` parameter is configured, you do not need to configure the `eip_
     * `dockerBaseSize` - The available disk space of a single docker container on the node in device mapper mode.
     * `DockerLVMConfigOverride` - Docker data disk configurations. The following is an example default configuration:
 
-```hcl
-  extend_param = {
-    DockerLVMConfigOverride = "dockerThinpool=vgpaas/90%VG;kubernetesLV=vgpaas/10%VG;diskType=evs;lvType=linear"
-  }
-```
+    ```hcl
+    extend_param = {
+      DockerLVMConfigOverride = "dockerThinpool=vgpaas/90%VG;kubernetesLV=vgpaas/10%VG;diskType=evs;lvType=linear"
+    }
+    ```
 
-**root_volume** **- (Required)** It corresponds to the system disk related configuration. Changing this parameter will create a new resource.
+**root_volume** **- (Required)** It corresponds to the system disk related configuration.
+  Changing this parameter will create a new resource.
 
-* `size` - (Required) Disk size in GB.
-    
-* `volumetype` - (Required) Disk type.
-    
-* `extend_params` - (Optional) Disk expansion parameters in key/value pair format.
+  * `size` - (Required) Disk size in GB. 
+  * `volumetype` - (Required) Disk type.    
+  * `extend_params` - (Optional) Disk expansion parameters in key/value pair format.
 
-**data_volumes** **- (Required)** Represents the data disk to be created. Changing this parameter will create a new resource.
+**data_volumes** **- (Required)** Represents the data disk to be created.
+  Changing this parameter will create a new resource.
     
-* `size` - (Required) Disk size in GB.
-    
-* `volumetype` - (Required) Disk type.
-    
-* `extend_params` - (Optional) Disk expansion parameters in key/value pair format.
+  * `size` - (Required) Disk size in GB.
+  * `volumetype` - (Required) Disk type.  
+  * `extend_params` - (Optional) Disk expansion parameters in key/value pair format.
 
-
-**taints** **- (Optional)** You can add taints to created nodes to configure anti-affinity. Each taint contains the following parameters:
+**taints** **- (Optional)** You can add taints to created nodes to configure anti-affinity.
+  Each taint contains the following parameters:
 
   * `key` - (Required) A key must contain 1 to 63 characters starting with a letter or digit. Only letters, digits, hyphens (-),
     underscores (_), and periods (.) are allowed. A DNS subdomain name can be used as the prefix of a key.
@@ -134,8 +126,8 @@ If the `eip_ids` parameter is configured, you do not need to configure the `eip_
 
 All above argument parameters can be exported as attribute parameters along with attribute reference.
 
- * `status` -  Node status information.
-
- * `private_ip` - Private IP of the CCE node.
-
- * `public_ip` - Public IP of the CCE node.
+* `id` - The resource ID in UUID format.
+* `status` -  Node status information.
+* `server_id` - ID of the ECS instance associated with the node.
+* `private_ip` - Private IP of the CCE node.
+* `public_ip` - Public IP of the CCE node.

--- a/flexibleengine/resource_flexibleengine_cce_node_pool.go
+++ b/flexibleengine/resource_flexibleengine_cce_node_pool.go
@@ -11,6 +11,7 @@ import (
 	"github.com/huaweicloud/golangsdk"
 	"github.com/huaweicloud/golangsdk/openstack/cce/v3/nodepools"
 	"github.com/huaweicloud/golangsdk/openstack/cce/v3/nodes"
+	"github.com/huaweicloud/golangsdk/openstack/common/tags"
 )
 
 func resourceCCENodePool() *schema.Resource {
@@ -59,6 +60,7 @@ func resourceCCENodePool() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"root_volume": {
 				Type:     schema.TypeList,
@@ -115,17 +117,17 @@ func resourceCCENodePool() *schema.Resource {
 				Computed: true,
 			},
 			"key_pair": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				// ExactlyOneOf: []string{"password", "key_pair"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ExactlyOneOf: []string{"password", "key_pair"},
 			},
 			"password": {
-				Type:      schema.TypeString,
-				Optional:  true,
-				ForceNew:  true,
-				Sensitive: true,
-				// ExactlyOneOf: []string{"password", "key_pair"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Sensitive:    true,
+				ExactlyOneOf: []string{"password", "key_pair"},
 			},
 			"taints": {
 				Type:     schema.TypeList,
@@ -147,9 +149,11 @@ func resourceCCENodePool() *schema.Resource {
 						},
 					}},
 			},
-			"billing_mode": {
+			"tags": tagsSchema(),
+			"max_pods": {
 				Type:     schema.TypeInt,
-				Computed: true,
+				Optional: true,
+				ForceNew: true,
 			},
 			"preinstall": {
 				Type:     schema.TypeString,
@@ -208,12 +212,37 @@ func resourceCCENodePool() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+
+			"billing_mode": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},
 	}
+}
+
+func resourceCCENodePoolTags(d *schema.ResourceData) []tags.ResourceTag {
+	tagRaw := d.Get("tags").(map[string]interface{})
+	return expandResourceTags(tagRaw)
+}
+
+func buildCCENodePoolLoginSpec(d *schema.ResourceData) nodes.LoginSpec {
+	var loginSpec nodes.LoginSpec
+
+	if v1, ok := d.GetOk("key_pair"); ok {
+		loginSpec.SshKey = v1.(string)
+	} else if v2, ok := d.GetOk("password"); ok {
+		loginSpec.UserPassword = nodes.UserPassword{
+			Username: "root",
+			Password: v2.(string),
+		}
+	}
+
+	return loginSpec
 }
 
 func resourceCCENodePoolCreate(d *schema.ResourceData, meta interface{}) error {
@@ -223,20 +252,20 @@ func resourceCCENodePoolCreate(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating Flexibleengine CCE Node Pool client: %s", err)
 	}
 
-	var loginSpec nodes.LoginSpec
-	if hasFilledOpt(d, "key_pair") {
-		loginSpec = nodes.LoginSpec{SshKey: d.Get("key_pair").(string)}
-	} else if hasFilledOpt(d, "password") {
-		loginSpec = nodes.LoginSpec{
-			UserPassword: nodes.UserPassword{
-				Username: "root",
-				Password: d.Get("password").(string),
-			},
-		}
+	// wait for the cce cluster to become available
+	clusterid := d.Get("cluster_id").(string)
+	stateCluster := &resource.StateChangeConf{
+		Target:     []string{"Available"},
+		Refresh:    waitForClusterAvailable(nodePoolClient, clusterid),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Delay:      5 * time.Second,
+		MinTimeout: 5 * time.Second,
+	}
+	if _, err = stateCluster.WaitForState(); err != nil {
+		return fmt.Errorf("CCE Cluster %s is inactive: %s", clusterid, err)
 	}
 
 	initialNodeCount := d.Get("initial_node_count").(int)
-
 	createOpts := nodepools.CreateOpts{
 		Kind:       "NodePool",
 		ApiVersion: "v3",
@@ -249,7 +278,6 @@ func resourceCCENodePoolCreate(d *schema.ResourceData, meta interface{}) error {
 				Flavor:      d.Get("flavor_id").(string),
 				Az:          d.Get("availability_zone").(string),
 				Os:          d.Get("os").(string),
-				Login:       loginSpec,
 				RootVolume:  resourceCCERootVolume(d),
 				DataVolumes: resourceCCEDataVolume(d),
 				K8sTags:     resourceCCENodeK8sTags(d),
@@ -262,6 +290,7 @@ func resourceCCENodePoolCreate(d *schema.ResourceData, meta interface{}) error {
 				},
 				ExtendParam: resourceCCEExtendParam(d),
 				Taints:      resourceCCETaint(d),
+				UserTags:    resourceCCENodePoolTags(d),
 			},
 			Autoscaling: nodepools.AutoscalingSpec{
 				Enable:                d.Get("scall_enable").(bool),
@@ -274,17 +303,10 @@ func resourceCCENodePoolCreate(d *schema.ResourceData, meta interface{}) error {
 		},
 	}
 
-	clusterid := d.Get("cluster_id").(string)
-	stateCluster := &resource.StateChangeConf{
-		Target:     []string{"Available"},
-		Refresh:    waitForClusterAvailable(nodePoolClient, clusterid),
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      15 * time.Second,
-		MinTimeout: 5 * time.Second,
-	}
-	_, err = stateCluster.WaitForState()
-
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	// Add loginSpec here so it wouldn't go in the above log entry
+	createOpts.Spec.NodeTemplate.Login = buildCCENodePoolLoginSpec(d)
+
 	s, err := nodepools.Create(nodePoolClient, clusterid, createOpts).Extract()
 	if err != nil {
 		if _, ok := err.(golangsdk.ErrDefault403); ok {
@@ -384,6 +406,13 @@ func resourceCCENodePoolRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("[DEBUG] Error saving root Volume to state for Flexibleengine Node Pool (%s): %s", d.Id(), err)
 	}
 
+	tagmap := tagsToMap(s.Spec.NodeTemplate.UserTags)
+	// ignore "CCE-Dynamic-Provisioning-Node"
+	delete(tagmap, "CCE-Dynamic-Provisioning-Node")
+	if err := d.Set("tags", tagmap); err != nil {
+		return fmt.Errorf("Error saving tags to state for CCE Node Pool(%s): %s", d.Id(), err)
+	}
+
 	d.Set("status", s.Status.Phase)
 
 	return nil
@@ -397,7 +426,6 @@ func resourceCCENodePoolUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	initialNodeCount := d.Get("initial_node_count").(int)
-
 	updateOpts := nodepools.UpdateOpts{
 		Kind:       "NodePool",
 		ApiVersion: "v3",
@@ -413,6 +441,16 @@ func resourceCCENodePoolUpdate(d *schema.ResourceData, meta interface{}) error {
 				ScaleDownCooldownTime: d.Get("scale_down_cooldown_time").(int),
 				Priority:              d.Get("priority").(int),
 			},
+			NodeTemplate: nodes.Spec{
+				Flavor:      d.Get("flavor_id").(string),
+				Az:          d.Get("availability_zone").(string),
+				Login:       buildCCENodePoolLoginSpec(d),
+				RootVolume:  resourceCCERootVolume(d),
+				DataVolumes: resourceCCEDataVolume(d),
+				Count:       1,
+				UserTags:    resourceCCENodePoolTags(d),
+			},
+			Type: d.Get("type").(string),
 		},
 	}
 

--- a/flexibleengine/resource_flexibleengine_cce_node_pool_test.go
+++ b/flexibleengine/resource_flexibleengine_cce_node_pool_test.go
@@ -30,18 +30,27 @@ func TestAccCCENodePool_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodePoolExists(resourceName, clusterName, &nodePool),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "scall_enable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "initial_node_count", "1"),
+					resource.TestCheckResourceAttr(resourceName, "min_node_count", "0"),
+					resource.TestCheckResourceAttr(resourceName, "max_node_count", "0"),
+					resource.TestCheckResourceAttr(resourceName, "max_pods", "200"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 				),
 			},
 			{
 				Config: testAccCCENodePool_update(rName, updateName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
-					resource.TestCheckResourceAttr(resourceName, "initial_node_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "scall_enable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "initial_node_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "min_node_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "max_node_count", "9"),
 					resource.TestCheckResourceAttr(resourceName, "scale_down_cooldown_time", "100"),
 					resource.TestCheckResourceAttr(resourceName, "priority", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 				),
 			},
 		},
@@ -156,15 +165,16 @@ resource "flexibleengine_cce_node_pool_v3" "test" {
   name               = "%s"
   os                 = "EulerOS 2.5"
   flavor_id          = "s3.large.2"
-  initial_node_count = 1
   availability_zone  = data.flexibleengine_compute_availability_zones_v2.test.names[0]
   key_pair           = flexibleengine_compute_keypair_v2.test.name
-  scall_enable      = false
-  min_node_count    = 0
-  max_node_count    = 0
+  scall_enable       = false
+  initial_node_count = 1
+  min_node_count     = 0
+  max_node_count     = 0
+  max_pods           = 200
   scale_down_cooldown_time = 0
   priority          = 0
-  type 				= "vm"
+  type              = "vm"
 
   root_volume {
     size       = 40
@@ -173,6 +183,11 @@ resource "flexibleengine_cce_node_pool_v3" "test" {
   data_volumes {
     size       = 100
     volumetype = "SSD"
+  }
+
+  tags = {
+    key = "value"
+    foo = "bar"
   }
 }
 `, testAccCCENodePool_Base(rName), rName)
@@ -187,15 +202,15 @@ resource "flexibleengine_cce_node_pool_v3" "test" {
   name               = "%s"
   os                 = "EulerOS 2.5"
   flavor_id          = "s3.large.2"
-  initial_node_count = 2
   availability_zone  = data.flexibleengine_compute_availability_zones_v2.test.names[0]
   key_pair           = flexibleengine_compute_keypair_v2.test.name
-  scall_enable      = true
-  min_node_count    = 2
-  max_node_count    = 9
+  scall_enable       = true
+  initial_node_count = 2
+  min_node_count     = 2
+  max_node_count     = 9
   scale_down_cooldown_time = 100
   priority          = 1
-  type 				= "vm"
+  type              = "vm"
 
   root_volume {
     size       = 40
@@ -204,6 +219,11 @@ resource "flexibleengine_cce_node_pool_v3" "test" {
   data_volumes {
     size       = 100
     volumetype = "SSD"
+  }
+
+  tags = {
+    key   = "value1"
+    owner = "terraform"
   }
 }
 `, testAccCCENodePool_Base(rName), updateName)

--- a/flexibleengine/resource_flexibleengine_cce_node_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_cce_node_v3_test.go
@@ -27,6 +27,7 @@ func TestAccCCENodesV3_basic(t *testing.T) {
 					testAccCheckCCENodeV3Exists("flexibleengine_cce_node_v3.node_1", "flexibleengine_cce_cluster_v3.cluster_1", &node),
 					resource.TestCheckResourceAttr(resourceName, "name", "test-node"),
 					resource.TestCheckResourceAttr(resourceName, "flavor_id", "s1.medium"),
+					resource.TestCheckResourceAttr(resourceName, "status", "Active"),
 				),
 			},
 			{


### PR DESCRIPTION
fixes #519 

- cce node: deprecated unused parameters and add `status` attribute
- cce node pool: support `tags` and `max_pods` fields

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCCENodesV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCCENodesV3_basic -timeout 720m
=== RUN   TestAccCCENodesV3_basic
--- PASS: TestAccCCENodesV3_basic (2112.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 2112.012s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCCENodePool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCCENodePool_basic -timeout 720m
=== RUN   TestAccCCENodePool_basic
=== PAUSE TestAccCCENodePool_basic
=== CONT  TestAccCCENodePool_basic
--- PASS: TestAccCCENodePool_basic (2292.52s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 2292.531s
```