### PR TITLE
add autoscaling lifecyclehook resource

### DIFF
--- a/docs/resources/as_lifecycle_hook_v1.md
+++ b/docs/resources/as_lifecycle_hook_v1.md
@@ -1,0 +1,74 @@
+---
+subcategory: "Auto Scaling (AS)"
+---
+
+# flexibleengine_as_lifecycle_hook_v1
+
+Manages an AS Lifecycle Hook resource within FlexibleEngine.
+
+## Example Usage
+
+### Basic Lifecycle Hook
+
+```hcl
+variable "hook_name" {}
+
+variable "as_group_id" {}
+
+variable "smn_topic_urn" {}
+
+resource "flexibleengine_as_lifecycle_hook_v1" "test" {
+  name                   = var.hook_name
+  scaling_group_id       = var.as_group_id
+  type                   = "ADD"  
+  default_result         = "ABANDON"
+  notification_topic_urn = var.smn_topic_urn
+  notification_message   = "This is a test message"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String) Specifies the lifecycle hook name.
+  This parameter can contain a maximum of 32 characters, which may consist of letters, digits,
+  underscores (_) and hyphens (-).
+
+* `scaling_group_id` - (Required, String, ForceNew) Specifies the ID of the AS group in UUID format.
+  Changing this creates a new AS lifecycle hook.
+
+* `type` - (Required, String) Specifies the lifecycle hook type.
+  The valid values are following strings:
+  * `ADD`: The hook suspends the instance when the instance is started.
+  * `REMOVE`: The hook suspends the instance when the instance is terminated.
+
+* `notification_topic_urn` - (Required, String) Specifies a unique topic in SMN.
+
+* `default_result` - (Optional, String) Specifies the default lifecycle hook callback operation.
+  This operation is performed when the timeout duration expires.
+  The valid values are *ABANDON* and *CONTINUE*, default to *ABANDON*.
+
+* `timeout` - (Optional, Int) Specifies the lifecycle hook timeout duration, which ranges from 300 to 86400 in the
+  unit of second, default to 3600.
+
+* `notification_message` - (Optional, String) Specifies a customized notification.
+  This parameter can contains a maximum of 256 characters, which cannot contain the following characters: <>&'().
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `notification_topic_name` - The topic name in SMN.
+
+* `create_time` - The server time in UTC format when the lifecycle hook is created.
+
+## Import
+
+Lifecycle hooks can be imported using the AS group ID and hook ID separated by a slash, e.g.
+
+```
+$ terraform import flexibleengine_as_lifecycle_hook_v1.test <AS group ID>/<Lifecycle hook ID>
+```

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -276,6 +276,7 @@ func Provider() terraform.ResourceProvider {
 			"flexibleengine_as_group_v1":                        resourceASGroup(),
 			"flexibleengine_as_configuration_v1":                resourceASConfiguration(),
 			"flexibleengine_as_policy_v1":                       resourceASPolicy(),
+			"flexibleengine_as_lifecycle_hook_v1":               resourceASLifecycleHook(),
 			"flexibleengine_smn_topic_v2":                       resourceTopic(),
 			"flexibleengine_smn_subscription_v2":                resourceSubscription(),
 			"flexibleengine_rds_instance_v3":                    resourceRdsInstanceV3(),

--- a/flexibleengine/resource_flexibleengine_as_lifecycle_hook.go
+++ b/flexibleengine/resource_flexibleengine_as_lifecycle_hook.go
@@ -1,0 +1,229 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks"
+)
+
+var hookTypeMap = map[string]string{
+	"ADD":    "INSTANCE_LAUNCHING",
+	"REMOVE": "INSTANCE_TERMINATING",
+}
+
+func resourceASLifecycleHook() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceASLifecycleHookCreate,
+		Read:   resourceASLifecycleHookRead,
+		Update: resourceASLifecycleHookUpdate,
+		Delete: resourceASLifecycleHookDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceASLifecycleHookImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"scaling_group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"ADD", "REMOVE",
+				}, false),
+			},
+			"notification_topic_urn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"default_result": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "ABANDON",
+				ValidateFunc: validation.StringInSlice([]string{
+					"ABANDON", "CONTINUE",
+				}, false),
+			},
+			"timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      3600,
+				ValidateFunc: validation.IntBetween(300, 86400),
+			},
+			"notification_message": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile("^[^()<>&']{1,256}$"),
+					"The 'notification_message' of the lifecycle hook has special character"),
+			},
+			"notification_topic_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceASLifecycleHookCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	client, err := config.AutoscalingV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine AutoScaling client: %s", err)
+	}
+
+	groupID := d.Get("scaling_group_id").(string)
+	createOpts := lifecyclehooks.CreateOpts{
+		Name:                 d.Get("name").(string),
+		DefaultResult:        d.Get("default_result").(string),
+		Timeout:              d.Get("timeout").(int),
+		NotificationTopicURN: d.Get("notification_topic_urn").(string),
+		NotificationMetadata: d.Get("notification_message").(string),
+	}
+	hookType := d.Get("type").(string)
+	v, ok := hookTypeMap[hookType]
+	if !ok {
+		return fmt.Errorf("Lifecycle hook type (%s) is not in the map (%#v)", hookType, hookTypeMap)
+	}
+	createOpts.Type = v
+	hook, err := lifecyclehooks.Create(client, createOpts, groupID).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating lifecycle hook: %s", err)
+	}
+	d.SetId(hook.Name)
+
+	return resourceASLifecycleHookRead(d, meta)
+}
+
+func resourceASLifecycleHookRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	region := GetRegion(d, config)
+	client, err := config.AutoscalingV1Client(region)
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine AutoScaling client: %s", err)
+	}
+
+	groupID := d.Get("scaling_group_id").(string)
+	hook, err := lifecyclehooks.Get(client, groupID, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "AutoScaling lifecycle hook")
+	}
+	d.Set("region", region)
+	if err = setASLifecycleHookToState(d, hook); err != nil {
+		return fmt.Errorf("Error setting the lifecycle hook to state: %s", err)
+	}
+	return nil
+}
+
+func resourceASLifecycleHookUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	client, err := config.AutoscalingV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine AutoScaling client: %s", err)
+	}
+
+	updateOpts := lifecyclehooks.UpdateOpts{}
+	if d.HasChange("type") {
+		hookType := d.Get("type").(string)
+		v, ok := hookTypeMap[hookType]
+		if !ok {
+			return fmt.Errorf("The type (%s) of hook is not in the map (%#v)", hookType, hookTypeMap)
+		}
+		updateOpts.Type = v
+	}
+	if d.HasChange("default_result") {
+		updateOpts.DefaultResult = d.Get("default_result").(string)
+	}
+	if d.HasChange("timeout") {
+		updateOpts.Timeout = d.Get("timeout").(int)
+	}
+	if d.HasChange("notification_topic_urn") {
+		updateOpts.NotificationTopicURN = d.Get("notification_topic_urn").(string)
+	}
+	if d.HasChange("notification_message") {
+		updateOpts.NotificationMetadata = d.Get("notification_message").(string)
+	}
+
+	groupID := d.Get("scaling_group_id").(string)
+	_, err = lifecyclehooks.Update(client, updateOpts, groupID, d.Id()).Extract()
+	if err != nil {
+		return fmt.Errorf("Error updating the lifecycle hook of the AutoScaling service: %s", err)
+	}
+
+	return resourceASLifecycleHookRead(d, meta)
+}
+
+func resourceASLifecycleHookDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	client, err := config.AutoscalingV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine AutoScaling client: %s", err)
+	}
+
+	groupID := d.Get("scaling_group_id").(string)
+	err = lifecyclehooks.Delete(client, groupID, d.Id()).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("Error deleting the lifecycle hook of the AutoScaling service: %s", err)
+	}
+
+	return nil
+}
+
+func setASLifecycleHookToState(d *schema.ResourceData, hook *lifecyclehooks.Hook) error {
+	mErr := multierror.Append(
+		d.Set("name", hook.Name),
+		d.Set("default_result", hook.DefaultResult),
+		d.Set("timeout", hook.Timeout),
+		d.Set("notification_topic_urn", hook.NotificationTopicURN),
+		d.Set("notification_message", hook.NotificationMetadata),
+		setASLifecycleHookType(d, hook),
+		d.Set("notification_topic_name", hook.NotificationTopicName),
+		d.Set("create_time", hook.CreateTime),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func setASLifecycleHookType(d *schema.ResourceData, hook *lifecyclehooks.Hook) error {
+	for k, v := range hookTypeMap {
+		if v == hook.Type {
+			err := d.Set("type", k)
+			return err
+		}
+	}
+	return fmt.Errorf("The type of hook response is not in the map")
+}
+
+func resourceASLifecycleHookImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("Invalid format specified for lifecycle hook, must be <scaling_group_id>/<hook_id>")
+	}
+	d.SetId(parts[1])
+	d.Set("scaling_group_id", parts[0])
+	return []*schema.ResourceData{d}, nil
+}

--- a/flexibleengine/resource_flexibleengine_as_lifecycle_hook_test.go
+++ b/flexibleengine/resource_flexibleengine_as_lifecycle_hook_test.go
@@ -1,0 +1,177 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks"
+)
+
+func TestAccASLifecycleHook_basic(t *testing.T) {
+	var hook lifecyclehooks.Hook
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceGroupName := "flexibleengine_as_group_v1.hth_as_group"
+	resourceHookName := "flexibleengine_as_lifecycle_hook_v1.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckASLifecycleHookDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testASLifecycleHook_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckASLifecycleHookExists(resourceGroupName, resourceHookName, &hook),
+					resource.TestCheckResourceAttr(resourceHookName, "name", rName),
+					resource.TestCheckResourceAttr(resourceHookName, "type", "ADD"),
+					resource.TestCheckResourceAttr(resourceHookName, "default_result", "ABANDON"),
+					resource.TestCheckResourceAttr(resourceHookName, "timeout", "3600"),
+					resource.TestCheckResourceAttr(resourceHookName, "notification_message", "This is a test message"),
+					resource.TestCheckResourceAttrSet(resourceHookName, "notification_topic_urn"),
+				),
+			},
+			{
+				Config: testASLifecycleHook_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckASLifecycleHookExists(resourceGroupName, resourceHookName, &hook),
+					resource.TestCheckResourceAttr(resourceHookName, "name", rName),
+					resource.TestCheckResourceAttr(resourceHookName, "type", "REMOVE"),
+					resource.TestCheckResourceAttr(resourceHookName, "default_result", "CONTINUE"),
+					resource.TestCheckResourceAttr(resourceHookName, "timeout", "600"),
+					resource.TestCheckResourceAttr(resourceHookName, "notification_message",
+						"This is a update message"),
+				),
+			},
+			{
+				ResourceName:      resourceHookName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccASLifecycleHookImportStateIdFunc(resourceGroupName, resourceHookName),
+			},
+		},
+	})
+}
+
+func testAccCheckASLifecycleHookDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	asClient, err := config.AutoscalingV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating autoscaling client: %s", err)
+	}
+
+	var groupID string
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type == "flexibleengine_as_group_v1" {
+			groupID = rs.Primary.ID
+			break
+		}
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_as_lifecycle_hook_v1" {
+			continue
+		}
+
+		_, err := lifecyclehooks.Get(asClient, groupID, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("AS lifecycle hook still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckASLifecycleHookExists(resGroup, resHook string, hook *lifecyclehooks.Hook) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resGroup]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resGroup)
+		}
+		groupID := rs.Primary.ID
+
+		rs, ok = s.RootModule().Resources[resHook]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resHook)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		asClient, err := config.AutoscalingV1Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating autoscaling client: %s", err)
+		}
+		found, err := lifecyclehooks.Get(asClient, groupID, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+		hook = found
+
+		return nil
+	}
+}
+
+func testAccASLifecycleHookImportStateIdFunc(groupRes, hookRes string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		group, ok := s.RootModule().Resources[groupRes]
+		if !ok {
+			return "", fmt.Errorf("Auto Scaling group not found: %s", group)
+		}
+		hook, ok := s.RootModule().Resources[hookRes]
+		if !ok {
+			return "", fmt.Errorf("Auto Scaling lifecycle hook not found: %s", hook)
+		}
+		if group.Primary.ID == "" || hook.Primary.ID == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", group.Primary.ID, hook.Primary.ID)
+		}
+		return fmt.Sprintf("%s/%s", group.Primary.ID, hook.Primary.ID), nil
+	}
+}
+
+func testASLifecycleHook_base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_smn_topic_v2" "test" {
+  name = "%s"
+}
+
+resource "flexibleengine_smn_topic_v2" "update" {
+  name = "%s-update"
+}
+`, testASV1Group_basic, rName, rName)
+}
+
+func testASLifecycleHook_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_as_lifecycle_hook_v1" "test" {
+  name                   = "%s"
+  type                   = "ADD"
+  scaling_group_id       = flexibleengine_as_group_v1.hth_as_group.id
+  notification_topic_urn = flexibleengine_smn_topic_v2.test.topic_urn
+  notification_message   = "This is a test message"
+}
+`, testASLifecycleHook_base(rName), rName)
+}
+
+func testASLifecycleHook_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_as_lifecycle_hook_v1" "test" {
+  name                   = "%s"
+  type                   = "REMOVE"
+  scaling_group_id       = flexibleengine_as_group_v1.hth_as_group.id
+  notification_topic_urn = flexibleengine_smn_topic_v2.update.topic_urn
+  notification_message   = "This is a update message"
+  default_result         = "CONTINUE"
+  timeout                = 600
+}
+`, testASLifecycleHook_base(rName), rName)
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210511031538-124f151770d5
+	github.com/huaweicloud/golangsdk v0.0.0-20210521023342-0c12216e9be5
 	github.com/huaweicloud/terraform-provider-huaweicloud v1.23.1-0.20210406030556-c63d7fdb3533
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jtolds/gls v4.20.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -229,6 +229,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20210408110332-c61d9b336da5 h1:qsDthJ6oy
 github.com/huaweicloud/golangsdk v0.0.0-20210408110332-c61d9b336da5/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/golangsdk v0.0.0-20210511031538-124f151770d5 h1:YiZrQLNWjvHpcIGpuHqcZX4FJ1J82oAU/F2mUUlbZAE=
 github.com/huaweicloud/golangsdk v0.0.0-20210511031538-124f151770d5/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210521023342-0c12216e9be5 h1:iwWx/ZiWPnKx+rQviTZCVclds+n6mpgd+FfKEP/5hCw=
+github.com/huaweicloud/golangsdk v0.0.0-20210521023342-0c12216e9be5/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.23.1-0.20210406030556-c63d7fdb3533 h1:T1XFVhGzVwLMahLUK8/ww//Mls8fZ1BXTi2CpJswL0k=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.23.1-0.20210406030556-c63d7fdb3533/go.mod h1:GJUvfnw1G3LjHIXsYO+quUH86842c06MvVaeIFqingk=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks/requests.go
@@ -1,0 +1,108 @@
+package lifecyclehooks
+
+import "github.com/huaweicloud/golangsdk"
+
+// CreateOpts is a struct which will be used to create a lifecycle hook.
+type CreateOpts struct {
+	// The lifecycle hook name.
+	// The name contains only letters, digits, underscores (_), and hyphens (-), and cannot exceed 32 characters.
+	Name string `json:"lifecycle_hook_name" required:"true"`
+	// The lifecycle hook type.
+	// INSTANCE_TERMINATING: The hook suspends the instance when the instance is terminated.
+	// INSTANCE_LAUNCHING: The hook suspends the instance when the instance is started.
+	Type string `json:"lifecycle_hook_type" required:"true"`
+	// The default lifecycle hook callback operation: ABANDON and CONTINUE.
+	// By default, this operation is performed when the timeout duration expires.
+	DefaultResult string `json:"default_result,omitempty"`
+	// The lifecycle hook timeout duration, which ranges from 300 to 86400 in the unit of second.
+	// The default value is 3600.
+	Timeout int `json:"default_timeout,omitempty"`
+	// The unique topic in SMN.
+	// This parameter specifies a notification object for a lifecycle hook.
+	NotificationTopicURN string `json:"notification_topic_urn" required:"true"`
+	// The customized notification, which contains no more than 256 characters in length.
+	// The message cannot contain the following characters: <>&'().
+	NotificationMetadata string `json:"notification_metadata,omitempty"`
+}
+
+// CreateOptsBuilder is an interface by which can serialize the create parameters.
+type CreateOptsBuilder interface {
+	ToLifecycleHookCreateMap() (map[string]interface{}, error)
+}
+
+func (opts CreateOpts) ToLifecycleHookCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create is a method which can be able to access to create the hook of autoscaling service.
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder, groupID string) (r CreateResult) {
+	b, err := opts.ToLifecycleHookCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(rootURL(client, groupID), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Get is a method to obtains the hook detail of autoscaling service.
+func Get(client *golangsdk.ServiceClient, groupID, hookName string) (r GetResult) {
+	_, r.Err = client.Get(resourceURL(client, groupID, hookName), &r.Body, nil)
+	return
+}
+
+// List is a method to obtains a hook array of the autoscaling service.
+func List(client *golangsdk.ServiceClient, groupID string) (r ListResult) {
+	_, r.Err = client.Get(listURL(client, groupID), &r.Body, nil)
+	return
+}
+
+// UpdateOpts is a struct which will be used to update the existing hook.
+type UpdateOpts struct {
+	// The lifecycle hook type
+	Type string `json:"lifecycle_hook_type,omitempty"`
+	// The default lifecycle hook callback operation: ABANDON and CONTINUE.
+	// By default, this operation is performed when the timeout duration expires.
+	DefaultResult string `json:"default_result,omitempty"`
+	// The lifecycle hook timeout duration, which ranges from 300 to 86400 in the unit of second.
+	// The default value is 3600.
+	Timeout int `json:"default_timeout,omitempty"`
+	// The unique topic in SMN.
+	// This parameter specifies a notification object for a lifecycle hook.
+	NotificationTopicURN string `json:"notification_topic_urn,omitempty"`
+	// The customized notification, which contains no more than 256 characters in length.
+	// The message cannot contain the following characters: <>&'().
+	NotificationMetadata string `json:"notification_metadata,omitempty"`
+}
+
+// CreateOptsBuilder is an interface by which can serialize the create parameters
+type UpdateOptsBuilder interface {
+	ToLifecycleHookUpdateMap() (map[string]interface{}, error)
+}
+
+func (opts UpdateOpts) ToLifecycleHookUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Update is a method which can be able to access to udpate the existing hook of the autoscaling service.
+func Update(client *golangsdk.ServiceClient, opts UpdateOptsBuilder, groupID, hookName string) (r UpdateResult) {
+	b, err := opts.ToLifecycleHookUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Put(resourceURL(client, groupID, hookName), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+//Delete is a method which can be able to access to delete the existing hook of the autoscaling service.
+func Delete(client *golangsdk.ServiceClient, groupID, hookName string) (r DeleteResult) {
+	_, r.Err = client.Delete(resourceURL(client, groupID, hookName), nil)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks/results.go
@@ -1,0 +1,64 @@
+package lifecyclehooks
+
+import "github.com/huaweicloud/golangsdk"
+
+// Hook is a struct that represents the result of API calling.
+type Hook struct {
+	// The lifecycle hook name.
+	Name string `json:"lifecycle_hook_name"`
+	// The lifecycle hook type: INSTANCE_TERMINATING and INSTANCE_LAUNCHING.
+	Type string `json:"lifecycle_hook_type"`
+	// The default lifecycle hook callback operation: ABANDON and CONTINUE.
+	DefaultResult string `json:"default_result"`
+	// The lifecycle hook timeout duration in the unit of second.
+	Timeout int `json:"default_timeout"`
+	// The unique topic in SMN.
+	NotificationTopicURN string `json:"notification_topic_urn"`
+	// The topic name in SMN.
+	NotificationTopicName string `json:"notification_topic_name"`
+	// The notification message.
+	NotificationMetadata string `json:"notification_metadata"`
+	// The UTC-compliant time when the lifecycle hook is created.
+	CreateTime string `json:"create_time"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract will deserialize the result to Hook object.
+func (r commonResult) Extract() (*Hook, error) {
+	var s Hook
+	err := r.Result.ExtractInto(&s)
+	return &s, err
+}
+
+type CreateResult struct {
+	commonResult
+}
+
+type GetResult struct {
+	commonResult
+}
+
+type UpdateResult struct {
+	commonResult
+}
+
+type ListResult struct {
+	commonResult
+}
+
+// Extract will deserialize the result to Hook array.
+func (r ListResult) Extract() (*[]Hook, error) {
+	var s struct {
+		// An array of lifecycle hooks.
+		Hooks []Hook `json:"lifecycle_hooks"`
+	}
+	err := r.Result.ExtractInto(&s)
+	return &s.Hooks, err
+}
+
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks/urls.go
@@ -1,0 +1,17 @@
+package lifecyclehooks
+
+import "github.com/huaweicloud/golangsdk"
+
+const rootPath = "scaling_lifecycle_hook"
+
+func rootURL(client *golangsdk.ServiceClient, groupID string) string {
+	return client.ServiceURL(rootPath, groupID)
+}
+
+func resourceURL(client *golangsdk.ServiceClient, groupID, hookName string) string {
+	return client.ServiceURL(rootPath, groupID, hookName)
+}
+
+func listURL(client *golangsdk.ServiceClient, groupID string) string {
+	return client.ServiceURL(rootPath, groupID, "list")
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cloudeyeservice/alarmrule/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cloudeyeservice/alarmrule/requests.go
@@ -48,6 +48,7 @@ type CreateOpts struct {
 	OkActions               []ActionOpts  `json:"ok_actions,omitempty"`
 	AlarmEnabled            bool          `json:"alarm_enabled"`
 	AlarmActionEnabled      bool          `json:"alarm_action_enabled"`
+	EnterpriseProjectID     string        `json:"enterprise_project_id,omitempty"`
 }
 
 func (opts CreateOpts) ToAlarmRuleCreateMap() (map[string]interface{}, error) {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/cloudeyeservice/alarmrule/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/cloudeyeservice/alarmrule/results.go
@@ -58,6 +58,7 @@ type AlarmRule struct {
 	AlarmActionEnabled      bool          `json:"alarm_action_enabled"`
 	UpdateTime              int64         `json:"update_time"`
 	AlarmState              string        `json:"alarm_state"`
+	EnterpriseProjectID     string        `json:"enterprise_project_id"`
 }
 
 type GetResult struct {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/dds/v3/instances/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/dds/v3/instances/requests.go
@@ -8,19 +8,20 @@ import (
 )
 
 type CreateOpts struct {
-	Name             string         `json:"name"  required:"true"`
-	DataStore        DataStore      `json:"datastore" required:"true"`
-	Region           string         `json:"region" required:"true"`
-	AvailabilityZone string         `json:"availability_zone" required:"true"`
-	VpcId            string         `json:"vpc_id" required:"true"`
-	SubnetId         string         `json:"subnet_id" required:"true"`
-	SecurityGroupId  string         `json:"security_group_id" required:"true"`
-	Password         string         `json:"password" required:"true"`
-	DiskEncryptionId string         `json:"disk_encryption_id,omitempty"`
-	Ssl              string         `json:"ssl_option,omitempty"`
-	Mode             string         `json:"mode" required:"true"`
-	Flavor           []Flavor       `json:"flavor" required:"true"`
-	BackupStrategy   BackupStrategy `json:"backup_strategy,omitempty"`
+	Name                string         `json:"name"  required:"true"`
+	DataStore           DataStore      `json:"datastore" required:"true"`
+	Region              string         `json:"region" required:"true"`
+	AvailabilityZone    string         `json:"availability_zone" required:"true"`
+	VpcId               string         `json:"vpc_id" required:"true"`
+	SubnetId            string         `json:"subnet_id" required:"true"`
+	SecurityGroupId     string         `json:"security_group_id" required:"true"`
+	Password            string         `json:"password" required:"true"`
+	DiskEncryptionId    string         `json:"disk_encryption_id,omitempty"`
+	Ssl                 string         `json:"ssl_option,omitempty"`
+	Mode                string         `json:"mode" required:"true"`
+	Flavor              []Flavor       `json:"flavor" required:"true"`
+	BackupStrategy      BackupStrategy `json:"backup_strategy,omitempty"`
+	EnterpriseProjectID string         `json:"enterprise_project_id,omitempty"`
 }
 
 type DataStore struct {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/dds/v3/instances/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/dds/v3/instances/results.go
@@ -14,20 +14,21 @@ type CreateResult struct {
 }
 
 type Instance struct {
-	Id               string            `json:"id"`
-	Name             string            `json:"name"`
-	DataStore        DataStore         `json:"datastore"`
-	Status           string            `json:"status"`
-	Region           string            `json:"region"`
-	AvailabilityZone string            `json:"availability_zone"`
-	VpcId            string            `json:"vpc_id"`
-	SubnetId         string            `json:"subnet_id"`
-	SecurityGroupId  string            `json:"security_group_id"`
-	DiskEncryptionId string            `json:"disk_encryption_id"`
-	Ssl              string            `json:"ssl_option"`
-	Mode             string            `json:"mode"`
-	Flavor           []FlavorOpt       `json:"flavor"`
-	BackupStrategy   BackupStrategyOpt `json:"backup_strategy"`
+	Id                  string            `json:"id"`
+	Name                string            `json:"name"`
+	DataStore           DataStore         `json:"datastore"`
+	Status              string            `json:"status"`
+	Region              string            `json:"region"`
+	AvailabilityZone    string            `json:"availability_zone"`
+	VpcId               string            `json:"vpc_id"`
+	SubnetId            string            `json:"subnet_id"`
+	SecurityGroupId     string            `json:"security_group_id"`
+	DiskEncryptionId    string            `json:"disk_encryption_id"`
+	Ssl                 string            `json:"ssl_option"`
+	Mode                string            `json:"mode"`
+	Flavor              []FlavorOpt       `json:"flavor"`
+	BackupStrategy      BackupStrategyOpt `json:"backup_strategy"`
+	EnterpriseProjectID string            `json:"enterprise_project_id"`
 }
 
 type FlavorOpt struct {
@@ -77,27 +78,28 @@ type ListInstanceResponse struct {
 }
 
 type InstanceResponse struct {
-	Id                string         `json:"id"`
-	Name              string         `json:"name"`
-	Status            string         `json:"status"`
-	Port              string         `json:"port"`
-	Mode              string         `json:"mode"`
-	Region            string         `json:"region"`
-	DataStore         DataStore      `json:"datastore"`
-	Engine            string         `json:"engine"`
-	Created           string         `json:"created"`
-	Updated           string         `json:"updated"`
-	DbUserName        string         `json:"db_user_name"`
-	Ssl               int            `json:"ssl"`
-	VpcId             string         `json:"vpc_id"`
-	SubnetId          string         `json:"subnet_id"`
-	SecurityGroupId   string         `json:"security_group_id"`
-	BackupStrategy    BackupStrategy `json:"backup_strategy"`
-	MaintenanceWindow string         `json:"maintenance_window"`
-	Groups            []Group        `json:"groups"`
-	DiskEncryptionId  string         `json:"disk_encryption_id"`
-	TimeZone          string         `json:"time_zone"`
-	Actions           []string       `json:"actions"`
+	Id                  string         `json:"id"`
+	Name                string         `json:"name"`
+	Status              string         `json:"status"`
+	Port                string         `json:"port"`
+	Mode                string         `json:"mode"`
+	Region              string         `json:"region"`
+	DataStore           DataStore      `json:"datastore"`
+	Engine              string         `json:"engine"`
+	Created             string         `json:"created"`
+	Updated             string         `json:"updated"`
+	DbUserName          string         `json:"db_user_name"`
+	Ssl                 int            `json:"ssl"`
+	VpcId               string         `json:"vpc_id"`
+	SubnetId            string         `json:"subnet_id"`
+	SecurityGroupId     string         `json:"security_group_id"`
+	BackupStrategy      BackupStrategy `json:"backup_strategy"`
+	MaintenanceWindow   string         `json:"maintenance_window"`
+	Groups              []Group        `json:"groups"`
+	DiskEncryptionId    string         `json:"disk_encryption_id"`
+	TimeZone            string         `json:"time_zone"`
+	Actions             []string       `json:"actions"`
+	EnterpriseProjectID string         `json:"enterprise_project_id"`
 }
 
 type Group struct {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/ecs/v1/cloudservers/results.go
@@ -72,6 +72,7 @@ type VolumeAttached struct {
 
 type SecurityGroups struct {
 	Name string `json:"name"`
+	ID   string `json:"id"`
 }
 
 // CloudServer is only used for method that requests details on a single server, by ID.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -261,7 +261,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210511031538-124f151770d5
+# github.com/huaweicloud/golangsdk v0.0.0-20210521023342-0c12216e9be5
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -270,6 +270,7 @@ github.com/huaweicloud/golangsdk/openstack/antiddos/v1/antiddos
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/configurations
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/groups
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/instances
+github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/lifecyclehooks
 github.com/huaweicloud/golangsdk/openstack/autoscaling/v1/policies
 github.com/huaweicloud/golangsdk/openstack/blockstorage/extensions/volumeactions
 github.com/huaweicloud/golangsdk/openstack/blockstorage/v2/volumes


### PR DESCRIPTION
fixes #525 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccASLifecycleHook_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccASLifecycleHook_basic -timeout 720m
=== RUN   TestAccASLifecycleHook_basic
=== PAUSE TestAccASLifecycleHook_basic
=== CONT  TestAccASLifecycleHook_basic
--- PASS: TestAccASLifecycleHook_basic (112.43s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 112.441s
```