### PR TITLE
subnets: Allow DNS Nameservers to be cleared

### DIFF
--- a/flexibleengine/resource_flexibleengine_vpc_subnet_v1.go
+++ b/flexibleengine/resource_flexibleengine_vpc_subnet_v1.go
@@ -236,7 +236,8 @@ func resourceVpcSubnetV1Update(d *schema.ResourceData, meta interface{}) error {
 		updateOpts.SECONDARY_DNS = d.Get("secondary_dns").(string)
 	}
 	if d.HasChange("dns_list") {
-		updateOpts.DnsList = resourceSubnetDNSListV1(d)
+		dnsList := resourceSubnetDNSListV1(d)
+		updateOpts.DnsList = &dnsList
 	}
 	if d.HasChange("dhcp_enable") {
 		updateOpts.EnableDHCP = d.Get("dhcp_enable").(bool)

--- a/flexibleengine/resource_flexibleengine_vpc_subnet_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_vpc_subnet_v1_test.go
@@ -30,6 +30,7 @@ func TestAccFlexibleEngineVpcSubnetV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
 					resource.TestCheckResourceAttr(resourceName, "cidr", "192.168.0.0/16"),
 					resource.TestCheckResourceAttr(resourceName, "gateway_ip", "192.168.0.1"),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210521023342-0c12216e9be5
+	github.com/huaweicloud/golangsdk v0.0.0-20210528023633-c90ae4249a71
 	github.com/huaweicloud/terraform-provider-huaweicloud v1.23.1-0.20210406030556-c63d7fdb3533
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jtolds/gls v4.20.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -225,12 +225,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huaweicloud/golangsdk v0.0.0-20210402075152-aba310c2a950 h1:Ys3DRL6qJGYL/9mX8gvzSQade5TOJi8COrPyG58HOQs=
 github.com/huaweicloud/golangsdk v0.0.0-20210402075152-aba310c2a950/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/golangsdk v0.0.0-20210408110332-c61d9b336da5 h1:qsDthJ6oyB3Jexl1NTK/d8LePQL+zM7dIVyeeSpSmBs=
-github.com/huaweicloud/golangsdk v0.0.0-20210408110332-c61d9b336da5/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/golangsdk v0.0.0-20210511031538-124f151770d5 h1:YiZrQLNWjvHpcIGpuHqcZX4FJ1J82oAU/F2mUUlbZAE=
-github.com/huaweicloud/golangsdk v0.0.0-20210511031538-124f151770d5/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/golangsdk v0.0.0-20210521023342-0c12216e9be5 h1:iwWx/ZiWPnKx+rQviTZCVclds+n6mpgd+FfKEP/5hCw=
-github.com/huaweicloud/golangsdk v0.0.0-20210521023342-0c12216e9be5/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210528023633-c90ae4249a71 h1:o2s9CcW277XbOQp0EolTCWHrNdBUHCjuu0aKtAedF/k=
+github.com/huaweicloud/golangsdk v0.0.0-20210528023633-c90ae4249a71/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.23.1-0.20210406030556-c63d7fdb3533 h1:T1XFVhGzVwLMahLUK8/ww//Mls8fZ1BXTi2CpJswL0k=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.23.1-0.20210406030556-c63d7fdb3533/go.mod h1:GJUvfnw1G3LjHIXsYO+quUH86842c06MvVaeIFqingk=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/subnets/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/subnets/requests.go
@@ -196,7 +196,7 @@ type UpdateOpts struct {
 	EnableDHCP    bool           `json:"dhcp_enable"`
 	PRIMARY_DNS   string         `json:"primary_dns,omitempty"`
 	SECONDARY_DNS string         `json:"secondary_dns,omitempty"`
-	DnsList       []string       `json:"dnsList,omitempty"`
+	DnsList       *[]string      `json:"dnsList,omitempty"`
 	ExtraDhcpOpts []ExtraDhcpOpt `json:"extra_dhcp_opts,omitempty"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -261,7 +261,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210521023342-0c12216e9be5
+# github.com/huaweicloud/golangsdk v0.0.0-20210528023633-c90ae4249a71
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
the acceptance testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccFlexibleEngineVpcSubnetV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccFlexibleEngineVpcSubnetV1_basic -timeout 720m
=== RUN   TestAccFlexibleEngineVpcSubnetV1_basic
--- PASS: TestAccFlexibleEngineVpcSubnetV1_basic (70.15s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 70.163s
```