### PR TITLE
refactor: add expandResource functions and add more acc checks for cce node

### DIFF
--- a/flexibleengine/import_flexibleengine_cce_node_test.go
+++ b/flexibleengine/import_flexibleengine_cce_node_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccCCENodeV3_importBasic(t *testing.T) {
@@ -25,7 +26,26 @@ func TestAccCCENodeV3_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateIdFunc: testAccCCENodeImportStateIdFunc(),
 			},
 		},
 	})
+}
+
+func testAccCCENodeImportStateIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		cluster, ok := s.RootModule().Resources["flexibleengine_cce_cluster_v3.cluster_1"]
+		if !ok {
+			return "", fmt.Errorf("Cluster not found: %s", cluster)
+		}
+		node, ok := s.RootModule().Resources["flexibleengine_cce_node_v3.node_1"]
+		if !ok {
+			return "", fmt.Errorf("Node not found: %s", node)
+		}
+
+		if cluster.Primary.ID == "" || node.Primary.ID == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", cluster.Primary.ID, node.Primary.ID)
+		}
+		return fmt.Sprintf("%s/%s", cluster.Primary.ID, node.Primary.ID), nil
+	}
 }

--- a/flexibleengine/resource_flexibleengine_cce_node_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_cce_node_v3_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/huaweicloud/golangsdk/openstack/cce/v3/nodes"
 )
 
-func TestAccCCENodesV3_basic(t *testing.T) {
+func TestAccCCENodeV3_basic(t *testing.T) {
 	var node nodes.Nodes
 	var cceName = fmt.Sprintf("terra-test-%s", acctest.RandString(5))
 	resourceName := "flexibleengine_cce_node_v3.node_1"
@@ -28,12 +28,16 @@ func TestAccCCENodesV3_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", "test-node"),
 					resource.TestCheckResourceAttr(resourceName, "flavor_id", "s1.medium"),
 					resource.TestCheckResourceAttr(resourceName, "status", "Active"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 				),
 			},
 			{
 				Config: testAccCCENodeV3_update(cceName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "test-node2"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 				),
 			},
 		},
@@ -128,6 +132,7 @@ resource "flexibleengine_cce_node_v3" "node_1" {
   flavor_id         = "s1.medium"
   availability_zone = "%s"
   key_pair          = "%s"
+
   root_volume {
     size       = 40
     volumetype = "SATA"
@@ -135,6 +140,10 @@ resource "flexibleengine_cce_node_v3" "node_1" {
   data_volumes {
     size       = 100
     volumetype = "SATA"
+  }
+  tags = {
+    key = "value"
+    foo = "bar"
   }
 }`, cceName, OS_VPC_ID, OS_NETWORK_ID, OS_AVAILABILITY_ZONE, OS_KEYPAIR_NAME)
 }
@@ -156,6 +165,7 @@ resource "flexibleengine_cce_node_v3" "node_1" {
   flavor_id         = "s1.medium"
   availability_zone = "%s"
   key_pair          = "%s"
+
   root_volume {
     size       = 40
     volumetype = "SATA"
@@ -163,6 +173,10 @@ resource "flexibleengine_cce_node_v3" "node_1" {
   data_volumes {
     size       = 100
     volumetype = "SATA"
+  }
+  tags = {
+    key   = "value1"
+    owner = "terraform"
   }
 }`, cceName, OS_VPC_ID, OS_NETWORK_ID, OS_AVAILABILITY_ZONE, OS_KEYPAIR_NAME)
 }


### PR DESCRIPTION
- add expandResourceCCE* functions to make the Read more clearly;
- add acc checks for tags

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCCENodeV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCCENodeV3_basic -timeout 720m
=== RUN   TestAccCCENodeV3_basic
--- PASS: TestAccCCENodeV3_basic (1975.14s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 1975.151s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCCENodeV3_importBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCCENodeV3_importBasic -timeout 720m
=== RUN   TestAccCCENodeV3_importBasic
--- PASS: TestAccCCENodeV3_importBasic (1921.50s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 1921.517s
```