### PR TITLE
cce node pool: make taints and labels be updatable

### DIFF
--- a/docs/resources/cce_node_pool_v3.md
+++ b/docs/resources/cce_node_pool_v3.md
@@ -89,8 +89,7 @@ The following arguments are supported:
 
 * `priority` - (Optional, Int) Weight of a node pool. A node pool with a higher weight has a higher priority during scaling.
 
-* `labels` - (Optional, Map, ForceNew) Tags of a Kubernetes node, key/value pair format.
-    Changing this parameter will create a new resource.
+* `labels` - (Optional, Map) Tags of a Kubernetes node, key/value pair format.
 
 * `tags` - (Optional, Map) Tags of a VM node, key/value pair format.
 
@@ -100,7 +99,7 @@ The following arguments are supported:
 * `data_volumes` - (Required, List, ForceNew) Represents the data disk to be created.
     The object structure is documented below. Changing this parameter will create a new resource.
 
-* `taints` - (Optional, List, ForceNew) You can add taints to created nodes to configure anti-affinity.
+* `taints` - (Optional, List) You can add taints to created nodes to configure anti-affinity.
     The object structure is documented below.
 
 The `root_volume` block supports:
@@ -121,7 +120,7 @@ The `data_volumes` block supports:
 
 The `taints` block supports:
     
-* `key` - (Required, String, ForceNew) A key must contain 1 to 63 characters starting with a letter or digit.
+* `key` - (Required, String) A key must contain 1 to 63 characters starting with a letter or digit.
   Only letters, digits, hyphens (-), underscores (_), and periods (.) are allowed.
   A DNS subdomain name can be used as the prefix of a key.
     

--- a/flexibleengine/resource_flexibleengine_cce_node_pool_test.go
+++ b/flexibleengine/resource_flexibleengine_cce_node_pool_test.go
@@ -35,6 +35,10 @@ func TestAccCCENodePool_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "min_node_count", "0"),
 					resource.TestCheckResourceAttr(resourceName, "max_node_count", "0"),
 					resource.TestCheckResourceAttr(resourceName, "max_pods", "200"),
+					resource.TestCheckResourceAttr(resourceName, "taints.0.key", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "taints.0.value", "foo"),
+					resource.TestCheckResourceAttr(resourceName, "taints.0.effect", "NoSchedule"),
+					resource.TestCheckResourceAttr(resourceName, "labels.pool", "acc-test-pool"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 				),
@@ -49,6 +53,10 @@ func TestAccCCENodePool_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "max_node_count", "9"),
 					resource.TestCheckResourceAttr(resourceName, "scale_down_cooldown_time", "100"),
 					resource.TestCheckResourceAttr(resourceName, "priority", "1"),
+					resource.TestCheckResourceAttr(resourceName, "taints.0.key", "looks"),
+					resource.TestCheckResourceAttr(resourceName, "taints.0.value", "bad"),
+					resource.TestCheckResourceAttr(resourceName, "taints.0.effect", "NoExecute"),
+					resource.TestCheckResourceAttr(resourceName, "labels.pool", "acc-test-pool-update"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 				),
@@ -177,6 +185,14 @@ resource "flexibleengine_cce_node_pool_v3" "test" {
     volumetype = "SSD"
   }
 
+  taints {
+    key    = "bar"
+    value  = "foo"
+    effect = "NoSchedule"
+  }
+  labels = {
+    pool = "acc-test-pool"
+  }
   tags = {
     key = "value"
     foo = "bar"
@@ -213,6 +229,14 @@ resource "flexibleengine_cce_node_pool_v3" "test" {
     volumetype = "SSD"
   }
 
+  taints {
+    key    = "looks"
+    value  = "bad"
+    effect = "NoExecute"
+  }
+  labels = {
+    pool = "acc-test-pool-update"
+  }
   tags = {
     key   = "value1"
     owner = "terraform"


### PR DESCRIPTION
fixes #549 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCCENodePool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCCENodePool_basic -timeout 720m
=== RUN   TestAccCCENodePool_basic
=== PAUSE TestAccCCENodePool_basic
=== CONT  TestAccCCENodePool_basic
--- PASS: TestAccCCENodePool_basic (2217.30s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 2217.322s
```