### PR TITLE
support default encryption for an oss bucket

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -158,6 +158,10 @@ The following arguments are supported:
 * `versioning` - (Optional) Whether enable versioning. Once you version-enable a bucket, it can never return to an unversioned state.
   You can, however, suspend versioning on that bucket.
 
+* `encryption` - (Optional) Whether enable default server-side encryption of the bucket in SSE-KMS mode.
+
+* `kms_key_id` - (Optional) Specifies the ID of a kms key. If omitted, the default master key will be used.
+
 * `logging` - (Optional) A settings of bucket logging (documented below).
 * `website` - (Optional) A website object (documented below).
 * `cors_rule` - (Optional) A rule of Cross-Origin Resource Sharing (documented below).

--- a/flexibleengine/resource_flexibleengine_obs_bucket_test.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket_test.go
@@ -26,6 +26,7 @@ func TestAccObsBucket_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "bucket_domain_name", testAccObsBucketDomainName(rInt)),
 					resource.TestCheckResourceAttr(resourceName, "acl", "private"),
 					resource.TestCheckResourceAttr(resourceName, "storage_class", "STANDARD"),
+					resource.TestCheckResourceAttr(resourceName, "encryption", "false"),
 					resource.TestCheckResourceAttr(resourceName, "multi_az", "false"),
 					resource.TestCheckResourceAttr(resourceName, "region", OS_REGION_NAME),
 				),

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210602080359-3d6e5cdfc40f
+	github.com/huaweicloud/golangsdk v0.0.0-20210616094011-88532780cf01
 	github.com/huaweicloud/terraform-provider-huaweicloud v1.23.1-0.20210406030556-c63d7fdb3533
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jtolds/gls v4.20.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -225,10 +225,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huaweicloud/golangsdk v0.0.0-20210402075152-aba310c2a950 h1:Ys3DRL6qJGYL/9mX8gvzSQade5TOJi8COrPyG58HOQs=
 github.com/huaweicloud/golangsdk v0.0.0-20210402075152-aba310c2a950/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/golangsdk v0.0.0-20210528023633-c90ae4249a71 h1:o2s9CcW277XbOQp0EolTCWHrNdBUHCjuu0aKtAedF/k=
-github.com/huaweicloud/golangsdk v0.0.0-20210528023633-c90ae4249a71/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
-github.com/huaweicloud/golangsdk v0.0.0-20210602080359-3d6e5cdfc40f h1:7FSmwn+mnDmezxuOjfDotwmyxQCQOU1waZDLORl7kGc=
-github.com/huaweicloud/golangsdk v0.0.0-20210602080359-3d6e5cdfc40f/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210616094011-88532780cf01 h1:5d6ZpTOFXe7NIyGHafxlfsxOx3o9p0GOFFK3Q9xgX7o=
+github.com/huaweicloud/golangsdk v0.0.0-20210616094011-88532780cf01/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.23.1-0.20210406030556-c63d7fdb3533 h1:T1XFVhGzVwLMahLUK8/ww//Mls8fZ1BXTi2CpJswL0k=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.23.1-0.20210406030556-c63d7fdb3533/go.mod h1:GJUvfnw1G3LjHIXsYO+quUH86842c06MvVaeIFqingk=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/common/structs/structs.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/common/structs/structs.go
@@ -1,0 +1,9 @@
+package structs
+
+type ChargeInfo struct {
+	ChargeMode  string `json:"charge_mode" required:"true"`
+	PeriodType  string `json:"period_type,omitempty"`
+	PeriodNum   int    `json:"period_num,omitempty"`
+	IsAutoRenew string `json:"is_auto_renew,omitempty"`
+	IsAutoPay   string `json:"is_auto_pay,omitempty"`
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/eips/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/eips/requests.go
@@ -2,6 +2,7 @@ package eips
 
 import (
 	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/common/structs"
 	"github.com/huaweicloud/golangsdk/pagination"
 )
 
@@ -16,6 +17,9 @@ type ApplyOpts struct {
 	IP                  PublicIpOpts  `json:"publicip" required:"true"`
 	Bandwidth           BandwidthOpts `json:"bandwidth" required:"true"`
 	EnterpriseProjectID string        `json:"enterprise_project_id,omitempty"`
+
+	//ExtendParam is only valid by v2.0 client
+	ExtendParam *structs.ChargeInfo `json:"extendParam,omitempty"`
 }
 
 type PublicIpOpts struct {

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/eips/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/eips/results.go
@@ -11,11 +11,20 @@ type ApplyResult struct {
 }
 
 func (r ApplyResult) Extract() (PublicIp, error) {
-	var ip struct {
-		Ip PublicIp `json:"publicip"`
+	var ipResp struct {
+		IP         PublicIp `json:"publicip"`
+		OrderID    string   `json:"order_id"`
+		PublicipID string   `json:"publicip_id"`
 	}
-	err := r.Result.ExtractInto(&ip)
-	return ip.Ip, err
+	err := r.Result.ExtractInto(&ipResp)
+	if ipResp.PublicipID != "" {
+		ipResp.IP.ID = ipResp.PublicipID
+	}
+	if ipResp.OrderID != "" {
+		ipResp.IP.OrderID = ipResp.OrderID
+	}
+
+	return ipResp.IP, err
 }
 
 //PublicIp is a struct that represents a public ip
@@ -27,6 +36,7 @@ type PublicIp struct {
 	PrivateAddress      string `json:"private_ip_address"`
 	PortID              string `json:"port_id"`
 	TenantID            string `json:"tenant_id"`
+	OrderID             string `json:"order_id"`
 	CreateTime          string `json:"create_time"`
 	BandwidthID         string `json:"bandwidth_id"`
 	BandwidthSize       int    `json:"bandwidth_size"`
@@ -40,11 +50,11 @@ type GetResult struct {
 }
 
 func (r GetResult) Extract() (PublicIp, error) {
-	var Ip struct {
-		Ip PublicIp `json:"publicip"`
+	var getResp struct {
+		IP PublicIp `json:"publicip"`
 	}
-	err := r.Result.ExtractInto(&Ip)
-	return Ip.Ip, err
+	err := r.Result.ExtractInto(&getResp)
+	return getResp.IP, err
 }
 
 //DeleteResult is a struct of delete result

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/client.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/client.go
@@ -662,6 +662,45 @@ func (obsClient ObsClient) DeleteBucketLifecycleConfiguration(bucketName string,
 	return
 }
 
+// SetBucketEncryption sets the default server-side encryption for a bucket.
+//
+// You can use this API to create or update the default server-side encryption for a bucket.
+func (obsClient ObsClient) SetBucketEncryption(input *SetBucketEncryptionInput, extensions ...extensionOptions) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("SetBucketEncryptionInput is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("SetBucketEncryption", HTTP_PUT, input.Bucket, input, output, extensions)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+// GetBucketEncryption gets the encryption configuration of a bucket.
+//
+// You can use this API to obtain obtain the encryption configuration of a bucket.
+func (obsClient ObsClient) GetBucketEncryption(bucketName string, extensions ...extensionOptions) (output *GetBucketEncryptionOutput, err error) {
+	output = &GetBucketEncryptionOutput{}
+	err = obsClient.doActionWithBucket("GetBucketEncryption", HTTP_GET, bucketName, newSubResourceSerial(SubResourceEncryption), output, extensions)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+// DeleteBucketEncryption deletes the encryption configuration of a bucket.
+//
+// You can use this API to delete the encryption configuration of a bucket.
+func (obsClient ObsClient) DeleteBucketEncryption(bucketName string, extensions ...extensionOptions) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("DeleteBucketEncryption", HTTP_DELETE, bucketName, newSubResourceSerial(SubResourceEncryption), output, extensions)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
 // SetBucketTagging sets bucket tags.
 //
 // You can use this API to set bucket tags.

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/const.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/const.go
@@ -255,6 +255,7 @@ var (
 		"delete":                       true,
 		"cors":                         true,
 		"restore":                      true,
+		"encryption":                   true,
 		"tagging":                      true,
 		"append":                       true,
 		"position":                     true,
@@ -706,6 +707,9 @@ const (
 
 	// SubResourceNotification subResource value: notification
 	SubResourceNotification SubResourceType = "notification"
+
+	// SubResourceEncryption subResource value: encryption
+	SubResourceEncryption SubResourceType = "encryption"
 
 	// SubResourceTagging subResource value: tagging
 	SubResourceTagging SubResourceType = "tagging"

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/convert.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/convert.go
@@ -406,6 +406,31 @@ func ConvertLifecyleConfigurationToXml(input BucketLifecyleConfiguration, return
 	return
 }
 
+// ConvertEncryptionConfigurationToXml converts BucketEncryptionConfiguration value to XML data and returns it
+func ConvertEncryptionConfigurationToXml(input BucketEncryptionConfiguration, returnMd5 bool, isObs bool) (data string, md5 string) {
+	xml := make([]string, 0, 5)
+	xml = append(xml, "<ServerSideEncryptionConfiguration><Rule><ApplyServerSideEncryptionByDefault>")
+
+	algorithm := XmlTranscoding(input.SSEAlgorithm)
+	xml = append(xml, fmt.Sprintf("<SSEAlgorithm>%s</SSEAlgorithm>", algorithm))
+
+	if input.KMSMasterKeyID != "" {
+		kmsKeyID := XmlTranscoding(input.KMSMasterKeyID)
+		xml = append(xml, fmt.Sprintf("<KMSMasterKeyID>%s</KMSMasterKeyID>", kmsKeyID))
+	}
+	if input.ProjectID != "" {
+		projectID := XmlTranscoding(input.ProjectID)
+		xml = append(xml, fmt.Sprintf("<ProjectID>%s</ProjectID>", projectID))
+	}
+
+	xml = append(xml, "</ApplyServerSideEncryptionByDefault></Rule></ServerSideEncryptionConfiguration>")
+	data = strings.Join(xml, "")
+	if returnMd5 {
+		md5 = Base64Md5([]byte(data))
+	}
+	return
+}
+
 func converntFilterRulesToXML(filterRules []FilterRule, isObs bool) string {
 	if length := len(filterRules); length > 0 {
 		xml := make([]string, 0, length*4)

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/model.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/model.go
@@ -613,6 +613,26 @@ type GetBucketLifecycleConfigurationOutput struct {
 	BucketLifecyleConfiguration
 }
 
+// BucketEncryptionConfiguration defines the bucket encryption configuration
+type BucketEncryptionConfiguration struct {
+	XMLName        xml.Name `xml:"ServerSideEncryptionConfiguration"`
+	SSEAlgorithm   string   `xml:"Rule>ApplyServerSideEncryptionByDefault>SSEAlgorithm"`
+	KMSMasterKeyID string   `xml:"Rule>ApplyServerSideEncryptionByDefault>KMSMasterKeyID,omitempty"`
+	ProjectID      string   `xml:"Rule>ApplyServerSideEncryptionByDefault>ProjectID,omitempty"`
+}
+
+// SetBucketEncryptionInput is the input parameter of SetBucketEncryption function
+type SetBucketEncryptionInput struct {
+	Bucket string `xml:"-"`
+	BucketEncryptionConfiguration
+}
+
+// GetBucketEncryptionOutput is the result of GetBucketEncryption function
+type GetBucketEncryptionOutput struct {
+	BaseModel
+	BucketEncryptionConfiguration
+}
+
 // Tag defines tag property in BucketTagging
 type Tag struct {
 	XMLName xml.Name `xml:"Tag"`

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/obs/trait.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/obs/trait.go
@@ -335,6 +335,12 @@ func (input SetBucketLifecycleConfigurationInput) trans(isObs bool) (params map[
 	return
 }
 
+func (input SetBucketEncryptionInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourceEncryption): ""}
+	data, _ = ConvertEncryptionConfigurationToXml(input.BucketEncryptionConfiguration, false, isObs)
+	return
+}
+
 func (input SetBucketTaggingInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
 	params = map[string]string{string(SubResourceTagging): ""}
 	data, md5, err := ConvertRequestToIoReaderV2(input)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -261,7 +261,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210602080359-3d6e5cdfc40f
+# github.com/huaweicloud/golangsdk v0.0.0-20210616094011-88532780cf01
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -283,6 +283,7 @@ github.com/huaweicloud/golangsdk/openstack/cce/v3/clusters
 github.com/huaweicloud/golangsdk/openstack/cce/v3/nodepools
 github.com/huaweicloud/golangsdk/openstack/cce/v3/nodes
 github.com/huaweicloud/golangsdk/openstack/cloudeyeservice/alarmrule
+github.com/huaweicloud/golangsdk/openstack/common/structs
 github.com/huaweicloud/golangsdk/openstack/common/tags
 github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/attachinterfaces
 github.com/huaweicloud/golangsdk/openstack/compute/v2/extensions/availabilityzones


### PR DESCRIPTION
fixes #419 
fixes #252 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccObsBucket_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccObsBucket_basic -timeout 720m
=== RUN   TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (23.06s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 23.079s
```