### PR TITLE
config: set RegionProjectIDMap as early as possible

### DIFF
--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/pathorcontents"
-	"github.com/hashicorp/terraform-plugin-sdk/httpclient"
 	"github.com/huaweicloud/golangsdk"
 	huaweisdk "github.com/huaweicloud/golangsdk/openstack"
 	"github.com/huaweicloud/golangsdk/openstack/identity/v3/domains"
@@ -109,7 +108,7 @@ func genClient(c *Config, ao golangsdk.AuthOptionsProvider) (*golangsdk.Provider
 	}
 
 	// Set UserAgent
-	client.UserAgent.Prepend(httpclient.TerraformUserAgent(c.TerraformVersion))
+	client.UserAgent.Prepend("terraform-provider-flexibleengine")
 
 	config, err := generateTLSConfig(c)
 	if err != nil {

--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -50,6 +50,10 @@ func (c *Config) LoadAndValidate() error {
 		return err
 	}
 
+	if c.HwClient != nil && c.HwClient.ProjectID != "" {
+		c.RegionProjectIDMap[c.Region] = c.HwClient.ProjectID
+	}
+
 	// set DomainID for IAM resource
 	if c.DomainID == "" {
 		if domainID, err := c.getDomainID(); err == nil {


### PR DESCRIPTION
fixes #548 

When the rds is located in sub project under a region, the provider will use the project id of the region rather than the sub project.
Setting the project id to Config.RegionProjectIDMap will fix it.

This PR wil also update the User-Agent to "terraform-provider-flexibleengine".