### PR TITLE
waf: add domain resource

### DIFF
--- a/docs/resources/waf_domain.md
+++ b/docs/resources/waf_domain.md
@@ -1,0 +1,114 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# flexibleengine_waf_domain
+
+Manages a WAF domain resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_waf_certificate" "certificate_1" {
+  name        = "cert_1"
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIFazCCA1OgAwIBAgIUN3w1KX8/T/HWVxZIOdHXPhUOnsAwDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+...
+dKvZbPEsygYRIjwyhHHUh/YXH8KDI/uu6u6AxDckQ3rP1BkkKXr5NPBGjVgM3ZI=
+-----END CERTIFICATE-----
+EOT
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIJQQIBADANBgkqhkiG9w0BAQEFAASCCSswggknAgEAAoICAQC+9uwFVenCdPD9
+5LWSWMuy4riZW718wxBpYV5Y9N8nM7N0qZLLdpImZrzBbaBldTI+AZGI3Nupuurw
+...
+s9urs/Kk/tbQhsEvu0X8FyGwo0zH6rG8apTFTlac+v4mJ4vlpxSvT5+FW2lgLISE
++4sM7kp0qO3/p+45HykwBY5iHq3H
+-----END PRIVATE KEY-----
+EOT
+}
+
+resource "flexibleengine_waf_domain" "domain_1" {
+  domain          = "www.example.com"
+  certificate_id  = flexibleengine_waf_certificate.certificate_1.id
+  proxy           = true
+  sip_header_name = "default"
+  sip_header_list = ["X-Forwarded-For"]
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "90.84.181.77"
+    port            = "8080"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain` - (Required, String, ForceNew) Specifies the domain name to be protected. For example, www.example.com or *.example.com.
+  Changing this creates a new domain.
+
+* `server` - (Required, List) Specifies an array of origin web servers. The object structure is documented below.
+
+* `certificate_id` - (Optional, String) Specifies the certificate ID. This parameter is mandatory when `client_protocol` is set to HTTPS.
+
+* `policy_id` - (Optional, String, ForceNew) Specifies the policy ID associated with the domain.
+  If not specified, a new policy will be created automatically. Changing this create a new domain.
+
+* `keep_proxy` - (Optional, Bool) Specifies whether to retain the policy when deleting a domain name. Defaults to true.
+
+* `proxy` - (Optional, Bool) Specifies whether a proxy is configured.
+
+* `sip_header_name` - (Optional, String) Specifies the type of the source IP header.
+  This parameter is required only when proxy is set to true. The options are as follows:
+  *default*, *cloudflare*, *akamai*, and *custom*.
+
+* `sip_header_list` - (Optional, List) Specifies an array of HTTP request header for identifying the real source IP address.
+  This parameter is required only when proxy is set to true.
+  - If `sip_header_name` is *default*, the value is ["X-Forwarded-For"].
+  - If `sip_header_name` is *cloudflare*, the value is ["CF-Connecting-IP", "X-Forwarded-For"].
+  - If `sip_header_name` is *akamai*, the value is ["True-Client-IP"].
+  - If `sip_header_name` is *custom*, you can customize a value.
+
+The `server` block supports:
+
+* `client_protocol` - (Required, String) Protocol type of the client. The options are *HTTP* and *HTTPS*.
+
+* `server_protocol` - (Required, String) Protocol used by WAF to forward client requests to the server.
+  The options are *HTTP* and *HTTPS*.
+
+* `address` - (Required, String) IP address or domain name of the web server that the client accesses.
+  For example, 192.168.1.1 or www.a.com.
+
+* `port` - (Required, Int) Port number used by the web server. The value ranges from 0 to 65535, for example, 8080.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` -  ID of the domain.
+
+* `cname` - The CNAME value.
+
+* `txt_code` - The TXT record. This attribute is returned only when proxy is set to true.
+
+* `sub_domain` - The subdomain name. This attribute is returned only when proxy is set to true.
+
+* `protect_status` - The WAF mode. -1: bypassed, 0: disabled, 1: enabled.
+
+* `access_status` - Whether a domain name is connected to WAF. 0: The domain name is not connected to WAF, 1: The domain name is connected to WAF.
+
+* `protocol` - The protocol type of the client. The options are HTTP, HTTPS, and HTTP&HTTPS.
+
+## Import
+
+Domains can be imported using the `id`, e.g.
+
+```sh
+terraform import flexibleengine_waf_domain.dom_1 7117d38e-4c8f-4624-a505-bd96b97d024c
+```

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -324,6 +324,7 @@ func Provider() terraform.ResourceProvider {
 			"flexibleengine_vpcep_endpoint":                     resourceVPCEndpoint(),
 			"flexibleengine_vpcep_service":                      resourceVPCEndpointService(),
 			"flexibleengine_waf_certificate":                    resourceWafCertificateV1(),
+			"flexibleengine_waf_domain":                         resourceWafDomainV1(),
 			"flexibleengine_waf_policy":                         resourceWafPolicyV1(),
 
 			// Deprecated resource

--- a/flexibleengine/resource_flexibleengine_waf_domain.go
+++ b/flexibleengine/resource_flexibleengine_waf_domain.go
@@ -1,0 +1,321 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/huaweicloud/golangsdk/openstack/waf/v1/domains"
+	"github.com/huaweicloud/golangsdk/openstack/waf/v1/policies"
+)
+
+func resourceWafDomainV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceWafDomainV1Create,
+		Read:   resourceWafDomainV1Read,
+		Update: resourceWafDomainV1Update,
+		Delete: resourceWafDomainV1Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"server": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: false,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"client_protocol": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"server_protocol": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"address": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"port": {
+							Type:         schema.TypeInt,
+							ValidateFunc: validation.IntBetween(0, 65535),
+							Required:     true,
+						},
+					},
+				},
+			},
+			"certificate_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"policy_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"proxy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"sip_header_name": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"default", "cloudflare", "akamai", "custom"}, true),
+			},
+			"sip_header_list": {
+				Type:         schema.TypeList,
+				Optional:     true,
+				RequiredWith: []string{"sip_header_name"},
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"keep_policy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
+			"cname": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"txt_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"sub_domain": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"protect_status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"access_status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"protocol": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func buildWafDomainServers(d *schema.ResourceData) []domains.ServerOpts {
+	servers := d.Get("server").([]interface{})
+
+	serverOpts := make([]domains.ServerOpts, len(servers))
+	for i, v := range servers {
+		server := v.(map[string]interface{})
+		serverOpts[i] = domains.ServerOpts{
+			ClientProtocol: server["client_protocol"].(string),
+			ServerProtocol: server["server_protocol"].(string),
+			Address:        server["address"].(string),
+			Port:           strconv.Itoa(server["port"].(int)),
+		}
+	}
+
+	log.Printf("[DEBUG] build WAF domain ServerOpts: %#v", serverOpts)
+	return serverOpts
+}
+
+func resourceWafDomainV1Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Client: %s", err)
+	}
+
+	var hosts []string
+	if v, ok := d.GetOk("policy_id"); ok {
+		policyID := v.(string)
+		policy, err := policies.Get(wafClient, policyID).Extract()
+		if err != nil {
+			return fmt.Errorf("error retrieving Waf Policy %s: %s", policyID, err)
+		}
+		hosts = append(hosts, policy.Hosts...)
+	}
+
+	proxy := d.Get("proxy").(bool)
+	if _, ok := d.GetOk("sip_header_name"); ok && !proxy {
+		return fmt.Errorf("sip_header_name is only valid when proxy is true")
+	}
+	v := d.Get("sip_header_list").([]interface{})
+	headers := make([]string, len(v))
+	for i, v := range v {
+		headers[i] = v.(string)
+	}
+
+	createOpts := domains.CreateOpts{
+		HostName:      d.Get("domain").(string),
+		CertificateId: d.Get("certificate_id").(string),
+		Servers:       buildWafDomainServers(d),
+		Proxy:         &proxy,
+		SipHeaderName: d.Get("sip_header_name").(string),
+		SipHeaderList: headers,
+	}
+	log.Printf("[DEBUG] CreateOpts: %#v", createOpts)
+
+	domain, err := domains.Create(wafClient, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("error creating WAF Domain: %s", err)
+	}
+
+	log.Printf("[DEBUG] Waf domain created: %#v", domain)
+	d.SetId(domain.Id)
+
+	if v, ok := d.GetOk("policy_id"); ok {
+		policyID := v.(string)
+		hosts = append(hosts, d.Id())
+		updateHostsOpts := policies.UpdateHostsOpts{
+			Hosts: hosts,
+		}
+
+		log.Printf("[DEBUG] Bind Waf domain %s to policy %s", d.Id(), policyID)
+		_, err = policies.UpdateHosts(wafClient, policyID, updateHostsOpts).Extract()
+		if err != nil {
+			return fmt.Errorf("error updating WAF Policy Hosts: %s", err)
+		}
+
+		// delete the policy that was auto-created by domain
+		err = policies.Delete(wafClient, domain.PolicyID).ExtractErr()
+		if err != nil {
+			log.Printf("[WARN] error deleting WAF Policy %s: %s", domain.PolicyID, err)
+		}
+	}
+
+	return resourceWafDomainV1Read(d, meta)
+}
+
+func resourceWafDomainV1Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	n, err := domains.Get(wafClient, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "WAF Domain")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("region", GetRegion(d, config)),
+		d.Set("domain", n.HostName),
+		d.Set("certificate_id", n.CertificateId),
+		d.Set("policy_id", n.PolicyID),
+		d.Set("proxy", n.Proxy),
+		d.Set("sip_header_name", n.SipHeaderName),
+		d.Set("sip_header_list", n.SipHeaderList),
+		d.Set("cname", n.Cname),
+		d.Set("txt_code", n.TxtCode),
+		d.Set("sub_domain", n.SubDomain),
+		d.Set("protect_status", n.ProtectStatus),
+		d.Set("access_status", n.AccessStatus),
+		d.Set("protocol", n.Protocol),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmt.Errorf("error setting WAF fields: %s", err)
+	}
+
+	servers := make([]map[string]interface{}, len(n.Servers))
+	for i, server := range n.Servers {
+		servers[i] = map[string]interface{}{
+			"client_protocol": server.ClientProtocol,
+			"server_protocol": server.ServerProtocol,
+			"address":         server.Address,
+			"port":            server.Port,
+		}
+	}
+	d.Set("server", servers)
+
+	return nil
+}
+
+func resourceWafDomainV1Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Client: %s", err)
+	}
+
+	if d.HasChanges("certificate_id", "server", "proxy", "sip_header_name", "sip_header_list") {
+		proxy := d.Get("proxy").(bool)
+		headerName := d.Get("sip_header_name").(string)
+		if headerName != "" && !proxy {
+			return fmt.Errorf("sip_header_name is only valid when proxy is true")
+		}
+
+		updateOpts := domains.UpdateOpts{
+			CertificateId: d.Get("certificate_id").(string),
+			Servers:       buildWafDomainServers(d),
+			Proxy:         &proxy,
+			SipHeaderName: headerName,
+		}
+
+		v := d.Get("sip_header_list").([]interface{})
+		headers := make([]string, len(v))
+		for i, v := range v {
+			headers[i] = v.(string)
+		}
+		updateOpts.SipHeaderList = headers
+
+		log.Printf("[DEBUG] updateOpts: %#v", updateOpts)
+
+		_, err = domains.Update(wafClient, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return fmt.Errorf("error updating WAF Domain: %s", err)
+		}
+	}
+	return resourceWafDomainV1Read(d, meta)
+}
+
+func resourceWafDomainV1Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	delOpts := domains.DeleteOpts{
+		KeepPolicy: d.Get("keep_policy").(bool),
+	}
+
+	err = domains.Delete(wafClient, d.Id(), delOpts).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("error deleting WAF Domain: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/flexibleengine/resource_flexibleengine_waf_domain_test.go
+++ b/flexibleengine/resource_flexibleengine_waf_domain_test.go
@@ -1,0 +1,214 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/huaweicloud/golangsdk/openstack/waf/v1/domains"
+)
+
+func TestAccWafDomainV1_basic(t *testing.T) {
+	var domain domains.Domain
+	resourceName := "flexibleengine_waf_domain.domain_1"
+	randName := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckWafDomainV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDomainV1_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDomainV1Exists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "domain", fmt.Sprintf("www.%s.com", randName)),
+					resource.TestCheckResourceAttr(resourceName, "proxy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8080"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "cname"),
+				),
+			},
+			{
+				Config: testAccWafDomainV1_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDomainV1Exists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8443"),
+					resource.TestCheckResourceAttr(resourceName, "proxy", "true"),
+					resource.TestCheckResourceAttr(resourceName, "sip_header_name", "default"),
+					resource.TestCheckResourceAttrSet(resourceName, "sub_domain"),
+					resource.TestCheckResourceAttrSet(resourceName, "txt_code"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"keep_policy"},
+			},
+		},
+	})
+}
+
+func TestAccWafDomainV1_policy(t *testing.T) {
+	var domain domains.Domain
+	resourceName := "flexibleengine_waf_domain.domain_1"
+	randName := acctest.RandString(10)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckWafDomainV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDomainV1_policy(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDomainV1Exists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "domain", fmt.Sprintf("www.%s.com", randName)),
+					resource.TestCheckResourceAttr(resourceName, "proxy", "true"),
+					resource.TestCheckResourceAttr(resourceName, "sip_header_name", "default"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8080"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "cname"),
+					resource.TestCheckResourceAttrSet(resourceName, "sub_domain"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckWafDomainV1Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	wafClient, err := config.WafV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_waf_domain" {
+			continue
+		}
+
+		_, err := domains.Get(wafClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Waf domain still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafDomainV1Exists(n string, domain *domains.Domain) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		wafClient, err := config.WafV1Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+		}
+
+		found, err := domains.Get(wafClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("Waf domain not found")
+		}
+
+		*domain = *found
+
+		return nil
+	}
+}
+
+func testAccWafDomainV1_basic(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_networking_floatingip_v2" "fip_1" {
+}
+
+%s
+
+resource "flexibleengine_waf_domain" "domain_1" {
+  domain         = "www.%s.com"
+  certificate_id = flexibleengine_waf_certificate.certificate_1.id
+  keep_policy    = false
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = flexibleengine_networking_floatingip_v2.fip_1.address
+    port            = 8080
+  }
+}
+`, testAccWafCertificateV1_conf(name), name)
+}
+
+func testAccWafDomainV1_update(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_networking_floatingip_v2" "fip_1" {
+}
+
+%s
+
+resource "flexibleengine_waf_domain" "domain_1" {
+  domain          = "www.%s.com"
+  certificate_id  = flexibleengine_waf_certificate.certificate_1.id
+  keep_policy     = false
+  proxy           = true
+  sip_header_name = "default"
+  sip_header_list = ["X-Forwarded-For"]
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = flexibleengine_networking_floatingip_v2.fip_1.address
+    port            = 8443
+  }
+}
+`, testAccWafCertificateV1_conf(name), name)
+}
+
+func testAccWafDomainV1_policy(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_networking_floatingip_v2" "fip_1" {
+}
+
+%s
+
+resource "flexibleengine_waf_policy" "policy_1" {
+  name = "policy_%s"
+}
+
+resource "flexibleengine_waf_domain" "domain_1" {
+  domain          = "www.%s.com"
+  certificate_id  = flexibleengine_waf_certificate.certificate_1.id
+  policy_id       = flexibleengine_waf_policy.policy_1.id
+  proxy           = true
+  sip_header_name = "default"
+  sip_header_list = ["X-Forwarded-For"]
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = flexibleengine_networking_floatingip_v2.fip_1.address
+    port            = 8080
+  }
+}
+`, testAccWafCertificateV1_conf(name), name, name)
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210618085032-346d1a790f57
+	github.com/huaweicloud/golangsdk v0.0.0-20210619075926-bc59084e8485
 	github.com/huaweicloud/terraform-provider-huaweicloud v1.25.1-0.20210617120809-f8e7bbf67cb6
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jtolds/gls v4.20.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20210616094011-88532780cf01 h1:5d6ZpTOFX
 github.com/huaweicloud/golangsdk v0.0.0-20210616094011-88532780cf01/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/golangsdk v0.0.0-20210618085032-346d1a790f57 h1:skuLDHrV5i+CEO7vPO2s+fDEQFyQvajXd8WYl9krri0=
 github.com/huaweicloud/golangsdk v0.0.0-20210618085032-346d1a790f57/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210619075926-bc59084e8485 h1:xeJzaCvFOm/myoJJ1EDESXJmuXHCBrK999U5kbyP3AE=
+github.com/huaweicloud/golangsdk v0.0.0-20210619075926-bc59084e8485/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.23.1-0.20210406030556-c63d7fdb3533 h1:T1XFVhGzVwLMahLUK8/ww//Mls8fZ1BXTi2CpJswL0k=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.23.1-0.20210406030556-c63d7fdb3533/go.mod h1:GJUvfnw1G3LjHIXsYO+quUH86842c06MvVaeIFqingk=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.25.1-0.20210617120809-f8e7bbf67cb6 h1:YfTBwEiAHv6jh4PiLbgWQrH9QzsD5j7daL/MpRb4r5k=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/domains/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/domains/requests.go
@@ -1,0 +1,146 @@
+package domains
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+var RequestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToDomainCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new backup.
+type CreateOpts struct {
+	// Domain name
+	HostName string `json:"hostname" required:"true"`
+	// The original server information
+	Servers []ServerOpts `json:"server" required:"true"`
+	// Whether proxy is configured
+	Proxy *bool `json:"proxy" required:"true"`
+	// Certificate ID
+	CertificateId string `json:"certificate_id,omitempty"`
+	// The type of the source IP header
+	SipHeaderName string `json:"sip_header_name,omitempty"`
+	// The HTTP request header for identifying the real source IP.
+	SipHeaderList []string `json:"sip_header_list,omitempty"`
+}
+
+// ServerOpts contains the origin server information.
+type ServerOpts struct {
+	// Protocol type of the client
+	ClientProtocol string `json:"client_protocol" required:"true"`
+	// Protocol used by WAF to forward client requests to the server
+	ServerProtocol string `json:"server_protocol" required:"true"`
+	// IP address or domain name of the web server that the client accesses.
+	Address string `json:"address" required:"true"`
+	// Port number used by the web server, the value ranges from 0 to 65535.
+	Port string `json:"port" required:"true"`
+}
+
+// ToDomainCreateMap builds a create request body from CreateOpts.
+func (opts CreateOpts) ToDomainCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create will create a new Domain based on the values in CreateOpts.
+func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToDomainCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, reqOpt)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToDomainUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains all the values needed to update a Domain.
+type UpdateOpts struct {
+	// Certificate ID
+	CertificateId string `json:"certificate_id,omitempty"`
+	// The original server information
+	Servers []ServerOpts `json:"server,omitempty"`
+	// Whether proxy is configured
+	Proxy *bool `json:"proxy,omitempty"`
+	// The type of the source IP header
+	SipHeaderName string `json:"sip_header_name,omitempty"`
+	// The HTTP request header for identifying the real source IP.
+	SipHeaderList []string `json:"sip_header_list,omitempty"`
+}
+
+// ToDomainUpdateMap builds a update request body from UpdateOpts.
+func (opts UpdateOpts) ToDomainUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Update accepts a UpdateOpts struct and uses the values to update a Domain.The response code from api is 200
+func Update(c *golangsdk.ServiceClient, domainID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToDomainUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Put(resourceURL(c, domainID), b, nil, reqOpt)
+	return
+}
+
+// Get retrieves a particular Domain based on its unique ID.
+func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
+	reqOpt := &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	}
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, reqOpt)
+	return
+}
+
+// DeleteOptsBuilder allows extensions to add additional parameters to the
+// delete request.
+type DeleteOptsBuilder interface {
+	ToDeleteQuery() (string, error)
+}
+
+// DeleteOpts contains all the values needed to delete a domain.
+type DeleteOpts struct {
+	// KeepPolicy specifies whether to retain the policy when deleting a domain name
+	// the default value is false
+	KeepPolicy bool `q:"keepPolicy"`
+}
+
+// ToDeleteQuery builds a delete request body from DeleteOpts.
+func (opts DeleteOpts) ToDeleteQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// Delete will permanently delete a particular Domain based on its unique ID.
+func Delete(c *golangsdk.ServiceClient, id string, opts DeleteOptsBuilder) (r DeleteResult) {
+	url := resourceURL(c, id)
+	if opts != nil {
+		var query string
+		query, r.Err = opts.ToDeleteQuery()
+		if r.Err != nil {
+			return
+		}
+		url += query
+	}
+
+	reqOpt := &golangsdk.RequestOpts{
+		OkCodes:     []int{204},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	}
+	_, r.Err = c.Delete(url, reqOpt)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/domains/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/domains/results.go
@@ -1,0 +1,84 @@
+package domains
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+type Domain struct {
+	// Domain ID
+	Id string `json:"id"`
+	// Domain name
+	HostName string `json:"hostname"`
+	// CNAME value
+	Cname string `json:"cname"`
+	// TXT record
+	TxtCode string `json:"txt_code"`
+	// Sub Domain name
+	SubDomain string `json:"sub_domain"`
+	// Policy ID
+	PolicyID string `json:"policy_id"`
+	// WAF mode: 0 - disabled, 1 - enabled, -1 - bypassed.
+	ProtectStatus int `json:"protect_status"`
+	// Whether a domain name is connected to WAF
+	AccessStatus int `json:"access_status"`
+	// Protocol type
+	Protocol string `json:"protocol"`
+	// Certificate ID
+	CertificateId string `json:"certificate_id"`
+	//The original server information
+	Servers []Server `json:"server"`
+	//Whether proxy is configured
+	Proxy bool `json:"proxy"`
+	//The type of the source IP header
+	SipHeaderName string `json:"sip_header_name"`
+	//The HTTP request header for identifying the real source IP.
+	SipHeaderList []string `json:"sip_header_list"`
+	// the time when the domain is created in unix timestamp
+	TimeStamp int `json:"timestamp"`
+}
+
+type Server struct {
+	// Protocol type of the client
+	ClientProtocol string `json:"client_protocol"`
+	// Protocol used by WAF to forward client requests to the server
+	ServerProtocol string `json:"server_protocol"`
+	// IP address or domain name of the web server that the client accesses.
+	Address string `json:"address"`
+	// Port number used by the web server
+	Port int `json:"port"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a domain.
+func (r commonResult) Extract() (*Domain, error) {
+	var response Domain
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Domain.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of a update operation. Call its Extract
+// method to interpret it as a Domain.
+type UpdateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Domain.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/domains/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/domains/urls.go
@@ -1,0 +1,11 @@
+package domains
+
+import "github.com/huaweicloud/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("instance")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL("instance", id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -261,7 +261,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210618085032-346d1a790f57
+# github.com/huaweicloud/golangsdk v0.0.0-20210619075926-bc59084e8485
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -394,6 +394,7 @@ github.com/huaweicloud/golangsdk/openstack/vbs/v2/policies
 github.com/huaweicloud/golangsdk/openstack/vpcep/v1/endpoints
 github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services
 github.com/huaweicloud/golangsdk/openstack/waf/v1/certificates
+github.com/huaweicloud/golangsdk/openstack/waf/v1/domains
 github.com/huaweicloud/golangsdk/openstack/waf/v1/policies
 github.com/huaweicloud/golangsdk/pagination
 # github.com/huaweicloud/terraform-provider-huaweicloud v1.25.1-0.20210617120809-f8e7bbf67cb6


### PR DESCRIPTION
related to #533

add new resource **flexibleengine_waf_domain** to manage a WAF domain resource within FlexibleEngine.

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccWafDomainV1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccWafDomainV1 -timeout 720m
=== RUN   TestAccWafDomainV1_basic
=== PAUSE TestAccWafDomainV1_basic
=== RUN   TestAccWafDomainV1_policy
=== PAUSE TestAccWafDomainV1_policy
=== CONT  TestAccWafDomainV1_basic
=== CONT  TestAccWafDomainV1_policy
--- PASS: TestAccWafDomainV1_policy (31.07s)
--- PASS: TestAccWafDomainV1_basic (41.69s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 41.702s
```