### PR TITLE
waf: add alarm_masking and data_masking resources

### DIFF
--- a/docs/resources/waf_rule_alarm_masking.md
+++ b/docs/resources/waf_rule_alarm_masking.md
@@ -1,0 +1,48 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# flexibleengine_waf_rule_alarm_masking
+
+Manages a WAF False Alarm Masking Rule resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_waf_policy" "policy_1" {
+  name = "policy_1"
+}
+
+resource "flexibleengine_waf_rule_alarm_masking" "rule_1" {
+  policy_id = flexibleengine_waf_policy.policy_1.id
+  path      = "/a"
+  event_id  = "3737fb122f2140f39292f597ad3b7e9a"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_id` - (Required, String, ForceNew) Specifies the WAF policy ID. Changing this creates a new rule.
+
+* `path` - (Required, String) Specifies a misreported URL excluding a domain name.
+
+* `event_id` - (Required, String) Specifies the event ID. It is the ID of a misreported event
+  in Events whose type is not *Custom*.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The rule ID in UUID format.
+* `event_type` - The event type.
+
+## Import
+
+Alarm Masking Rules can be imported using the policy ID and rule ID
+separated by a slash, e.g.:
+
+```sh
+terraform import flexibleengine_waf_rule_alarm_masking.rule_1 44d887434169475794b2717438f7fa78/6cdc116040d444f6b3e1bf1dd629f1d0
+```

--- a/docs/resources/waf_rule_data_masking.md
+++ b/docs/resources/waf_rule_data_masking.md
@@ -1,0 +1,49 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# flexibleengine_waf_rule_data_masking
+
+Manages a WAF Data Masking Rule resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_waf_policy" "policy_1" {
+  name = "policy_1"
+}
+
+resource "flexibleengine_waf_rule_data_masking" "rule_1" {
+  policy_id = flexibleengine_waf_policy.policy_1.id
+  path      = "/login"
+  field     = "params"
+  subfield  = "password"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_id` - (Required, String, ForceNew) Specifies the WAF policy ID. Changing this creates a new rule.
+
+* `path` - (Required, String) Specifies the URL to which the data masking rule applies (exact match by default).
+
+* `field` - (Required, String) Specifies the masked field. The options are *params* and *header*.
+
+* `subfield` - (Required, String) Specifies the masked subfield.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The rule ID in UUID format.
+
+## Import
+
+Data Masking Rules can be imported using the policy ID and rule ID
+separated by a slash, e.g.:
+
+```sh
+terraform import flexibleengine_waf_rule_data_masking.rule_1 523083f4543c497faecd25fcfcc0b2a0/c6482bd0059148559b625f78e8ce92be
+```

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -326,6 +326,8 @@ func Provider() terraform.ResourceProvider {
 			"flexibleengine_waf_certificate":                    resourceWafCertificateV1(),
 			"flexibleengine_waf_domain":                         resourceWafDomainV1(),
 			"flexibleengine_waf_policy":                         resourceWafPolicyV1(),
+			"flexibleengine_waf_rule_alarm_masking":             resourceWafRuleAlarmMasking(),
+			"flexibleengine_waf_rule_data_masking":              resourceWafRuleDataMasking(),
 
 			// Deprecated resource
 			"flexibleengine_rds_instance_v1": resourceRdsInstance(),

--- a/flexibleengine/resource_flexibleengine_waf_rule_alarm_masking.go
+++ b/flexibleengine/resource_flexibleengine_waf_rule_alarm_masking.go
@@ -1,0 +1,132 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	rules "github.com/huaweicloud/golangsdk/openstack/waf/v1/falsealarmmasking_rules"
+)
+
+func resourceWafRuleAlarmMasking() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceWafRuleAlarmMaskingCreate,
+		Read:   resourceWafRuleAlarmMaskingRead,
+		Update: resourceWafRuleAlarmMaskingUpdate,
+		Delete: resourceWafRuleAlarmMaskingDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceWafRulesImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"event_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"event_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceWafRuleAlarmMaskingCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	createOpts := rules.CreateOpts{
+		Path:    d.Get("path").(string),
+		EventID: d.Get("event_id").(string),
+	}
+
+	log.Printf("[DEBUG] WAF Alarm Masking Rule creating opts: %#v", createOpts)
+	rule, err := rules.Create(wafClient, policyID, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Alarm Masking Rule: %s", err)
+	}
+
+	log.Printf("[DEBUG] WAF alarm masking rule created: %#v", rule)
+	d.SetId(rule.Id)
+
+	return resourceWafRuleAlarmMaskingRead(d, meta)
+}
+
+func resourceWafRuleAlarmMaskingRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	n, err := rules.Get(wafClient, policyID, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "WAF Alarm Masking Rule")
+	}
+	log.Printf("[DEBUG] fetching WAF alarm masking rule created: %#v", n)
+
+	d.SetId(n.Id)
+	d.Set("policy_id", n.PolicyID)
+	d.Set("path", n.Path)
+	d.Set("event_id", n.EventID)
+	d.Set("event_type", n.EventType)
+
+	return nil
+}
+
+func resourceWafRuleAlarmMaskingUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Client: %s", err)
+	}
+
+	if d.HasChanges("path", "event_id") {
+		policyID := d.Get("policy_id").(string)
+		updateOpts := rules.UpdateOpts{
+			Path:    d.Get("path").(string),
+			EventID: d.Get("event_id").(string),
+		}
+
+		log.Printf("[DEBUG] WAF Alarm Masking Rule updating opts: %#v", updateOpts)
+		_, err = rules.Update(wafClient, policyID, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return fmt.Errorf("error updating WAF Alarm Masking Rule: %s", err)
+		}
+	}
+
+	return resourceWafRuleAlarmMaskingRead(d, meta)
+}
+
+func resourceWafRuleAlarmMaskingDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	err = rules.Delete(wafClient, policyID, d.Id()).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("error deleting WAF Alarm Masking Rule: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/flexibleengine/resource_flexibleengine_waf_rule_alarm_masking_test.go
+++ b/flexibleengine/resource_flexibleengine_waf_rule_alarm_masking_test.go
@@ -1,0 +1,129 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	rules "github.com/huaweicloud/golangsdk/openstack/waf/v1/falsealarmmasking_rules"
+)
+
+func TestAccWafRuleAlarmMasking_basic(t *testing.T) {
+	var rule rules.AlarmMasking
+	randName := acctest.RandString(5)
+	resourceName := "flexibleengine_waf_rule_alarm_masking.rule_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckWafRuleAlarmMaskingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafRuleAlarmMasking_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleAlarmMaskingExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "path", "/a"),
+					resource.TestCheckResourceAttrSet(resourceName, "event_type"),
+				),
+			},
+			{
+				Config: testAccWafRuleAlarmMasking_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleAlarmMaskingExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "path", "/abc"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWafRuleImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckWafRuleAlarmMaskingDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	wafClient, err := config.WafV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_waf_rule_alarm_masking" {
+			continue
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		_, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("WAF alarm masking rule still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafRuleAlarmMaskingExists(n string, rule *rules.AlarmMasking) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		wafClient, err := config.WafV1Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		found, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("WAF alarm masking rule not found")
+		}
+
+		*rule = *found
+
+		return nil
+	}
+}
+
+func testAccWafRuleAlarmMasking_basic(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_waf_policy" "policy_1" {
+  name = "policy_%s"
+}
+
+resource "flexibleengine_waf_rule_alarm_masking" "rule_1" {
+  policy_id = flexibleengine_waf_policy.policy_1.id
+  path      = "/a"
+  event_id  = "3737fb122f2140f39292f597ad3b7e9a"
+}
+`, name)
+}
+
+func testAccWafRuleAlarmMasking_update(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_waf_policy" "policy_1" {
+  name = "policy_%s"
+}
+
+resource "flexibleengine_waf_rule_alarm_masking" "rule_1" {
+  policy_id = flexibleengine_waf_policy.policy_1.id
+  path      = "/abc"
+  event_id  = "3737fb122f2140f39292f597ad3b7e9a"
+}
+`, name)
+}

--- a/flexibleengine/resource_flexibleengine_waf_rule_data_masking.go
+++ b/flexibleengine/resource_flexibleengine_waf_rule_data_masking.go
@@ -1,0 +1,154 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	rules "github.com/huaweicloud/golangsdk/openstack/waf/v1/datamasking_rules"
+)
+
+func resourceWafRuleDataMasking() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceWafRuleDataMaskingCreate,
+		Read:   resourceWafRuleDataMaskingRead,
+		Update: resourceWafRuleDataMaskingUpdate,
+		Delete: resourceWafRuleDataMaskingDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceWafRulesImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"field": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"params", "header",
+				}, false),
+			},
+			"subfield": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceWafRuleDataMaskingCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	createOpts := rules.CreateOpts{
+		Path:     d.Get("path").(string),
+		Category: d.Get("field").(string),
+		Index:    d.Get("subfield").(string),
+	}
+
+	log.Printf("[DEBUG] WAF Data Masking Rule creating opts: %#v", createOpts)
+	rule, err := rules.Create(wafClient, policyID, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Data Masking Rule: %s", err)
+	}
+
+	log.Printf("[DEBUG] WAF data masking rule created: %#v", rule)
+	d.SetId(rule.Id)
+
+	return resourceWafRuleDataMaskingRead(d, meta)
+}
+
+func resourceWafRuleDataMaskingRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	n, err := rules.Get(wafClient, policyID, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "WAF Data Masking Rule")
+	}
+	log.Printf("[DEBUG] fetching WAF data masking rule: %#v", n)
+
+	d.SetId(n.Id)
+	d.Set("policy_id", n.PolicyID)
+	d.Set("path", n.Path)
+	d.Set("field", n.Category)
+	d.Set("subfield", n.Index)
+
+	return nil
+}
+
+func resourceWafRuleDataMaskingUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Client: %s", err)
+	}
+
+	if d.HasChanges("path", "field", "subfield") {
+		policyID := d.Get("policy_id").(string)
+		updateOpts := rules.UpdateOpts{
+			Path:     d.Get("path").(string),
+			Category: d.Get("field").(string),
+			Index:    d.Get("subfield").(string),
+		}
+
+		log.Printf("[DEBUG] WAF Data Masking Rule updating opts: %#v", updateOpts)
+		_, err = rules.Update(wafClient, policyID, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return fmt.Errorf("error updating Flexibleengine WAF Data Masking Rule: %s", err)
+		}
+	}
+
+	return resourceWafRuleDataMaskingRead(d, meta)
+}
+
+func resourceWafRuleDataMaskingDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	err = rules.Delete(wafClient, policyID, d.Id()).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("error deleting Flexibleengine WAF Data Masking Rule: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceWafRulesImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		err := fmt.Errorf("Invalid format specified for WAF rule. Format must be <policy id>/<rule id>")
+		return nil, err
+	}
+
+	policyID := parts[0]
+	ruleID := parts[1]
+
+	d.SetId(ruleID)
+	d.Set("policy_id", policyID)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/flexibleengine/resource_flexibleengine_waf_rule_data_masking_test.go
+++ b/flexibleengine/resource_flexibleengine_waf_rule_data_masking_test.go
@@ -1,0 +1,152 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	rules "github.com/huaweicloud/golangsdk/openstack/waf/v1/datamasking_rules"
+)
+
+func TestAccWafRuleDataMasking_basic(t *testing.T) {
+	var rule rules.DataMasking
+	randName := acctest.RandString(5)
+	resourceName := "flexibleengine_waf_rule_data_masking.rule_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckWafRuleDataMaskingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafRuleDataMasking_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleDataMaskingExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "path", "/login"),
+					resource.TestCheckResourceAttr(resourceName, "field", "params"),
+					resource.TestCheckResourceAttr(resourceName, "subfield", "password"),
+				),
+			},
+			{
+				Config: testAccWafRuleDataMasking_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleDataMaskingExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "path", "/login_new"),
+					resource.TestCheckResourceAttr(resourceName, "field", "params"),
+					resource.TestCheckResourceAttr(resourceName, "subfield", "secret"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWafRuleImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckWafRuleDataMaskingDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	wafClient, err := config.WafV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_waf_rule_data_masking" {
+			continue
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		_, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("WAF data masking rule still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafRuleDataMaskingExists(n string, rule *rules.DataMasking) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		wafClient, err := config.WafV1Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		found, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("WAF data masking rule not found")
+		}
+
+		*rule = *found
+
+		return nil
+	}
+}
+
+func testAccWafRuleImportStateIdFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		policy, ok := s.RootModule().Resources["flexibleengine_waf_policy.policy_1"]
+		if !ok {
+			return "", fmt.Errorf("WAF policy not found")
+		}
+		rule, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("WAF rule not found")
+		}
+
+		if policy.Primary.ID == "" || rule.Primary.ID == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", policy.Primary.ID, rule.Primary.ID)
+		}
+		return fmt.Sprintf("%s/%s", policy.Primary.ID, rule.Primary.ID), nil
+	}
+}
+
+func testAccWafRuleDataMasking_basic(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_waf_policy" "policy_1" {
+  name = "policy_%s"
+}
+
+resource "flexibleengine_waf_rule_data_masking" "rule_1" {
+  policy_id = flexibleengine_waf_policy.policy_1.id
+  path      = "/login"
+  field     = "params"
+  subfield  = "password"
+}
+`, name)
+}
+
+func testAccWafRuleDataMasking_update(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_waf_policy" "policy_1" {
+  name = "policy_%s"
+}
+
+resource "flexibleengine_waf_rule_data_masking" "rule_1" {
+  policy_id = flexibleengine_waf_policy.policy_1.id
+  path      = "/login_new"
+  field     = "params"
+  subfield  = "secret"
+}
+`, name)
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210619075926-bc59084e8485
+	github.com/huaweicloud/golangsdk v0.0.0-20210621115823-3cecb9fc9172
 	github.com/huaweicloud/terraform-provider-huaweicloud v1.25.1-0.20210621022651-b1aa07d8ce12
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jtolds/gls v4.20.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -228,6 +228,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/huaweicloud/golangsdk v0.0.0-20210618111817-9c67059b7682/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/golangsdk v0.0.0-20210619075926-bc59084e8485 h1:xeJzaCvFOm/myoJJ1EDESXJmuXHCBrK999U5kbyP3AE=
 github.com/huaweicloud/golangsdk v0.0.0-20210619075926-bc59084e8485/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210621115823-3cecb9fc9172 h1:6OLBFIxdht5gTP3AVkKM4CngryJSwRrFGX43xqAPAu4=
+github.com/huaweicloud/golangsdk v0.0.0-20210621115823-3cecb9fc9172/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.25.1-0.20210621022651-b1aa07d8ce12 h1:Gnt3/6dft3Q5tKyKMThZdmzdDtkP85diIBcrvgcs2vg=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.25.1-0.20210621022651-b1aa07d8ce12/go.mod h1:SPfV6A6ZdqeIaqnPOVMomuMdVjjnzA0pzdALxcR5wXY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/datamasking_rules/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/datamasking_rules/requests.go
@@ -1,0 +1,88 @@
+package datamasking_rules
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+var RequestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToDataMaskingCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new datamasking rule.
+type CreateOpts struct {
+	Path     string `json:"path" required:"true"`
+	Category string `json:"category" required:"true"`
+	Index    string `json:"index" required:"true"`
+}
+
+// ToDataMaskingCreateMap builds a create request body from CreateOpts.
+func (opts CreateOpts) ToDataMaskingCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create will create a new datamasking rule based on the values in CreateOpts.
+func Create(c *golangsdk.ServiceClient, policyID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToDataMaskingCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Post(rootURL(c, policyID), b, &r.Body, reqOpt)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToDataMaskingUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains all the values needed to update a datamasking rule.
+type UpdateOpts struct {
+	Path     string `json:"path" required:"true"`
+	Category string `json:"category" required:"true"`
+	Index    string `json:"index" required:"true"`
+}
+
+// ToDataMaskingUpdateMap builds a update request body from UpdateOpts.
+func (opts UpdateOpts) ToDataMaskingUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Update accepts a UpdateOpts struct and uses the values to update a rule.The response code from api is 200
+func Update(c *golangsdk.ServiceClient, policyID, ruleID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToDataMaskingUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Put(resourceURL(c, policyID, ruleID), b, nil, reqOpt)
+	return
+}
+
+// Get retrieves a particular datamasking rule based on its unique ID.
+func Get(c *golangsdk.ServiceClient, policyID, ruleID string) (r GetResult) {
+	reqOpt := &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	}
+
+	_, r.Err = c.Get(resourceURL(c, policyID, ruleID), &r.Body, reqOpt)
+	return
+}
+
+// Delete will permanently delete a particular datamasking rule based on its unique ID.
+func Delete(c *golangsdk.ServiceClient, policyID, ruleID string) (r DeleteResult) {
+	reqOpt := &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	}
+	_, r.Err = c.Delete(resourceURL(c, policyID, ruleID), reqOpt)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/datamasking_rules/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/datamasking_rules/results.go
@@ -1,0 +1,53 @@
+package datamasking_rules
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+type DataMasking struct {
+	// DataMasking Rule ID
+	Id string `json:"id"`
+	// Policy ID
+	PolicyID string `json:"policy_id"`
+	// DataMaksing Rule URL
+	Path string `json:"path"`
+	// Masked Field
+	Category string `json:"category"`
+	// Masked Subfield
+	Index string `json:"index"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a datamasking rule.
+func (r commonResult) Extract() (*DataMasking, error) {
+	var response DataMasking
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a DataMasking rule.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of a update operation. Call its Extract
+// method to interpret it as a DataMasking rule.
+type UpdateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a DataMasking rule.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/datamasking_rules/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/datamasking_rules/urls.go
@@ -1,0 +1,11 @@
+package datamasking_rules
+
+import "github.com/huaweicloud/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient, policy_id string) string {
+	return c.ServiceURL("policy", policy_id, "privacy")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, policy_id, id string) string {
+	return c.ServiceURL("policy", policy_id, "privacy", id)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/falsealarmmasking_rules/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/falsealarmmasking_rules/requests.go
@@ -1,0 +1,93 @@
+package falsealarmmasking_rules
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+var RequestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToAlarmMaskingCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new falsealarmmasking rule.
+type CreateOpts struct {
+	Path    string `json:"path" required:"true"`
+	EventID string `json:"event_id" required:"true"`
+}
+
+// ToAlarmMaskingCreateMap builds a create request body from CreateOpts.
+func (opts CreateOpts) ToAlarmMaskingCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create will create a new falsealarmmasking rule based on the values in CreateOpts.
+func Create(c *golangsdk.ServiceClient, policyID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToAlarmMaskingCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Post(rootURL(c, policyID), b, &r.Body, reqOpt)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToAlarmMaskingUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains all the values needed to update a falsealarmmasking rule.
+type UpdateOpts struct {
+	Path    string `json:"path,omitempty"`
+	EventID string `json:"event_id,omitempty"`
+}
+
+// ToAlarmMaskingUpdateMap builds a update request body from UpdateOpts.
+func (opts UpdateOpts) ToAlarmMaskingUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Update accepts a UpdateOpts struct and uses the values to update a rule.The response code from api is 200
+func Update(c *golangsdk.ServiceClient, policyID, ruleID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToAlarmMaskingUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Put(resourceURL(c, policyID, ruleID), b, nil, reqOpt)
+	return
+}
+
+// Get retrieves a particular falsealarmmasking rule based on its unique ID.
+func Get(c *golangsdk.ServiceClient, policyID, ruleID string) (r GetResult) {
+	reqOpt := &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	}
+
+	_, r.Err = c.Get(resourceURL(c, policyID, ruleID), &r.Body, reqOpt)
+	return
+}
+
+// List retrieves falsealarmmasking rules.
+func List(c *golangsdk.ServiceClient, policyID string) (r ListResult) {
+	_, r.Err = c.Get(rootURL(c, policyID), &r.Body, &RequestOpts)
+	return
+}
+
+// Delete will permanently delete a particular falsealarmmasking rule based on its unique ID.
+func Delete(c *golangsdk.ServiceClient, policyID, ruleID string) (r DeleteResult) {
+	reqOpt := &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	}
+
+	_, r.Err = c.Delete(resourceURL(c, policyID, ruleID), reqOpt)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/falsealarmmasking_rules/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/falsealarmmasking_rules/results.go
@@ -1,0 +1,74 @@
+package falsealarmmasking_rules
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+type ListResponse struct {
+	// Total number of the Rules
+	Total int `json:"total"`
+
+	// List of AlarmMasking
+	Items []AlarmMasking `json:"items"`
+}
+
+type AlarmMasking struct {
+	// the ID of a false alarm masking rule
+	Id string `json:"id"`
+	// the policy ID
+	PolicyID string `json:"policy_id"`
+	// a misreported URL excluding a domain name
+	Path string `json:"path"`
+	// the event ID
+	EventID string `json:"event_id"`
+	// the event ID
+	EventType string `json:"event_type"`
+	// the rule ID, which consists of six digits and cannot be empty
+	Rule string `json:"rule"`
+	// the time when a false alarm masking rule is added
+	TimeStamp int `json:"timestamp"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a falsealarmmasking rule.
+func (r commonResult) Extract() (*AlarmMasking, error) {
+	var response AlarmMasking
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a False Alarm Masking rule.
+type CreateResult struct {
+	commonResult
+}
+
+type UpdateResult struct {
+	commonResult
+}
+
+type GetResult struct {
+	commonResult
+}
+
+type ListResult struct {
+	commonResult
+}
+
+func (r ListResult) Extract() ([]AlarmMasking, error) {
+	var s ListResponse
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+	return s.Items, nil
+}
+
+// DeleteResult represents the result of a delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/falsealarmmasking_rules/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/falsealarmmasking_rules/urls.go
@@ -1,0 +1,11 @@
+package falsealarmmasking_rules
+
+import "github.com/huaweicloud/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient, policyID string) string {
+	return c.ServiceURL("policy", policyID, "ignore")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, policyID, id string) string {
+	return c.ServiceURL("policy", policyID, "ignore", id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -261,7 +261,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210619075926-bc59084e8485
+# github.com/huaweicloud/golangsdk v0.0.0-20210621115823-3cecb9fc9172
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -394,7 +394,9 @@ github.com/huaweicloud/golangsdk/openstack/vbs/v2/policies
 github.com/huaweicloud/golangsdk/openstack/vpcep/v1/endpoints
 github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services
 github.com/huaweicloud/golangsdk/openstack/waf/v1/certificates
+github.com/huaweicloud/golangsdk/openstack/waf/v1/datamasking_rules
 github.com/huaweicloud/golangsdk/openstack/waf/v1/domains
+github.com/huaweicloud/golangsdk/openstack/waf/v1/falsealarmmasking_rules
 github.com/huaweicloud/golangsdk/openstack/waf/v1/policies
 github.com/huaweicloud/golangsdk/pagination
 # github.com/huaweicloud/terraform-provider-huaweicloud v1.25.1-0.20210621022651-b1aa07d8ce12


### PR DESCRIPTION
related to #533 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccWafRuleDataMasking_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccWafRuleDataMasking_basic -timeout 720m
=== RUN   TestAccWafRuleDataMasking_basic
--- PASS: TestAccWafRuleDataMasking_basic (24.66s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 24.673s
```