### PR TITLE
waf: add cc attack protection rule and blacklist rule resources

### DIFF
--- a/docs/resources/waf_rule_blacklist.md
+++ b/docs/resources/waf_rule_blacklist.md
@@ -1,0 +1,46 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# flexibleengine_waf_rule_blacklist
+
+Manages a WAF blacklist and whitelist rule resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_waf_policy" "policy_1" {
+  name = "policy_1"
+}
+
+resource "flexibleengine_waf_rule_blacklist" "rule_1" {
+  policy_id = flexibleengine_waf_policy.policy_1.id
+  address   = "192.168.0.0/24"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_id` - (Required, String, ForceNew) Specifies the WAF policy ID. Changing this creates a new rule.
+
+* `address` - (Required, String) Specifies the IP address or range. For example, 192.168.0.125 or 192.168.0.0/24.
+
+* `action` - (Optional, Int) Specifies the protective action. 1: Whitelist, 0: Blacklist.
+  If you do not configure the parameter, the value is Blacklist by default.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The rule ID in UUID format.
+
+## Import
+
+Blacklist Rules can be imported using the policy ID and rule ID
+separated by a slash, e.g.:
+
+```sh
+terraform import flexibleengine_waf_rule_blacklist.rule_1 523083f4543c497faecd25fcfcc0b2a0/e7f49f736bc74b828ce45e0e5c49d156
+```

--- a/docs/resources/waf_rule_cc_protection.md
+++ b/docs/resources/waf_rule_cc_protection.md
@@ -1,0 +1,83 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# flexibleengine_waf_rule_cc_protection
+
+Manages a WAF CC Attack Protection Rule resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_waf_policy" "policy_1" {
+  name = "policy_1"
+}
+
+resource "flexibleengine_waf_rule_cc_protection" "rule_1" {
+  policy_id    = flexibleengine_waf_policy.policy_1.id
+  path         = "/abc"
+  limit_num    = 10
+  limit_period = 60  
+  mode         = "cookie"
+  cookie       = "sessionid"
+
+  action             = "block"
+  block_time         = 10
+  block_page_type    = "application/json"
+  block_page_content = "{\"error\":\"forbidden\"}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_id` - (Required, String, ForceNew) Specifies the WAF policy ID. Changing this creates a new rule.
+
+* `path` - (Required, String) Specifies the URL to which the rule applies. The path ending with * indicates
+  that the path is used as a prefix. For example, if the path to be protected is /admin/test.php or /adminabc,
+  set Path to /admin*.
+
+* `limit_num` - (Required, Int) Specifies the number of requests allowed from a web visitor in a rate limiting period.
+  The value ranges from 0 to 2^32.
+
+* `limit_period` - (Required, Int) Specifies the rate limiting period. The value ranges from 0 seconds to 2^32 seconds.
+
+* `mode` - (Required, String) Specifies the rate limit mode. Valid Options are:
+  * *ip* - A web visitor is identified by the IP address.
+  * *cookie* - A web visitor is identified by the cookie key value.
+  * *other* - A web visitor is identified by the Referer field(user-defined request source).
+
+* `cookie` - (Optional, String) Specifies the cookie name. This field is mandatory when `mode` is set to *cookie*.
+
+* `content` - (Optional, String) Specifies the category content. The format is as follows: http://www.example.com/path.
+  This field is mandatory when `mode` is set to *other*.
+
+* `action` - (Required, String) Specifies the action when the number of requests reaches the upper limit. Valid Options are:
+  * *block* - block the requests.
+  * *captcha* - Verification code. The user needs to enter the correct verification code after blocking to restore the correct access page.
+
+  If `mode` is set to *other*, this parameter value can only be *block*.
+
+* `block_time` - (Optional, Int) Specifies the lock duration. The value ranges from 0 seconds to 2^32 seconds.
+
+* `block_page_type` - (Optional, String) Specifies the type of the returned page.
+  The options are `application/json`, `text/html`, and `text/xml`.
+
+* `block_page_content` - (Optional, String) Specifies the content of the returned page.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` -  The rule ID in UUID format.
+
+## Import
+
+CC Attack Protection Rules can be imported using the policy ID and rule ID
+separated by a slash, e.g.:
+
+```sh
+terraform import flexibleengine_waf_rule_cc_protection.rule_1 523083f4543c497faecd25fcfcc0b2a0/dd3c14e91550453f81cff5fc3b7c3e89
+```

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -329,6 +329,7 @@ func Provider() terraform.ResourceProvider {
 			"flexibleengine_waf_rule_blacklist":                 resourceWafRuleBlackList(),
 			"flexibleengine_waf_rule_alarm_masking":             resourceWafRuleAlarmMasking(),
 			"flexibleengine_waf_rule_data_masking":              resourceWafRuleDataMasking(),
+			"flexibleengine_waf_rule_cc_protection":             resourceWafRuleCCAttackProtection(),
 
 			// Deprecated resource
 			"flexibleengine_rds_instance_v1": resourceRdsInstance(),

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -326,6 +326,7 @@ func Provider() terraform.ResourceProvider {
 			"flexibleengine_waf_certificate":                    resourceWafCertificateV1(),
 			"flexibleengine_waf_domain":                         resourceWafDomainV1(),
 			"flexibleengine_waf_policy":                         resourceWafPolicyV1(),
+			"flexibleengine_waf_rule_blacklist":                 resourceWafRuleBlackList(),
 			"flexibleengine_waf_rule_alarm_masking":             resourceWafRuleAlarmMasking(),
 			"flexibleengine_waf_rule_data_masking":              resourceWafRuleDataMasking(),
 

--- a/flexibleengine/resource_flexibleengine_waf_rule_blacklist.go
+++ b/flexibleengine/resource_flexibleengine_waf_rule_blacklist.go
@@ -1,0 +1,129 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	rules "github.com/huaweicloud/golangsdk/openstack/waf/v1/whiteblackip_rules"
+)
+
+func resourceWafRuleBlackList() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceWafRuleBlackListCreate,
+		Read:   resourceWafRuleBlackListRead,
+		Update: resourceWafRuleBlackListUpdate,
+		Delete: resourceWafRuleBlackListDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceWafRulesImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"address": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"action": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      0,
+				ValidateFunc: validation.IntInSlice([]int{0, 1}),
+			},
+		},
+	}
+}
+
+func resourceWafRuleBlackListCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	createOpts := rules.CreateOpts{
+		Addr:  d.Get("address").(string),
+		White: d.Get("action").(int),
+	}
+
+	log.Printf("[DEBUG] WAF black list rule creating opts: %#v", createOpts)
+	rule, err := rules.Create(wafClient, policyID, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("error creating WAF black list rule: %s", err)
+	}
+
+	log.Printf("[DEBUG] WAF black list rule created: %#v", rule)
+	d.SetId(rule.Id)
+
+	return resourceWafRuleBlackListRead(d, meta)
+}
+
+func resourceWafRuleBlackListRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	n, err := rules.Get(wafClient, policyID, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "WAF Black List Rule")
+	}
+	log.Printf("[DEBUG] fetching WAF black list rule: %#v", n)
+
+	d.SetId(n.Id)
+	d.Set("policy_id", n.PolicyID)
+	d.Set("address", n.Addr)
+	d.Set("action", n.White)
+
+	return nil
+}
+
+func resourceWafRuleBlackListUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Client: %s", err)
+	}
+
+	if d.HasChanges("address", "action") {
+		white := d.Get("action").(int)
+		updateOpts := rules.UpdateOpts{
+			Addr:  d.Get("address").(string),
+			White: &white,
+		}
+		log.Printf("[DEBUG] updateOpts: %#v", updateOpts)
+
+		policyID := d.Get("policy_id").(string)
+		_, err = rules.Update(wafClient, policyID, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return fmt.Errorf("error updating Flexibleengine WAF WhiteBlackIP Rule: %s", err)
+		}
+	}
+
+	return resourceWafRuleBlackListRead(d, meta)
+}
+
+func resourceWafRuleBlackListDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	err = rules.Delete(wafClient, policyID, d.Id()).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("error deleting Flexibleengine WAF WhiteBlackIP Rule: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/flexibleengine/resource_flexibleengine_waf_rule_blacklist_test.go
+++ b/flexibleengine/resource_flexibleengine_waf_rule_blacklist_test.go
@@ -1,0 +1,130 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	rules "github.com/huaweicloud/golangsdk/openstack/waf/v1/whiteblackip_rules"
+)
+
+func TestAccWafRuleBlackList_basic(t *testing.T) {
+	var rule rules.WhiteBlackIP
+	randName := acctest.RandString(5)
+	resourceName := "flexibleengine_waf_rule_blacklist.rule_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckWafRuleBlackListDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafRuleBlackList_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleBlackListExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "address", "192.168.0.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "action", "0"),
+				),
+			},
+			{
+				Config: testAccWafRuleBlackList_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleBlackListExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "address", "192.168.0.125"),
+					resource.TestCheckResourceAttr(resourceName, "action", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWafRuleImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckWafRuleBlackListDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	wafClient, err := config.WafV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_waf_rule_blacklist" {
+			continue
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		_, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Waf rule still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafRuleBlackListExists(n string, rule *rules.WhiteBlackIP) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		wafClient, err := config.WafV1Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		found, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("WAF black list rule not found")
+		}
+
+		*rule = *found
+
+		return nil
+	}
+}
+
+func testAccWafRuleBlackList_basic(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_waf_policy" "policy_1" {
+  name = "policy_%s"
+}
+
+resource "flexibleengine_waf_rule_blacklist" "rule_1" {
+  policy_id = flexibleengine_waf_policy.policy_1.id
+  address   = "192.168.0.0/24"
+}
+`, name)
+}
+
+func testAccWafRuleBlackList_update(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_waf_policy" "policy_1" {
+  name = "policy_%s"
+}
+
+resource "flexibleengine_waf_rule_blacklist" "rule_1" {
+  policy_id = flexibleengine_waf_policy.policy_1.id
+  address   = "192.168.0.125"
+  action    = 1
+}
+`, name)
+}

--- a/flexibleengine/resource_flexibleengine_waf_rule_cc_protection.go
+++ b/flexibleengine/resource_flexibleengine_waf_rule_cc_protection.go
@@ -1,0 +1,239 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	rules "github.com/huaweicloud/golangsdk/openstack/waf/v1/ccattackprotection_rules"
+)
+
+func resourceWafRuleCCAttackProtection() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceWafRuleCCAttackProtectionCreate,
+		Read:   resourceWafRuleCCAttackProtectionRead,
+		Update: resourceWafRuleCCAttackProtectionUpdate,
+		Delete: resourceWafRuleCCAttackProtectionDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceWafRulesImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"mode": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"ip", "cookie", "other",
+				}, false),
+			},
+			"action": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"block", "captcha",
+				}, false),
+			},
+			"limit_num": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"limit_period": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"cookie": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"content"},
+			},
+			"content": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"block_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"block_page_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"application/json", "text/html", "text/xml",
+				}, false),
+			},
+			"block_page_content": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"block_page_type"},
+			},
+		},
+	}
+}
+
+func buildWafRuleTagCondition(d *schema.ResourceData) *rules.TagCondition {
+	if v, ok := d.GetOk("content"); ok {
+		condition := rules.TagCondition{
+			Category: "Referer",
+			Contents: []string{v.(string)},
+		}
+		return &condition
+	}
+
+	return nil
+}
+
+func buildWafRuleCcAction(d *schema.ResourceData) rules.Action {
+	action := rules.Action{
+		Category: d.Get("action").(string),
+	}
+
+	if v, ok := d.GetOk("block_page_content"); ok {
+		response := rules.Response{
+			ContentType: d.Get("block_page_type").(string),
+			Content:     v.(string),
+		}
+		action.Detail = &rules.Detail{
+			Response: response,
+		}
+	}
+
+	log.Printf("[DEBUG] Waf Rule CC Action opts: %#v", action)
+	return action
+}
+
+func resourceWafRuleCCAttackProtectionCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	limitNum := d.Get("limit_num").(int)
+	limitPeriod := d.Get("limit_period").(int)
+	blockTime := d.Get("block_time").(int)
+	createOpts := rules.CreateOpts{
+		LimitNum:     &limitNum,
+		LimitPeriod:  &limitPeriod,
+		LockTime:     &blockTime,
+		Url:          d.Get("path").(string),
+		TagType:      d.Get("mode").(string),
+		TagIndex:     d.Get("cookie").(string),
+		TagCondition: buildWafRuleTagCondition(d),
+		Action:       buildWafRuleCcAction(d),
+	}
+
+	log.Printf("[DEBUG] WAF CC attack protection rule creating opts: %#v", createOpts)
+	rule, err := rules.Create(wafClient, policyID, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF CC Attack Protection Rule: %s", err)
+	}
+
+	log.Printf("[DEBUG] Waf CC attack protection rule created: %#v", rule)
+	d.SetId(rule.Id)
+
+	return resourceWafRuleCCAttackProtectionRead(d, meta)
+}
+
+func resourceWafRuleCCAttackProtectionRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	n, err := rules.Get(wafClient, policyID, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "WAF CC Attack Protection Rule")
+	}
+
+	mErr := multierror.Append(nil,
+		d.Set("policy_id", n.PolicyID),
+		d.Set("path", n.Url),
+		d.Set("limit_num", n.LimitNum),
+		d.Set("limit_period", n.LimitPeriod),
+		d.Set("block_time", n.LockTime),
+		d.Set("mode", n.TagType),
+		d.Set("cookie", n.TagIndex),
+		d.Set("action", n.Action.Category),
+	)
+
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmt.Errorf("error setting WAF fields: %s", err)
+	}
+
+	contens := n.TagCondition.Contents
+	if len(contens) > 0 {
+		d.Set("content", contens[0])
+	}
+	blockDetail := n.Action.Detail
+	if blockDetail != nil {
+		d.Set("block_page_type", blockDetail.Response.ContentType)
+		d.Set("block_page_content", blockDetail.Response.Content)
+	}
+
+	return nil
+}
+
+func resourceWafRuleCCAttackProtectionUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	limitNum := d.Get("limit_num").(int)
+	limitPeriod := d.Get("limit_period").(int)
+	blockTime := d.Get("block_time").(int)
+	updateOpts := rules.CreateOpts{
+		LimitNum:     &limitNum,
+		LimitPeriod:  &limitPeriod,
+		LockTime:     &blockTime,
+		Url:          d.Get("path").(string),
+		TagType:      d.Get("mode").(string),
+		TagIndex:     d.Get("cookie").(string),
+		TagCondition: buildWafRuleTagCondition(d),
+		Action:       buildWafRuleCcAction(d),
+	}
+
+	log.Printf("[DEBUG] WAF CC attack protection rule updating opts: %#v", updateOpts)
+	_, err = rules.Update(wafClient, policyID, d.Id(), updateOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("error updating Flexibleengine WAF CC Attack Protection Rule: %s", err)
+	}
+
+	return resourceWafRuleCCAttackProtectionRead(d, meta)
+}
+
+func resourceWafRuleCCAttackProtectionDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	err = rules.Delete(wafClient, policyID, d.Id()).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("error deleting Flexibleengine WAF CC Attack Protection Rule: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/flexibleengine/resource_flexibleengine_waf_rule_cc_protection_test.go
+++ b/flexibleengine/resource_flexibleengine_waf_rule_cc_protection_test.go
@@ -1,0 +1,153 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	rules "github.com/huaweicloud/golangsdk/openstack/waf/v1/ccattackprotection_rules"
+)
+
+func TestAccWafRuleCCAttackProtection_basic(t *testing.T) {
+	var rule rules.CcAttack
+	randName := acctest.RandString(5)
+	resourceName := "flexibleengine_waf_rule_cc_protection.rule_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckWafRuleCCAttackProtectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafRuleCCAttackProtection_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleCCAttackProtectionExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "path", "/abc"),
+					resource.TestCheckResourceAttr(resourceName, "limit_num", "10"),
+					resource.TestCheckResourceAttr(resourceName, "limit_period", "60"),
+					resource.TestCheckResourceAttr(resourceName, "block_time", "10"),
+					resource.TestCheckResourceAttr(resourceName, "mode", "cookie"),
+					resource.TestCheckResourceAttr(resourceName, "action", "block"),
+				),
+			},
+			{
+				Config: testAccWafRuleCCAttackProtection_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleCCAttackProtectionExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "path", "/abcd"),
+					resource.TestCheckResourceAttr(resourceName, "limit_num", "30"),
+					resource.TestCheckResourceAttr(resourceName, "limit_period", "100"),
+					resource.TestCheckResourceAttr(resourceName, "block_time", "20"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWafRuleImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckWafRuleCCAttackProtectionDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	wafClient, err := config.WafV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_waf_rule_cc_protection" {
+			continue
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		_, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Waf rule still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafRuleCCAttackProtectionExists(n string, rule *rules.CcAttack) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		wafClient, err := config.WafV1Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		found, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("WAF rule not found")
+		}
+
+		*rule = *found
+
+		return nil
+	}
+}
+
+func testAccWafRuleCCAttackProtection_basic(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_waf_policy" "policy_1" {
+  name = "policy_%s"
+}
+
+resource "flexibleengine_waf_rule_cc_protection" "rule_1" {
+  policy_id    = flexibleengine_waf_policy.policy_1.id
+  path         = "/abc"
+  limit_num    = 10
+  limit_period = 60
+  mode         = "cookie"
+  cookie       = "sessionid"
+
+  action             = "block"
+  block_time         = 10
+  block_page_type = "application/json"
+  block_page_content      = "{\"error\":\"forbidden\"}"
+}
+`, name)
+}
+
+func testAccWafRuleCCAttackProtection_update(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_waf_policy" "policy_1" {
+  name = "policy_%s"
+}
+
+resource "flexibleengine_waf_rule_cc_protection" "rule_1" {
+  policy_id    = flexibleengine_waf_policy.policy_1.id
+  path         = "/abcd"
+  limit_num    = 30
+  limit_period = 100
+  mode         = "cookie"
+  cookie       = "sessionid"
+
+  action             = "block"
+  block_time         = 20
+  block_page_type    = "application/json"
+  block_page_content = "{\"error\":\"forbidden\"}"
+}
+`, name)
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210621115823-3cecb9fc9172
+	github.com/huaweicloud/golangsdk v0.0.0-20210624022515-eefdf1d43b21
 	github.com/huaweicloud/terraform-provider-huaweicloud v1.25.1-0.20210621022651-b1aa07d8ce12
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jtolds/gls v4.20.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -230,6 +230,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20210619075926-bc59084e8485 h1:xeJzaCvFO
 github.com/huaweicloud/golangsdk v0.0.0-20210619075926-bc59084e8485/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/golangsdk v0.0.0-20210621115823-3cecb9fc9172 h1:6OLBFIxdht5gTP3AVkKM4CngryJSwRrFGX43xqAPAu4=
 github.com/huaweicloud/golangsdk v0.0.0-20210621115823-3cecb9fc9172/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210624022515-eefdf1d43b21 h1:S6MdycKYfaCv/e4+xsIiDQE1HsZ3RqsrqKgCq8/3keg=
+github.com/huaweicloud/golangsdk v0.0.0-20210624022515-eefdf1d43b21/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.25.1-0.20210621022651-b1aa07d8ce12 h1:Gnt3/6dft3Q5tKyKMThZdmzdDtkP85diIBcrvgcs2vg=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.25.1-0.20210621022651-b1aa07d8ce12/go.mod h1:SPfV6A6ZdqeIaqnPOVMomuMdVjjnzA0pzdALxcR5wXY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/ccattackprotection_rules/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/ccattackprotection_rules/requests.go
@@ -1,0 +1,96 @@
+package ccattackprotection_rules
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+var RequestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToCcAttackCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new cc attack protection rule.
+type CreateOpts struct {
+	Url          string        `json:"path" required:"true"`
+	LimitNum     *int          `json:"limit_num" required:"true"`
+	LimitPeriod  *int          `json:"limit_period" required:"true"`
+	LockTime     *int          `json:"lock_time,omitempty"`
+	TagType      string        `json:"tag_type" required:"true"`
+	TagIndex     string        `json:"tag_index,omitempty"`
+	TagCondition *TagCondition `json:"tag_condition,omitempty"`
+	Action       Action        `json:"action" required:"true"`
+}
+
+type TagCondition struct {
+	Category string   `json:"category" required:"true"`
+	Contents []string `json:"contents" required:"true"`
+}
+
+type Action struct {
+	Category string  `json:"category" required:"true"`
+	Detail   *Detail `json:"detail,omitempty"`
+}
+
+type Detail struct {
+	Response Response `json:"response" required:"true"`
+}
+
+type Response struct {
+	ContentType string `json:"content_type" required:"true"`
+	Content     string `json:"content" required:"true"`
+}
+
+// ToCcAttackCreateMap builds a create request body from CreateOpts.
+func (opts CreateOpts) ToCcAttackCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create will create a new cc attack protection rule based on the values in CreateOpts.
+func Create(c *golangsdk.ServiceClient, policyID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToCcAttackCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Post(rootURL(c, policyID), b, &r.Body, reqOpt)
+	return
+}
+
+// Update will update a new cc attack protection rule based on the values in CreateOpts.
+// The response code from api is 200
+func Update(c *golangsdk.ServiceClient, policyID, ruleID string, opts CreateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToCcAttackCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Put(resourceURL(c, policyID, ruleID), b, &r.Body, reqOpt)
+	return
+}
+
+// Get retrieves a particular cc attack rule based on its unique ID.
+func Get(c *golangsdk.ServiceClient, policyID, ruleID string) (r GetResult) {
+	reqOpt := &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	}
+
+	_, r.Err = c.Get(resourceURL(c, policyID, ruleID), &r.Body, reqOpt)
+	return
+}
+
+// Delete will permanently delete a particular cc attack rule based on its unique ID.
+func Delete(c *golangsdk.ServiceClient, policyID, ruleID string) (r DeleteResult) {
+	reqOpt := &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	}
+
+	_, r.Err = c.Delete(resourceURL(c, policyID, ruleID), reqOpt)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/ccattackprotection_rules/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/ccattackprotection_rules/results.go
@@ -1,0 +1,55 @@
+package ccattackprotection_rules
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+type CcAttack struct {
+	Id           string       `json:"id"`
+	PolicyID     string       `json:"policy_id"`
+	Url          string       `json:"path"`
+	LimitNum     int          `json:"limit_num"`
+	LimitPeriod  int          `json:"limit_period"`
+	LockTime     int          `json:"lock_time"`
+	TagType      string       `json:"tag_type"`
+	TagIndex     string       `json:"tag_index"`
+	TagCondition TagCondition `json:"tag_condition"`
+	Action       Action       `json:"action"`
+	Default      bool         `json:"default"`
+	TimeStamp    int          `json:"timestamp"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a cc attack protection rule.
+func (r commonResult) Extract() (*CcAttack, error) {
+	var response CcAttack
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a cc attack protection rule.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of a update operation. Call its Extract
+// method to interpret it as a cc attack protection rule.
+type UpdateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a cc attack protection rule.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/ccattackprotection_rules/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/ccattackprotection_rules/urls.go
@@ -1,0 +1,11 @@
+package ccattackprotection_rules
+
+import "github.com/huaweicloud/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient, policyID string) string {
+	return c.ServiceURL("policy", policyID, "cc")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, policyID, id string) string {
+	return c.ServiceURL("policy", policyID, "cc", id)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/whiteblackip_rules/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/whiteblackip_rules/requests.go
@@ -1,0 +1,81 @@
+package whiteblackip_rules
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+var RequestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToWhiteBlackIPCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new whiteblackip rule.
+type CreateOpts struct {
+	Addr  string `json:"addr" required:"true"`
+	White int    `json:"white,omitempty"`
+}
+
+// ToWhiteBlackIPCreateMap builds a create request body from CreateOpts.
+func (opts CreateOpts) ToWhiteBlackIPCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create will create a new whiteblackip rule based on the values in CreateOpts.
+func Create(c *golangsdk.ServiceClient, policyID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToWhiteBlackIPCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Post(rootURL(c, policyID), b, &r.Body, reqOpt)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToWhiteBlackIPUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains all the values needed to update a whiteblackip rule.
+type UpdateOpts struct {
+	Addr  string `json:"addr" required:"true"`
+	White *int   `json:"white" required:"true"`
+}
+
+// ToWhiteBlackIPUpdateMap builds a update request body from UpdateOpts.
+func (opts UpdateOpts) ToWhiteBlackIPUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Update accepts a UpdateOpts struct and uses the values to update a rule.The response code from api is 200
+func Update(c *golangsdk.ServiceClient, policyID, ruleID string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToWhiteBlackIPUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Put(resourceURL(c, policyID, ruleID), b, nil, reqOpt)
+	return
+}
+
+// Get retrieves a particular whiteblackip rule based on its unique ID.
+func Get(c *golangsdk.ServiceClient, policyID, ruleID string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, policyID, ruleID), &r.Body, &RequestOpts)
+	return
+}
+
+// Delete will permanently delete a particular whiteblackip rule based on its unique ID.
+func Delete(c *golangsdk.ServiceClient, policyID, ruleID string) (r DeleteResult) {
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{204},
+		MoreHeaders: RequestOpts.MoreHeaders}
+	_, r.Err = c.Delete(resourceURL(c, policyID, ruleID), reqOpt)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/whiteblackip_rules/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/whiteblackip_rules/results.go
@@ -1,0 +1,51 @@
+package whiteblackip_rules
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+type WhiteBlackIP struct {
+	// WhiteBlackIP Rule ID
+	Id string `json:"id"`
+	// WhiteBlackIP Rule Addr
+	Addr string `json:"addr"`
+	// IP address type
+	White int `json:"white"`
+	// Policy ID
+	PolicyID string `json:"policy_id"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a whiteblackip rule.
+func (r commonResult) Extract() (*WhiteBlackIP, error) {
+	var response WhiteBlackIP
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a WhiteBlackIP rule.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of a update operation. Call its Extract
+// method to interpret it as a WhiteBlackIP rule.
+type UpdateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a WhiteBlackIP rule.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/whiteblackip_rules/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/whiteblackip_rules/urls.go
@@ -1,0 +1,11 @@
+package whiteblackip_rules
+
+import "github.com/huaweicloud/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient, policyID string) string {
+	return c.ServiceURL("policy", policyID, "whiteblackip")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, policyID, id string) string {
+	return c.ServiceURL("policy", policyID, "whiteblackip", id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -261,7 +261,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210621115823-3cecb9fc9172
+# github.com/huaweicloud/golangsdk v0.0.0-20210624022515-eefdf1d43b21
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -393,11 +393,13 @@ github.com/huaweicloud/golangsdk/openstack/vbs/v2/backups
 github.com/huaweicloud/golangsdk/openstack/vbs/v2/policies
 github.com/huaweicloud/golangsdk/openstack/vpcep/v1/endpoints
 github.com/huaweicloud/golangsdk/openstack/vpcep/v1/services
+github.com/huaweicloud/golangsdk/openstack/waf/v1/ccattackprotection_rules
 github.com/huaweicloud/golangsdk/openstack/waf/v1/certificates
 github.com/huaweicloud/golangsdk/openstack/waf/v1/datamasking_rules
 github.com/huaweicloud/golangsdk/openstack/waf/v1/domains
 github.com/huaweicloud/golangsdk/openstack/waf/v1/falsealarmmasking_rules
 github.com/huaweicloud/golangsdk/openstack/waf/v1/policies
+github.com/huaweicloud/golangsdk/openstack/waf/v1/whiteblackip_rules
 github.com/huaweicloud/golangsdk/pagination
 # github.com/huaweicloud/terraform-provider-huaweicloud v1.25.1-0.20210621022651-b1aa07d8ce12
 ## explicit


### PR DESCRIPTION
related to #533

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccWafRuleCCAttackProtection_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccWafRuleCCAttackProtection_basic -timeout 720m
=== RUN   TestAccWafRuleCCAttackProtection_basic
--- PASS: TestAccWafRuleCCAttackProtection_basic (22.72s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 22.734s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccWafRuleBlackList_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccWafRuleBlackList_basic -timeout 720m
=== RUN   TestAccWafRuleBlackList_basic
=== PAUSE TestAccWafRuleBlackList_basic
=== CONT  TestAccWafRuleBlackList_basic
--- PASS: TestAccWafRuleBlackList_basic (23.22s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 23.235s

```