### PR TITLE
waf: add precise protection rule and web tamper protection rule resource

### DIFF
--- a/docs/resources/waf_rule_precise_protection.md
+++ b/docs/resources/waf_rule_precise_protection.md
@@ -1,0 +1,102 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# flexibleengine_waf_rule_precise_protection
+
+Manages a WAF Precise Protection Rule resource within FlexibleEngine.
+
+## Example Usage
+
+### A rule takes effect immediately
+```hcl
+resource "flexibleengine_waf_rule_precise_protection" "rule_1" {
+  policy_id = var.policy_id
+  name      = "rule_1"
+  priority  = 10
+
+  conditions {
+    field   = "path"
+    logic   = "prefix"
+    content = "/login"
+  }
+}
+```
+
+### A rule takes effect at the scheduled time
+```hcl
+resource "flexibleengine_waf_rule_precise_protection" "rule_1" {
+  policy_id = var.policy_id
+  name      = "rule_1"
+  action     = "block"
+  priority   = 20
+  start_time = "2021-07-01 00:00:00"
+  end_time   = "2021-12-31 23:59:59"
+
+  conditions {
+    field   = "ip"
+    logic   = "equal"
+    content = "192.168.1.1"
+  }
+}
+
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_id` - (Required, String, ForceNew) Specifies the WAF policy ID. Changing this creates a new rule.
+
+* `name` - (Required, String) Specifies the name of a precise protection rule. The maximum length is
+  256 characters. Only digits, letters, underscores (_), and hyphens (-) are allowed.
+
+* `action` - (Optional, String) Specifies the protective action after the precise protection rule is matched.
+  The value can be *block* or *pass*. Defaults to *block*.
+
+* `priority` - (Required, Int) Specifies the priority of a rule being executed. Smaller values correspond to higher priorities.
+  If two rules are assigned with the same priority, the rule added earlier has higher priority, the rule added earlier
+  has higher priority. The value ranges from 0 to 65535.
+
+* `conditions` - (Required, List) Specifies the condition parameters. The object structure is documented below.
+
+* `start_time` - (Optional, String) Specifies the UTC time when the precise protection rule takes effect.
+  The time must be in "yyyy-MM-dd HH:mm:ss" format.
+  If not specified, the rule takes effect immediately.
+
+* `end_time` - (Optional, String) Specifies the UTC time when the precise protection rule expires.
+  The time must be in "yyyy-MM-dd HH:mm:ss" format.
+
+
+The `conditions` block supports:
+
+* `field` - (Required, String) Specifies the matched field. The value can be *path*, *user-agent*, *ip*,
+  *params*, *cookie*, *referer*, and *header*.
+
+* `subfield` - (Optional, String) Specifies the matched subfield.
+  - If `field` is set to *cookie*, subfield indicates cookie name.
+  - If `field` is set to *params*, subfield indicates param name.
+  - If `field` is set to *header*, subfield indicates an option in the header.
+
+* `logic` - (Required, String) Specifies the logic relationship. The value can be *contain*, *not_contain*,
+  *equal*, *not_equal*, *prefix*, *not_prefix*, *suffix*, and *not_suffix*.
+  If `field` is set to *ip*, `logic` can only be *equal* or *not_equal*.
+
+* `content` - (Required, String) Specifies the content matching the condition.
+
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The rule ID in UUID format.
+
+## Import
+
+Precise Protection Rules can be imported using the policy ID and rule ID
+separated by a slash, e.g.:
+
+```sh
+terraform import flexibleengine_waf_rule_precise_protection.rule_1 523083f4543c497faecd25fcfcc0b2a0/620801321b254f8fbc7dafa6bbebe652
+```

--- a/docs/resources/waf_rule_web_tamper_protection.md
+++ b/docs/resources/waf_rule_web_tamper_protection.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# flexibleengine_waf_rule_web_tamper_protection
+
+Manages a WAF Web Tamper Protection Rule resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_waf_policy" "policy_1" {
+  name = "policy_1"
+}
+
+resource "flexibleengine_waf_rule_web_tamper_protection" "rule_1" {
+  policy_id = flexibleengine_waf_policy.policy_1.id
+  domain    = "www.abc.com"
+  path      = "/a"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `policy_id` - (Required, String, ForceNew) Specifies the WAF policy ID. Changing this creates a new rule.
+
+* `domain` - (Required, String, ForceNew) Specifies the domain name. Changing this creates a new rule.
+
+* `path` - (Required, String, ForceNew) Specifies the URL protected by the web tamper protection rule,
+  excluding a domain name. Changing this creates a new rule.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The rule ID in UUID format.
+
+## Import
+
+Web Tamper Protection Rules can be imported using the policy ID and rule ID
+separated by a slash, e.g.:
+
+```sh
+terraform import flexibleengine_waf_rule_web_tamper_protection.rule_1 523083f4543c497faecd25fcfcc0b2a0/5b3b07fedc3642d18e424b2e45aebc8a
+```

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -331,6 +331,7 @@ func Provider() terraform.ResourceProvider {
 			"flexibleengine_waf_rule_data_masking":              resourceWafRuleDataMasking(),
 			"flexibleengine_waf_rule_cc_protection":             resourceWafRuleCCAttackProtection(),
 			"flexibleengine_waf_rule_precise_protection":        resourceWafRulePreciseProtection(),
+			"flexibleengine_waf_rule_web_tamper_protection":     resourceWafRuleWebTamperProtection(),
 
 			// Deprecated resource
 			"flexibleengine_rds_instance_v1": resourceRdsInstance(),

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -330,6 +330,7 @@ func Provider() terraform.ResourceProvider {
 			"flexibleengine_waf_rule_alarm_masking":             resourceWafRuleAlarmMasking(),
 			"flexibleengine_waf_rule_data_masking":              resourceWafRuleDataMasking(),
 			"flexibleengine_waf_rule_cc_protection":             resourceWafRuleCCAttackProtection(),
+			"flexibleengine_waf_rule_precise_protection":        resourceWafRulePreciseProtection(),
 
 			// Deprecated resource
 			"flexibleengine_rds_instance_v1": resourceRdsInstance(),

--- a/flexibleengine/resource_flexibleengine_waf_rule_precise_protection.go
+++ b/flexibleengine/resource_flexibleengine_waf_rule_precise_protection.go
@@ -1,0 +1,256 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	rules "github.com/huaweicloud/golangsdk/openstack/waf/v1/preciseprotection_rules"
+)
+
+func resourceWafRulePreciseProtection() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceWafRulePreciseProtectionCreate,
+		Read:   resourceWafRulePreciseProtectionRead,
+		Update: resourceWafRulePreciseProtectionUpdate,
+		Delete: resourceWafRulePreciseProtectionDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceWafRulesImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"action": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "block",
+				ValidateFunc: validation.StringInSlice([]string{
+					"block", "pass",
+				}, false),
+			},
+			"priority": {
+				Type:         schema.TypeInt,
+				Required:     true,
+				ValidateFunc: validation.IntBetween(0, 65535),
+			},
+			"conditions": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 30,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"field": {
+							Type:     schema.TypeString,
+							Required: true,
+							ValidateFunc: validation.StringInSlice([]string{
+								"path", "user-agent", "ip", "params", "cookie", "referer", "header",
+							}, false),
+						},
+						"subfield": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"logic": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"content": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"start_time": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: IsRFC3339Time,
+			},
+			"end_time": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: IsRFC3339Time,
+			},
+		},
+	}
+}
+
+func buildWafRuleProtectionConditions(d *schema.ResourceData) []rules.Condition {
+	conditions := d.Get("conditions").([]interface{})
+	conditionOpts := make([]rules.Condition, len(conditions))
+
+	for i, v := range conditions {
+		cond := v.(map[string]interface{})
+		conditionOpts[i] = rules.Condition{
+			Category: cond["field"].(string),
+			Index:    cond["subfield"].(string),
+			Logic:    cond["logic"].(string),
+			Contents: []string{cond["content"].(string)},
+		}
+	}
+
+	log.Printf("[DEBUG] build Protection Condition Rule opts: %#v", conditionOpts)
+	return conditionOpts
+}
+
+func buildWafRuleProtectionAction(d *schema.ResourceData) rules.Action {
+	action := rules.Action{
+		Category: d.Get("action").(string),
+	}
+	return action
+}
+
+func convertTimeToUnix(date string) (int64, error) {
+	var err error
+	if t, err := time.Parse(RFC3339ZNoTNoZ, date); err == nil {
+		return t.Unix(), nil
+	}
+	return 0, fmt.Errorf("[%s] is not an expected date: %+v", date, err)
+}
+
+func buildWafRuleProtectionOpts(d *schema.ResourceData) (*rules.CreateOpts, error) {
+	priority := d.Get("priority").(int)
+	opts := rules.CreateOpts{
+		Name:       d.Get("name").(string),
+		Priority:   &priority,
+		Conditions: buildWafRuleProtectionConditions(d),
+		Action:     buildWafRuleProtectionAction(d),
+	}
+
+	if v, ok := d.GetOk("start_time"); ok {
+		start, err := convertTimeToUnix(v.(string))
+		if err != nil {
+			return nil, fmt.Errorf("error converting start time: %s", err)
+		}
+		opts.Time = true
+		opts.Start = start
+	}
+	if v, ok := d.GetOk("end_time"); ok {
+		end, err := convertTimeToUnix(v.(string))
+		if err != nil {
+			return nil, fmt.Errorf("error converting end time: %s", err)
+		}
+		opts.Time = true
+		opts.End = end
+	}
+
+	return &opts, nil
+}
+
+func resourceWafRulePreciseProtectionCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Client: %s", err)
+	}
+
+	createOpts, err := buildWafRuleProtectionOpts(d)
+	if err != nil {
+		return fmt.Errorf("error building WAF Precise Protection Rule opts: %s", err)
+	}
+	log.Printf("[DEBUG] WAF precise protection rule creating opts: %#v", createOpts)
+
+	policyID := d.Get("policy_id").(string)
+	rule, err := rules.Create(wafClient, policyID, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Precise Protection Rule: %s", err)
+	}
+
+	log.Printf("[DEBUG] WAF precise protection rule created: %#v", rule)
+	d.SetId(rule.Id)
+
+	return resourceWafRulePreciseProtectionRead(d, meta)
+}
+
+func resourceWafRulePreciseProtectionUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Client: %s", err)
+	}
+
+	updateOpts, err := buildWafRuleProtectionOpts(d)
+	if err != nil {
+		return fmt.Errorf("error building WAF Precise Protection Rule opts: %s", err)
+	}
+	log.Printf("[DEBUG] WAF precise protection rule updating opts: %#v", updateOpts)
+
+	policyID := d.Get("policy_id").(string)
+	_, err = rules.Update(wafClient, policyID, d.Id(), updateOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("error updating Flexibleengine WAF Precise Protection Rule: %s", err)
+	}
+
+	return resourceWafRulePreciseProtectionRead(d, meta)
+}
+
+func resourceWafRulePreciseProtectionRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	n, err := rules.Get(wafClient, policyID, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "WAF Precise Protection Rule")
+	}
+
+	d.SetId(n.Id)
+	d.Set("policy_id", n.PolicyID)
+	d.Set("name", n.Name)
+	d.Set("action", n.Action.Category)
+	d.Set("priority", n.Priority)
+
+	conditions := make([]map[string]interface{}, len(n.Conditions))
+	for i, condition := range n.Conditions {
+		conditions[i] = make(map[string]interface{})
+		conditions[i]["field"] = condition.Category
+		conditions[i]["subfield"] = condition.Index
+		conditions[i]["logic"] = condition.Logic
+		if len(condition.Contents) > 0 {
+			conditions[i]["content"] = condition.Contents[0]
+		}
+	}
+	d.Set("conditions", conditions)
+
+	if n.Start != 0 {
+		startTime := time.Unix(n.Start, 0).UTC().Format(RFC3339ZNoTNoZ)
+		d.Set("start_time", startTime)
+	}
+	if n.End != 0 {
+		endTime := time.Unix(n.End, 0).UTC().Format(RFC3339ZNoTNoZ)
+		d.Set("end_time", endTime)
+	}
+
+	return nil
+}
+
+func resourceWafRulePreciseProtectionDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	err = rules.Delete(wafClient, policyID, d.Id()).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("error deleting Flexibleengine WAF Precise Protection Rule: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/flexibleengine/resource_flexibleengine_waf_rule_precise_protection_test.go
+++ b/flexibleengine/resource_flexibleengine_waf_rule_precise_protection_test.go
@@ -1,0 +1,207 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	rules "github.com/huaweicloud/golangsdk/openstack/waf/v1/preciseprotection_rules"
+)
+
+func TestAccWafRulePreciseProtection_basic(t *testing.T) {
+	var rule rules.Precise
+	randName := acctest.RandString(5)
+	resourceName := "flexibleengine_waf_rule_precise_protection.rule_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckWafRulePreciseProtectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafRulePreciseProtection_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRulePreciseProtectionExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("rule_%s", randName)),
+					resource.TestCheckResourceAttr(resourceName, "action", "block"),
+					resource.TestCheckResourceAttr(resourceName, "priority", "10"),
+					resource.TestCheckResourceAttr(resourceName, "conditions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "conditions.0.content", "/login"),
+					resource.TestCheckNoResourceAttr(resourceName, "start_time"),
+					resource.TestCheckNoResourceAttr(resourceName, "end_time"),
+				),
+			},
+			{
+				Config: testAccWafRulePreciseProtection_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRulePreciseProtectionExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("rule_%s_update", randName)),
+					resource.TestCheckResourceAttr(resourceName, "action", "block"),
+					resource.TestCheckResourceAttr(resourceName, "priority", "20"),
+					resource.TestCheckResourceAttr(resourceName, "conditions.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "conditions.0.content", "/login"),
+					resource.TestCheckResourceAttr(resourceName, "conditions.1.content", "192.168.1.1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWafRuleImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccWafRulePreciseProtection_time(t *testing.T) {
+	var rule rules.Precise
+	randName := acctest.RandString(5)
+	resourceName := "flexibleengine_waf_rule_precise_protection.rule_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckWafRulePreciseProtectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafRulePreciseProtection_time(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRulePreciseProtectionExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("rule_%s", randName)),
+					resource.TestCheckResourceAttr(resourceName, "action", "block"),
+					resource.TestCheckResourceAttr(resourceName, "priority", "10"),
+					resource.TestCheckResourceAttr(resourceName, "start_time", "2021-10-01 00:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "end_time", "2021-12-31 23:59:59"),
+					resource.TestCheckResourceAttr(resourceName, "conditions.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "conditions.0.content", "/login"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckWafRulePreciseProtectionDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	wafClient, err := config.WafV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_waf_rule_precise_protection" {
+			continue
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		_, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("WAF rule still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafRulePreciseProtectionExists(n string, rule *rules.Precise) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		wafClient, err := config.WafV1Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		found, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("WAF rule not found")
+		}
+
+		*rule = *found
+
+		return nil
+	}
+}
+
+func testAccWafRulePreciseProtection_basic(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_waf_policy" "policy_1" {
+  name = "policy_%s"
+}
+
+resource "flexibleengine_waf_rule_precise_protection" "rule_1" {
+  policy_id = flexibleengine_waf_policy.policy_1.id
+  name      = "rule_%s"
+  priority  = 10
+  
+  conditions {
+    field   = "path"
+    logic   = "contain"
+    content = "/login"
+  }
+}
+`, name, name)
+}
+
+func testAccWafRulePreciseProtection_update(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_waf_policy" "policy_1" {
+  name = "policy_%s"
+}
+
+resource "flexibleengine_waf_rule_precise_protection" "rule_1" {
+  policy_id = flexibleengine_waf_policy.policy_1.id
+  name      = "rule_%s_update"
+  priority  = 20
+  
+  conditions {
+    field   = "path"
+    logic   = "contain"
+    content = "/login"
+  }
+  conditions {
+    field   = "ip"
+    logic   = "equal"
+    content = "192.168.1.1"
+  }
+}
+`, name, name)
+}
+
+func testAccWafRulePreciseProtection_time(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_waf_policy" "policy_1" {
+  name = "policy_%s"
+}
+
+resource "flexibleengine_waf_rule_precise_protection" "rule_1" {
+  policy_id  = flexibleengine_waf_policy.policy_1.id
+  name       = "rule_%s"
+  action     = "block"
+  priority   = 10
+  start_time = "2021-10-01 00:00:00"
+  end_time   = "2021-12-31 23:59:59"
+  
+  conditions {
+    field   = "path"
+    logic   = "prefix"
+    content = "/login"
+  }
+}
+`, name, name)
+}

--- a/flexibleengine/resource_flexibleengine_waf_rule_web_tamper_protection.go
+++ b/flexibleengine/resource_flexibleengine_waf_rule_web_tamper_protection.go
@@ -1,0 +1,100 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	rules "github.com/huaweicloud/golangsdk/openstack/waf/v1/webtamperprotection_rules"
+)
+
+func resourceWafRuleWebTamperProtection() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceWafRuleWebTamperProtectionCreate,
+		Read:   resourceWafRuleWebTamperProtectionRead,
+		Delete: resourceWafRuleWebTamperProtectionDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceWafRulesImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"policy_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceWafRuleWebTamperProtectionCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Client: %s", err)
+	}
+
+	createOpts := rules.CreateOpts{
+		Hostname: d.Get("domain").(string),
+		Url:      d.Get("path").(string),
+	}
+
+	policyID := d.Get("policy_id").(string)
+	rule, err := rules.Create(wafClient, policyID, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Web Tamper Protection Rule: %s", err)
+	}
+
+	log.Printf("[DEBUG] WAF web tamper protection rule created: %#v", rule)
+	d.SetId(rule.Id)
+
+	return resourceWafRuleWebTamperProtectionRead(d, meta)
+}
+
+func resourceWafRuleWebTamperProtectionRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	n, err := rules.Get(wafClient, policyID, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "WAF Web Tamper Protection Rule")
+	}
+
+	d.SetId(n.Id)
+	d.Set("policy_id", n.PolicyID)
+	d.Set("domain", n.Hostname)
+	d.Set("path", n.Url)
+
+	return nil
+}
+
+func resourceWafRuleWebTamperProtectionDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	wafClient, err := config.WafV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	policyID := d.Get("policy_id").(string)
+	err = rules.Delete(wafClient, policyID, d.Id()).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("error deleting Flexibleengine WAF Web Tamper Protection Rule: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/flexibleengine/resource_flexibleengine_waf_rule_web_tamper_protection_test.go
+++ b/flexibleengine/resource_flexibleengine_waf_rule_web_tamper_protection_test.go
@@ -1,0 +1,109 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	rules "github.com/huaweicloud/golangsdk/openstack/waf/v1/webtamperprotection_rules"
+)
+
+func TestAccWafRuleWebTamperProtection_basic(t *testing.T) {
+	var rule rules.WebTamper
+	randName := acctest.RandString(5)
+	resourceName := "flexibleengine_waf_rule_web_tamper_protection.rule_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckWafWafRuleWebTamperProtectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafWafRuleWebTamperProtection_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafRuleWebTamperProtectionExists(resourceName, &rule),
+					resource.TestCheckResourceAttr(resourceName, "domain", "www.abc.com"),
+					resource.TestCheckResourceAttr(resourceName, "path", "/a"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccWafRuleImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckWafWafRuleWebTamperProtectionDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	wafClient, err := config.WafV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_waf_rule_web_tamper_protection" {
+			continue
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		_, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("WAF rule still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafRuleWebTamperProtectionExists(n string, rule *rules.WebTamper) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		wafClient, err := config.WafV1Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+		}
+
+		policyID := rs.Primary.Attributes["policy_id"]
+		found, err := rules.Get(wafClient, policyID, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("WAF web tamper protection rule not found")
+		}
+
+		*rule = *found
+
+		return nil
+	}
+}
+
+func testAccWafWafRuleWebTamperProtection_basic(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_waf_policy" "policy_1" {
+  name = "policy_%s"
+}
+
+resource "flexibleengine_waf_rule_web_tamper_protection" "rule_1" {
+  policy_id = flexibleengine_waf_policy.policy_1.id
+  domain    = "www.abc.com"
+  path      = "/a"
+}
+`, name)
+}

--- a/flexibleengine/validators.go
+++ b/flexibleengine/validators.go
@@ -323,3 +323,21 @@ func validateECSTagValue(v interface{}, k string) (ws []string, errors []error) 
 	}
 	return
 }
+
+// RFC3339ZNoTNoZ is a time format
+const RFC3339ZNoTNoZ = "2006-01-02 15:04:05"
+
+// IsRFC3339Time is a SchemaValidateFunc which tests if the provided value is of type string and a valid RFC33349Time
+func IsRFC3339Time(i interface{}, k string) (warnings []string, errors []error) {
+	v, ok := i.(string)
+	if !ok {
+		errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+		return warnings, errors
+	}
+
+	if _, err := time.Parse(RFC3339ZNoTNoZ, v); err != nil {
+		errors = append(errors, fmt.Errorf("expected %q to be a valid date, got %q: %+v", k, i, err))
+	}
+
+	return warnings, errors
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210624022515-eefdf1d43b21
+	github.com/huaweicloud/golangsdk v0.0.0-20210625084017-1140ae646b73
 	github.com/huaweicloud/terraform-provider-huaweicloud v1.25.1-0.20210621022651-b1aa07d8ce12
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jtolds/gls v4.20.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -232,6 +232,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20210621115823-3cecb9fc9172 h1:6OLBFIxdh
 github.com/huaweicloud/golangsdk v0.0.0-20210621115823-3cecb9fc9172/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/golangsdk v0.0.0-20210624022515-eefdf1d43b21 h1:S6MdycKYfaCv/e4+xsIiDQE1HsZ3RqsrqKgCq8/3keg=
 github.com/huaweicloud/golangsdk v0.0.0-20210624022515-eefdf1d43b21/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210625084017-1140ae646b73 h1:kniJvk+WbEk38yRkDFMRmm1bCaZXPzBa1jkGkePfMvU=
+github.com/huaweicloud/golangsdk v0.0.0-20210625084017-1140ae646b73/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.25.1-0.20210621022651-b1aa07d8ce12 h1:Gnt3/6dft3Q5tKyKMThZdmzdDtkP85diIBcrvgcs2vg=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.25.1-0.20210621022651-b1aa07d8ce12/go.mod h1:SPfV6A6ZdqeIaqnPOVMomuMdVjjnzA0pzdALxcR5wXY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/preciseprotection_rules/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/preciseprotection_rules/requests.go
@@ -1,0 +1,87 @@
+package preciseprotection_rules
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+var RequestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToPreciseCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new precise protection rule.
+type CreateOpts struct {
+	Name       string      `json:"name" required:"true"`
+	Time       bool        `json:"time"`
+	Start      int64       `json:"start,omitempty"`
+	End        int64       `json:"end,omitempty"`
+	Conditions []Condition `json:"conditions" required:"true"`
+	Action     Action      `json:"action" required:"true"`
+	Priority   *int        `json:"priority,omitempty"`
+}
+
+type Condition struct {
+	Category string   `json:"category" required:"true"`
+	Index    string   `json:"index,omitempty"`
+	Logic    string   `json:"logic" required:"true"`
+	Contents []string `json:"contents" required:"true"`
+}
+
+type Action struct {
+	Category string `json:"category" required:"true"`
+}
+
+// ToPreciseCreateMap builds a create request body from CreateOpts.
+func (opts CreateOpts) ToPreciseCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create will create a new precise protection rule based on the values in CreateOpts.
+func Create(c *golangsdk.ServiceClient, policyID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToPreciseCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Post(rootURL(c, policyID), b, &r.Body, reqOpt)
+	return
+}
+
+// Update will update a precise protection rule based on the values in CreateOpts.
+// The response code from api is 200
+func Update(c *golangsdk.ServiceClient, policyID, ruleID string, opts CreateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToPreciseCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Put(resourceURL(c, policyID, ruleID), b, &r.Body, reqOpt)
+	return
+}
+
+// Get retrieves a particular precise rule based on its unique ID.
+func Get(c *golangsdk.ServiceClient, policyID, ruleID string) (r GetResult) {
+	reqOpt := &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	}
+
+	_, r.Err = c.Get(resourceURL(c, policyID, ruleID), &r.Body, reqOpt)
+	return
+}
+
+// Delete will permanently delete a particular precise rule based on its unique ID.
+func Delete(c *golangsdk.ServiceClient, policyID, ruleID string) (r DeleteResult) {
+	reqOpt := &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	}
+
+	_, r.Err = c.Delete(resourceURL(c, policyID, ruleID), reqOpt)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/preciseprotection_rules/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/preciseprotection_rules/results.go
@@ -1,0 +1,52 @@
+package preciseprotection_rules
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+type Precise struct {
+	Id         string      `json:"id"`
+	PolicyID   string      `json:"policy_id"`
+	Name       string      `json:"name"`
+	Time       bool        `json:"time"`
+	Start      int64       `json:"start"`
+	End        int64       `json:"end"`
+	Conditions []Condition `json:"conditions"`
+	Action     Action      `json:"action"`
+	Priority   int         `json:"priority"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a precise protection rule.
+func (r commonResult) Extract() (*Precise, error) {
+	var response Precise
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a precise protection rule.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of a update operation. Call its Extract
+// method to interpret it as a precise protection rule.
+type UpdateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a precise protection rule.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/preciseprotection_rules/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/preciseprotection_rules/urls.go
@@ -1,0 +1,11 @@
+package preciseprotection_rules
+
+import "github.com/huaweicloud/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient, policyID string) string {
+	return c.ServiceURL("policy", policyID, "custom")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, policyID, id string) string {
+	return c.ServiceURL("policy", policyID, "custom", id)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/webtamperprotection_rules/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/webtamperprotection_rules/requests.go
@@ -1,0 +1,58 @@
+package webtamperprotection_rules
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+var RequestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToWebTamperCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts contains all the values needed to create a new web tamper protection rule.
+type CreateOpts struct {
+	Hostname string `json:"hostname" required:"true"`
+	Url      string `json:"path" required:"true"`
+}
+
+// ToWebTamperCreateMap builds a create request body from CreateOpts.
+func (opts CreateOpts) ToWebTamperCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create will create a new web tamper protection rule based on the values in CreateOpts.
+func Create(c *golangsdk.ServiceClient, policyID string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToWebTamperCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Post(rootURL(c, policyID), b, &r.Body, reqOpt)
+	return
+}
+
+// Get retrieves a particular web tamper protection rule based on its unique ID.
+func Get(c *golangsdk.ServiceClient, policyID, ruleID string) (r GetResult) {
+	reqOpt := &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	}
+
+	_, r.Err = c.Get(resourceURL(c, policyID, ruleID), &r.Body, reqOpt)
+	return
+}
+
+// Delete will permanently delete a particular web tamper protection rule based on its unique ID.
+func Delete(c *golangsdk.ServiceClient, policyID, ruleID string) (r DeleteResult) {
+	reqOpt := &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	}
+
+	_, r.Err = c.Delete(resourceURL(c, policyID, ruleID), reqOpt)
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/webtamperprotection_rules/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/webtamperprotection_rules/results.go
@@ -1,0 +1,48 @@
+package webtamperprotection_rules
+
+import (
+	"github.com/huaweicloud/golangsdk"
+)
+
+type WebTamper struct {
+	Id        string `json:"id"`
+	PolicyID  string `json:"policy_id"`
+	Hostname  string `json:"hostname"`
+	Url       string `json:"path"`
+	TimeStamp int64  `json:"timestamp"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a web tamper protection rule.
+func (r commonResult) Extract() (*WebTamper, error) {
+	var response WebTamper
+	err := r.ExtractInto(&response)
+	return &response, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Web Tamper Protection rule.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of a update operation. Call its Extract
+// method to interpret it as a Web Tamper Protection rule.
+type UpdateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Web Tamper Protection rule.
+type GetResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/webtamperprotection_rules/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/waf/v1/webtamperprotection_rules/urls.go
@@ -1,0 +1,11 @@
+package webtamperprotection_rules
+
+import "github.com/huaweicloud/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient, policyID string) string {
+	return c.ServiceURL("policy", policyID, "antitamper")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, policyID, id string) string {
+	return c.ServiceURL("policy", policyID, "antitamper", id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -261,7 +261,7 @@ github.com/hashicorp/terraform-svchost/auth
 github.com/hashicorp/terraform-svchost/disco
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210624022515-eefdf1d43b21
+# github.com/huaweicloud/golangsdk v0.0.0-20210625084017-1140ae646b73
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal
@@ -399,6 +399,7 @@ github.com/huaweicloud/golangsdk/openstack/waf/v1/datamasking_rules
 github.com/huaweicloud/golangsdk/openstack/waf/v1/domains
 github.com/huaweicloud/golangsdk/openstack/waf/v1/falsealarmmasking_rules
 github.com/huaweicloud/golangsdk/openstack/waf/v1/policies
+github.com/huaweicloud/golangsdk/openstack/waf/v1/preciseprotection_rules
 github.com/huaweicloud/golangsdk/openstack/waf/v1/whiteblackip_rules
 github.com/huaweicloud/golangsdk/pagination
 # github.com/huaweicloud/terraform-provider-huaweicloud v1.25.1-0.20210621022651-b1aa07d8ce12

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -400,6 +400,7 @@ github.com/huaweicloud/golangsdk/openstack/waf/v1/domains
 github.com/huaweicloud/golangsdk/openstack/waf/v1/falsealarmmasking_rules
 github.com/huaweicloud/golangsdk/openstack/waf/v1/policies
 github.com/huaweicloud/golangsdk/openstack/waf/v1/preciseprotection_rules
+github.com/huaweicloud/golangsdk/openstack/waf/v1/webtamperprotection_rules
 github.com/huaweicloud/golangsdk/openstack/waf/v1/whiteblackip_rules
 github.com/huaweicloud/golangsdk/pagination
 # github.com/huaweicloud/terraform-provider-huaweicloud v1.25.1-0.20210621022651-b1aa07d8ce12


### PR DESCRIPTION
the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccWafRuleWebTamperProtection_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccWafRuleWebTamperProtection_basic -timeout 720m
=== RUN   TestAccWafRuleWebTamperProtection_basic
=== PAUSE TestAccWafRuleWebTamperProtection_basic
=== CONT  TestAccWafRuleWebTamperProtection_basic
--- PASS: TestAccWafRuleWebTamperProtection_basic (13.93s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 13.943s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccWafRulePreciseProtection_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccWafRulePreciseProtection_basic -timeout 720m
=== RUN   TestAccWafRulePreciseProtection_basic
=== PAUSE TestAccWafRulePreciseProtection_basic
=== CONT  TestAccWafRulePreciseProtection_basic
--- PASS: TestAccWafRulePreciseProtection_basic (23.35s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 23.364s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccWafRulePreciseProtection_time'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccWafRulePreciseProtection_time -timeout 720m
=== RUN   TestAccWafRulePreciseProtection_time
=== PAUSE TestAccWafRulePreciseProtection_time
=== CONT  TestAccWafRulePreciseProtection_time
--- PASS: TestAccWafRulePreciseProtection_time (12.21s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 12.222s
```

All resources of WAF are implemented, we can fixes #533 