### PR TITLE
waf: make full_detection be updatable in policy

### DIFF
--- a/docs/resources/waf_policy.md
+++ b/docs/resources/waf_policy.md
@@ -30,6 +30,12 @@ The following arguments are supported:
   - *2*: medium
   - *3*: high
 
+* `full_detection` - (Optional, Bool) Specifies the detection mode in Precise Protection. Valid values are:
+  * *true*: full detection, Full detection finishes all threat detections before blocking requests that
+    meet Precise Protection specified conditions.
+  * *false*: instant detection. Instant detection immediately ends threat detection after blocking a request that
+    meets Precise Protection specified conditions.
+
 * `domains` - (Optional, List) An array of domain IDs.
 
 ## Attributes Reference
@@ -38,19 +44,13 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The policy ID in UUID format.
 
-* `full_detection` - The detection mode in Precise Protection.
-  * *true*: full detection, Full detection finishes all threat detections before blocking requests that meet Precise Protection specified conditions.
-  * *false*: instant detection. Instant detection immediately ends threat detection after blocking a request that meets Precise Protection specified conditions.
+* `protection_status` - The protection switches. The object structure is documented below.
 
-* `options` - The protection switches. The options object structure is documented below.
+The `protection_status` block supports:
 
-The `options` block supports:
+* `basic_web_protection` - Indicates whether Basic Web Protection is enabled.
 
-* `webattack` - Indicates whether Basic Web Protection is enabled.
-
-* `common` - Indicates whether General Check in Basic Web Protection is enabled.
-
-* `crawler` - Indicates whether the master crawler detection switch in Basic Web Protection is enabled.
+* `general_check` - Indicates whether General Check in Basic Web Protection is enabled.
 
 * `crawler_engine` - Indicates whether the Search Engine switch in Basic Web Protection is enabled.
 
@@ -62,17 +62,17 @@ The `options` block supports:
 
 * `webshell` - Indicates whether webshell detection in Basic Web Protection is enabled.
 
-* `cc` - Indicates whether CC Attack Protection is enabled.
+* `cc_protection` - Indicates whether CC Attack Protection is enabled.
 
-* `custom` - Indicates whether Precise Protection is enabled.
+* `precise_protection` - Indicates whether Precise Protection is enabled.
 
-* `whiteblackip` - Indicates whether Blacklist and Whitelist is enabled.
+* `blacklist` - Indicates whether Blacklist and Whitelist is enabled.
 
-* `privacy` - Indicates whether Data Masking is enabled.
+* `data_masking` - Indicates whether Data Masking is enabled.
 
-* `ignore` - Indicates whether False Alarm Masking is enabled.
+* `false_alarm_masking` - Indicates whether False Alarm Masking is enabled.
 
-* `antitamper` - Indicates whether Web Tamper Protection is enabled.
+* `web_tamper_protection` - Indicates whether Web Tamper Protection is enabled.
 
 ## Import
 

--- a/flexibleengine/resource_flexibleengine_waf_policy_test.go
+++ b/flexibleengine/resource_flexibleengine_waf_policy_test.go
@@ -16,7 +16,7 @@ func TestAccWafPolicyV1_basic(t *testing.T) {
 	randName := acctest.RandString(5)
 	resourceName := "flexibleengine_waf_policy.policy_1"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckWafPolicyV1Destroy,
@@ -29,6 +29,8 @@ func TestAccWafPolicyV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "protection_mode", "log"),
 					resource.TestCheckResourceAttr(resourceName, "level", "2"),
 					resource.TestCheckResourceAttr(resourceName, "full_detection", "false"),
+					resource.TestCheckResourceAttr(resourceName, "protection_status.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "protection_status.0.basic_web_protection", "true"),
 				),
 			},
 			{
@@ -38,6 +40,7 @@ func TestAccWafPolicyV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("policy-%s-updated", randName)),
 					resource.TestCheckResourceAttr(resourceName, "protection_mode", "block"),
 					resource.TestCheckResourceAttr(resourceName, "level", "1"),
+					resource.TestCheckResourceAttr(resourceName, "full_detection", "true"),
 				),
 			},
 			{
@@ -116,6 +119,7 @@ resource "flexibleengine_waf_policy" "policy_1" {
   name            = "policy-%s-updated"
   level           = 1
   protection_mode = "block"
+  full_detection  = true
 }
 `, name)
 }


### PR DESCRIPTION
the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccWafPolicyV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccWafPolicyV1_basic -timeout 720m
=== RUN   TestAccWafPolicyV1_basic
=== PAUSE TestAccWafPolicyV1_basic
=== CONT  TestAccWafPolicyV1_basic
--- PASS: TestAccWafPolicyV1_basic (21.59s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 21.606s
```