### PR TITLE
fix: convert dds port to int

### DIFF
--- a/flexibleengine/resource_flexibleengine_dds_instance_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_dds_instance_v3_test.go
@@ -25,6 +25,7 @@ func TestAccDDSV3Instance_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDDSV3InstanceExists(resourceName, &instance),
 					resource.TestCheckResourceAttr(resourceName, "name", instanceName),
+					resource.TestCheckResourceAttr(resourceName, "port", "8635"),
 					resource.TestCheckResourceAttr(resourceName, "ssl", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),


### PR DESCRIPTION
fixes #571 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDDSV3Instance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDDSV3Instance_basic -timeout 720m
=== RUN   TestAccDDSV3Instance_basic
--- PASS: TestAccDDSV3Instance_basic (669.03s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 669.044s
```