### PR TITLE
eip: add tags support

### DIFF
--- a/docs/resources/vpc_eip_v1.md
+++ b/docs/resources/vpc_eip_v1.md
@@ -19,6 +19,21 @@ resource "flexibleengine_vpc_eip_v1" "eip_1" {
     share_type = "PER"
   }
 }
+
+resource "flexibleengine_vpc_eip_v1" "eip_with_tags" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name       = "mybandwidth"
+    size       = 10
+    share_type = "PER"
+  }
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
 ```
 
 ## Argument Reference
@@ -32,6 +47,7 @@ The following arguments are supported:
 
 * `bandwidth` - (Required) The bandwidth object.
 
+* `tags` - (Optional) The key/value pairs to associate with the EIP.
 
 The `publicip` block supports:
 

--- a/flexibleengine/resource_flexibleengine_vpc_eip_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_vpc_eip_v1_test.go
@@ -33,6 +33,15 @@ func TestAccVpcV1EIP_basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccVpcV1EIP_tags(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcV1EIPExists(resourceName, &eip),
+					resource.TestCheckResourceAttr(resourceName, "status", "UNBOUND"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+				),
+			},
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -104,6 +113,25 @@ resource "flexibleengine_vpc_eip_v1" "eip_1" {
     share_type = "PER"
     name       = "%s"
     size       = 5
+  }
+}
+`, rName)
+}
+
+func testAccVpcV1EIP_tags(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc_eip_v1" "eip_1" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    share_type = "PER"
+    name       = "%s"
+    size       = 5
+  }
+  tags = {
+    foo = "bar"
+    key = "value"
   }
 }
 `, rName)


### PR DESCRIPTION
fixes #564 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccVpcV1EIP_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccVpcV1EIP_basic -timeout 720m
=== RUN   TestAccVpcV1EIP_basic
--- PASS: TestAccVpcV1EIP_basic (46.82s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 46.837s
```