### PR TITLE
set default value for tenant_name and auth_url

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,11 +11,10 @@ Use the navigation to the left to read about the available resources.
 ```hcl
 # Configure the FlexibleEngine Provider
 provider "flexibleengine" {
+  domain_name = "admin"
   user_name   = "admin"
-  tenant_name = "admin"
   password    = "pwd"
-  auth_url    = "http://myauthurl:5000/v2.0"
-  region      = "RegionOne"
+  region      = "eu-west-0"
 }
 
 # Create a web server
@@ -30,11 +29,9 @@ resource "flexibleengine_compute_instance_v2" "test-server" {
 
 ```hcl
 provider "flexibleengine" {
-  user_name   = "${var.user_name}"
-  password    = "${var.password}"
-  domain_name = "${var.domain_name}"
-  tenant_name = "${var.tenant_name}"
-  auth_url    = "https://iam.eu-west-0.prod-cloud-ocb.orange-business.com/v3"
+  domain_name = var.domain_name
+  user_name   = var.user_name
+  password    = var.password
   region      = "eu-west-0"
 }
 ```
@@ -43,11 +40,9 @@ provider "flexibleengine" {
 
 ```hcl
 provider "flexibleengine" {
-  access_key  = "${var.access_key}"
-  secret_key  = "${var.secret_key}"
-  domain_name = "${var.domain_name}"
-  tenant_name = "${var.tenant_name}"
-  auth_url    = "https://iam.eu-west-0.prod-cloud-ocb.orange-business.com/v3"
+  access_key  = var.access_key
+  secret_key  = var.secret_key
+  domain_name = var.domain_name
   region      = "eu-west-0"
 }
 ```
@@ -56,26 +51,26 @@ provider "flexibleengine" {
 
 ```hcl
 provider "flexibleengine" {
-  token       = "${var.token}"
-  domain_name = "${var.domain_name}"
-  tenant_name = "${var.tenant_name}"
-  auth_url    = "https://iam.eu-west-0.prod-cloud-ocb.orange-business.com/v3"
+  token       = var.token
+  domain_name = var.domain_name
+  tenant_name = var.tenant_name
   region      = "eu-west-0"
 }
 ```
-Note: if token, aksk and password are set simultaneously, then it will authenticate in the order of Token, Password and AKSK.
+
+-> If token, aksk and password are set simultaneously, then it will authenticate in the order of Token, Password and AKSK.
 
 ### Federated
 
 ```hcl
 provider "flexibleengine" {
-  token          = "${var.token}"
-  security_token = "${var.security_token}"
-  access_key     = "${var.access_key}"
-  secret_key     = "${var.secret_key}"
-  domain_name    = "${var.domain_name}"
-  tenant_name    = "${var.tenant_name}"
-  auth_url    = "https://iam.eu-west-0.prod-cloud-ocb.orange-business.com/v3"
+  token          = var.token
+  security_token = var.security_token
+  access_key     = var.access_key
+  secret_key     = var.secret_key
+  domain_name    = var.domain_name
+  tenant_name    = var.tenant_name
+  region         = "eu-west-0"
 }
 ```
 
@@ -83,63 +78,58 @@ provider "flexibleengine" {
 
 The following arguments are supported:
 
+* `region` - (Required) The region of the FlexibleEngine cloud to use. It must be provided,
+  but it can also be sourced from the `OS_REGION_NAME` environment variables.
+
+* `domain_id` - (Optional; Required if not using `domain_name`) The ID of the Domain to scope to.
+  If omitted, the following environment variables are checked (in this order):
+  `OS_USER_DOMAIN_ID`, `OS_PROJECT_DOMAIN_ID`, `OS_DOMAIN_ID`.
+
+* `domain_name` - (Optional; Required if not using `domain_id`) The Name of the Domain to scope to.
+  If omitted, the following environment variables are checked (in this order):
+  `OS_USER_DOMAIN_NAME`, `OS_PROJECT_DOMAIN_NAME`, `OS_DOMAIN_NAME`,
+  `DEFAULT_DOMAIN`.
+
 * `access_key` - (Optional) The access key of the FlexibleEngine cloud to use.
   If omitted, the `OS_ACCESS_KEY` environment variable is used.
 
 * `secret_key` - (Optional) The secret key of the FlexibleEngine cloud to use.
   If omitted, the `OS_SECRET_KEY` environment variable is used.
 
-* `auth_url` - (Required) The Identity authentication URL. If omitted, the
-  `OS_AUTH_URL` environment variable is used.
-
-* `region` - (Optional) The region of the FlexibleEngine cloud to use. If omitted,
-  the `OS_REGION_NAME` environment variable is used. If `OS_REGION_NAME` is
-  not set, then no region will be used. It should be possible to omit the
-  region in single-region FlexibleEngine environments, but this behavior may vary
-  depending on the FlexibleEngine environment being used.
-
-* `user_name` - (Optional) The Username to login with. If omitted, the
+* `user_name` - (Optional) The User name to login with. If omitted, the
   `OS_USERNAME` environment variable is used.
 
 * `user_id` - (Optional) The User ID to login with. If omitted, the
   `OS_USER_ID` environment variable is used.
 
-* `tenant_id` - (Optional) The ID of the Tenant (Identity v2) or Project
-  (Identity v3) to login with. If omitted, the `OS_TENANT_ID` or
-  `OS_PROJECT_ID` environment variables are used.
-
-* `tenant_name` - (Optional) The Name of the Tenant (Identity v2) or Project
-  (Identity v3) to login with. If omitted, the `OS_TENANT_NAME` or
-  `OS_PROJECT_NAME` environment variable are used.
-
 * `password` - (Optional) The Password to login with. If omitted, the
   `OS_PASSWORD` environment variable is used.
 
-* `token` - (Optional; Required if not using `user_name` and `password`)
-  A token is an expiring, temporary means of access issued via the Keystone
-  service. By specifying a token, you do not have to specify a username/password
+* `tenant_id` - (Optional) The ID of the Project to login with.
+  If omitted, the `OS_TENANT_ID` or `OS_PROJECT_ID` environment variables are used.
+
+* `tenant_name` - (Optional) The Name of the Project to login with.
+  If omitted, the `OS_TENANT_NAME`, `OS_PROJECT_NAME` environment variable or `region` is used.
+
+* `token` - (Optional) A token is an expiring, temporary means of access issued via the
+  IAM service. By specifying a token, you do not have to specify a username/password
   combination, since the token was already created by a username/password out of
   band of Terraform. If omitted, the `OS_AUTH_TOKEN` environment variable is used.
 
 * `security_token` - (Optional) Security token to use for OBS federated authentication.
 
-* `domain_id` - (Optional) The ID of the Domain to scope to (Identity v3). If
-  If omitted, the following environment variables are checked (in this order):
-  `OS_USER_DOMAIN_ID`, `OS_PROJECT_DOMAIN_ID`, `OS_DOMAIN_ID`.
-
-* `domain_name` - (Optional) The Name of the Domain to scope to (Identity v3).
-  If omitted, the following environment variables are checked (in this order):
-  `OS_USER_DOMAIN_NAME`, `OS_PROJECT_DOMAIN_NAME`, `OS_DOMAIN_NAME`,
-  `DEFAULT_DOMAIN`.
-
-* `insecure` - (Optional) Trust self-signed SSL certificates. If omitted, the
-  `OS_INSECURE` environment variable is used.
+* `auth_url` - (Optional) The Identity authentication URL.
+   If omitted, the `OS_AUTH_URL` environment variable is used.
+   The default value is https://iam.{{region}}.prod-cloud-ocb.orange-business.com/v3.
 
 * `max_retries` - (Optional) This is the maximum number of times an API
   call is retried, in the case where requests are being throttled or
   experiencing transient failures. The delay between the subsequent API
   calls increases exponentially. The default value is `5`.
   If omitted, the `OS_MAX_RETRIES` environment variable is used.
+
+* `insecure` - (Optional) Trust self-signed SSL certificates. If omitted, the
+  `OS_INSECURE` environment variable is used.
 
 * `cacert_file` - (Optional) Specify a custom CA certificate when communicating
   over SSL. You can specify either a path to the file or the contents of the
@@ -152,10 +142,6 @@ The following arguments are supported:
 * `key` - (Optional) Specify client private key file for SSL client
   authentication. You can specify either a path to the file or the contents of
   the key. If omitted the `OS_KEY` environment variable is used.
-
-* `endpoint_type` - (Optional) Specify which type of endpoint to use from the
-  service catalog. It can be set using the OS_ENDPOINT_TYPE environment
-  variable. If not set, public endpoints is used.
 
 ## Logging
 
@@ -179,27 +165,9 @@ variables must also be set:
 
 * `OS_REGION_NAME` - The region in which to create the server instance.
 
-* `OS_IMAGE_ID` or `OS_IMAGE_NAME` - a UUID or name of an existing image in
-    Glance.
+* `OS_ACCESS_KEY` - The access key of the FlexibleEngine cloud to use.
 
-* `OS_FLAVOR_ID` or `OS_FLAVOR_NAME` - an ID or name of an existing flavor.
-
-* `OS_POOL_NAME` - The name of a Floating IP pool.
-
-* `OS_NETWORK_ID` - The UUID of a network in your test environment.
-
-* `OS_EXTGW_ID` - The UUID of the external gateway.
+* `OS_SECRET_KEY` - The secret key of the FlexibleEngine cloud to use.
 
 You should be able to use any FlexibleEngine environment to develop on as long as the
 above environment variables are set.
-
-Most of Terraform's FlexibleEngine support is done in a standardized Packstack
-all-in-one environment. You can find the scripts to build this environment
-[here](https://github.com/jtopjian/terraform-devstack/tree/master/packstack-standard).
-The included `main.tf` file will need to be modified for your specific
-environment. Once it's up and running, you will have access to a standard,
-up-to-date FlexibleEngine environment with the latest FlexibleEngine services.
-
-If you require access to deprecated services, such as Keystone v2 and
-LBaaS v1, you can use the "legacy" environment
-[here](https://github.com/jtopjian/terraform-devstack/tree/master/packstack-legacy).


### PR DESCRIPTION
- set tenant_name to region when neither `tenant_name` nor `tenant_id` was specified
- set auth_url to https://iam.{{region}}.prod-cloud-ocb.orange-business.com/v3
- update docs

fixes #569 