### PR TITLE
feat: support vpc flow log resource

### DIFF
--- a/docs/resources/vpc_flow_log_v1.md
+++ b/docs/resources/vpc_flow_log_v1.md
@@ -1,0 +1,76 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# flexibleengine_vpc_flow_log_v1
+
+Manages a VPC flow log resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_lts_group" "log_group1" {
+  group_name = var.log_group_name
+}
+
+resource "flexibleengine_lts_topic" "log_topic1" {
+  group_id   = flexibleengine_lts_group.log_group1.id
+  topic_name = var.log_topic_name
+}
+
+resource "flexibleengine_vpc_flow_log_v1" "flowlog1" {
+  name          = var.flowlog_name
+  description   = var.flowlog_desc
+  resource_id   = var.port_id
+  traffic_type  = "all"
+  log_group_id  = flexibleengine_lts_group.log_group1.id
+  log_topic_id  = flexibleengine_lts_topic.log_topic1.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the VPC flow log resource.
+  If omitted, the provider-level region will be used. Changing this creates a new VPC flow log.
+
+* `name` - (Required, String) Specifies the VPC flow log name.
+  The value is a string of 1 to 64 characters that can contain letters, digits, underscores (_), hyphens (-) and periods (.).
+
+* `resource_id` - (Required, String, ForceNew) Specifies the network port ID.
+  Changing this creates a new VPC flow log.
+
+* `log_group_id` - (Required, String, ForceNew) Specifies the LTS log group ID.
+  Changing this creates a new VPC flow log.
+
+* `log_topic_id` - (Required, String, ForceNew) Specifies the LTS log topic ID.
+  Changing this creates a new VPC flow log.
+
+* `traffic_type` - (Optinal, String, ForceNew) Specifies the type of traffic to log. The value can be:
+  - *all*: specifies that both accepted and rejected traffic of the specified resource will be logged.
+  - *accept*: specifies that only accepted inbound and outbound traffic of the specified resource will be logged.
+  - *reject*: specifies that only rejected inbound and outbound traffic of the specified resource will be logged.
+
+  Defauts to *all*. Changing this creates a new VPC flow log.
+
+* `description` - (Optinal, String) Specifies supplementary information about the VPC flow log.
+  The value is a string of no more than 255 characters and cannot contain angle brackets (< or >).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The VPC flow log ID in UUID format.
+
+* `resource_type` - The type of resource on which to create the VPC flow log. The value is fixed to *port*.
+
+* `status` - The status of the flow log. The value can be `ACTIVE`, `DOWN` or `ERROR`.
+
+## Import
+
+VPC flow logs can be imported using the `id`, e.g.
+
+```sh
+terraform import flexibleengine_vpc_flow_log_v1.flowlog1 41b9d73f-eb1c-4795-a100-59a99b062513
+```

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -303,6 +303,7 @@ func Provider() terraform.ResourceProvider {
 			"flexibleengine_vpc_eip_v1":                         resourceVpcEIPV1(),
 			"flexibleengine_vpc_v1":                             resourceVirtualPrivateCloudV1(),
 			"flexibleengine_vpc_subnet_v1":                      resourceVpcSubnetV1(),
+			"flexibleengine_vpc_flow_log_v1":                    resourceVpcFlowLogV1(),
 			"flexibleengine_vpc_route_v2":                       resourceVPCRouteV2(),
 			"flexibleengine_vpc_peering_connection_v2":          resourceVpcPeeringConnectionV2(),
 			"flexibleengine_vpc_peering_connection_accepter_v2": resourceVpcPeeringConnectionAccepterV2(),

--- a/flexibleengine/resource_flexibleengine_vpc_flow_log.go
+++ b/flexibleengine/resource_flexibleengine_vpc_flow_log.go
@@ -1,0 +1,179 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/openstack/networking/v1/flowlogs"
+)
+
+func resourceVpcFlowLogV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVpcFlowLogV1Create,
+		Read:   resourceVpcFlowLogV1Read,
+		Update: resourceVpcFlowLogV1Update,
+		Delete: resourceVpcFlowLogV1Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"resource_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "port",
+				ValidateFunc: validation.StringInSlice([]string{
+					"port", "vpc", "network",
+				}, true),
+			},
+			"resource_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"traffic_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "all",
+				ValidateFunc: validation.StringInSlice([]string{
+					"all", "accept", "reject",
+				}, true),
+			},
+			"log_group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"log_topic_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceVpcFlowLogV1Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	vpcClient, err := config.NetworkingV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating FlexibleEngine vpc client: %s", err)
+	}
+
+	createOpts := flowlogs.CreateOpts{
+		Name:         d.Get("name").(string),
+		Description:  d.Get("description").(string),
+		ResourceType: d.Get("resource_type").(string),
+		ResourceID:   d.Get("resource_id").(string),
+		TrafficType:  d.Get("traffic_type").(string),
+		LogGroupID:   d.Get("log_group_id").(string),
+		LogTopicID:   d.Get("log_topic_id").(string),
+	}
+
+	log.Printf("[DEBUG] Create VPC Flow Log Options: %#v", createOpts)
+	fl, err := flowlogs.Create(vpcClient, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("error creating FlexibleEngine VPC flow log: %s", err)
+	}
+
+	d.SetId(fl.ID)
+	return resourceVpcFlowLogV1Read(d, config)
+}
+
+func resourceVpcFlowLogV1Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	vpcClient, err := config.NetworkingV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating FlexibleEngine vpc client: %s", err)
+	}
+
+	fl, err := flowlogs.Get(vpcClient, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "error retrieving flowlog")
+	}
+
+	d.Set("name", fl.Name)
+	d.Set("description", fl.Description)
+	d.Set("resource_type", fl.ResourceType)
+	d.Set("resource_id", fl.ResourceID)
+	d.Set("traffic_type", fl.TrafficType)
+	d.Set("log_group_id", fl.LogGroupID)
+	d.Set("log_topic_id", fl.LogTopicID)
+	d.Set("status", fl.Status)
+	d.Set("region", GetRegion(d, config))
+
+	return nil
+}
+
+func resourceVpcFlowLogV1Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	vpcClient, err := config.NetworkingV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating FlexibleEngine vpc client: %s", err)
+	}
+
+	if d.HasChanges("name", "description") {
+		updateOpts := flowlogs.UpdateOpts{
+			Name:        d.Get("name").(string),
+			Description: d.Get("description").(string),
+		}
+
+		_, err = flowlogs.Update(vpcClient, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return fmt.Errorf("error updating FlexibleEngine VPC flow log: %s", err)
+		}
+	}
+
+	return resourceVpcFlowLogV1Read(d, meta)
+}
+
+func resourceVpcFlowLogV1Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	vpcClient, err := config.NetworkingV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("error creating FlexibleEngine vpc client: %s", err)
+	}
+
+	err = flowlogs.Delete(vpcClient, d.Id()).ExtractErr()
+	if err != nil {
+		// ignore ErrDefault404
+		if _, ok := err.(golangsdk.ErrDefault404); ok {
+			log.Printf("[INFO] Successfully deleted FlexibleEngine vpc flow log %s", d.Id())
+			return nil
+		}
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/flexibleengine/resource_flexibleengine_vpc_flow_log_test.go
+++ b/flexibleengine/resource_flexibleengine_vpc_flow_log_test.go
@@ -1,0 +1,172 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+
+	"github.com/huaweicloud/golangsdk/openstack/networking/v1/flowlogs"
+)
+
+func TestAccVpcFlowLogV1_basic(t *testing.T) {
+	var flowlog flowlogs.FlowLog
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rNameUpdate := rName + "-updated"
+	resourceName := "flexibleengine_vpc_flow_log_v1.flow_log"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcFlowLogV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcFlowLogV1_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcFlowLogV1Exists(resourceName, &flowlog),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by terraform testacc"),
+					resource.TestCheckResourceAttr(resourceName, "resource_type", "port"),
+					resource.TestCheckResourceAttr(resourceName, "traffic_type", "all"),
+					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
+				),
+			},
+			{
+				Config: testAccVpcFlowLogV1_update(rName, rNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "description", "updated by terraform testacc"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckVpcFlowLogV1Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	vpcClient, err := config.NetworkingV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating FlexibleEngine vpc client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_vpc_flow_log_v1" {
+			continue
+		}
+
+		_, err := flowlogs.Get(vpcClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("VPC flow log still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckVpcFlowLogV1Exists(n string, flowlog *flowlogs.FlowLog) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		vpcClient, err := config.NetworkingV1Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating FlexibleEngine Vpc client: %s", err)
+		}
+
+		found, err := flowlogs.Get(vpcClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("VPC flow log not found")
+		}
+
+		*flowlog = *found
+
+		return nil
+	}
+}
+
+func testAccVpcFlowLogConfigBase(name string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_images_image_v2" "ubuntu" {
+  name = "OBS Ubuntu 18.04"
+}
+
+resource "flexibleengine_lts_group" "log_group1" {
+  group_name = "group-%s"
+}
+
+resource "flexibleengine_lts_topic" "log_topic1" {
+  group_id   = flexibleengine_lts_group.log_group1.id
+  topic_name = "topic-%s"
+}
+
+resource "flexibleengine_vpc_v1" "vpc_1" {
+  name = "vpc-%s"
+  cidr = "172.16.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "subnet_1" {
+  vpc_id     = flexibleengine_vpc_v1.vpc_1.id
+  name       = "subnet-%s"
+  cidr       = "172.16.0.0/24"
+  gateway_ip = "172.16.0.1"
+}
+
+resource "flexibleengine_compute_instance_v2" "instance_1" {
+  name              = "ecs-%s"
+  image_id          = data.flexibleengine_images_image_v2.ubuntu.id
+  flavor_name       = "s3.small.1"
+  security_groups   = ["default"]
+  availability_zone = "%s"
+
+  network {
+    uuid = flexibleengine_vpc_subnet_v1.subnet_1.id
+  }
+}
+`, name, name, name, name, name, OS_AVAILABILITY_ZONE)
+}
+
+func testAccVpcFlowLogV1_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpc_flow_log_v1" "flow_log" {
+  name          = "%s"
+  description   = "created by terraform testacc"
+  resource_id   = flexibleengine_compute_instance_v2.instance_1.network[0].port
+  log_group_id  = flexibleengine_lts_group.log_group1.id
+  log_topic_id  = flexibleengine_lts_topic.log_topic1.id
+}
+`, testAccVpcFlowLogConfigBase(name), name)
+}
+
+func testAccVpcFlowLogV1_update(base, name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpc_flow_log_v1" "flow_log" {
+  name          = "%s"
+  description   = "updated by terraform testacc"
+  resource_id   = flexibleengine_compute_instance_v2.instance_1.network[0].port
+  log_group_id  = flexibleengine_lts_group.log_group1.id
+  log_topic_id  = flexibleengine_lts_topic.log_topic1.id
+}
+`, testAccVpcFlowLogConfigBase(base), name)
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/flowlogs/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/flowlogs/requests.go
@@ -1,0 +1,169 @@
+package flowlogs
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToFlowLogsListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the subnet attributes you want to see returned.
+type ListOpts struct {
+	// Specifies the VPC flow log UUID.
+	ID string `q:"id"`
+
+	// Specifies the VPC flow log name.
+	Name string `q:"name"`
+
+	// Specifies the type of resource on which to create the VPC flow log..
+	ResourceType string `q:"resource_type"`
+
+	// Specifies the unique resource ID.
+	ResourceID string `q:"resource_id"`
+
+	// Specifies the type of traffic to log.
+	TrafficType string `q:"traffic_type"`
+
+	// Specifies the log group ID..
+	LogGroupID string `q:"log_group_id"`
+
+	// Specifies the log topic ID.
+	LogTopicID string `q:"log_topic_id"`
+
+	// Specifies the VPC flow log status, the value can be ACTIVE, DOWN or ERROR.
+	Status string `q:"status"`
+
+	//Specifies the number of records returned on each page.
+	//The value ranges from 0 to intmax.
+	Limit int `q:"limit"`
+
+	//Specifies the resource ID of pagination query.
+	//If the parameter is left blank, only resources on the first page are queried.
+	Marker string `q:"marker"`
+}
+
+// ToFlowLogsListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToFlowLogsListQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// VPC flow logs. It accepts a ListOpts struct, which allows you to filter
+//  and sort the returned collection for greater efficiency.
+func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToFlowLogsListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return FlowLogPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+type CreateOpts struct {
+	// Specifies the VPC flow log name. The value is a string of no more than 64
+	// characters that can contain letters, digits, underscores (_), hyphens (-) and periods (.).
+	Name string `json:"name,omitempty"`
+
+	// Provides supplementary information about the VPC flow log.
+	// The value is a string of no more than 255 characters and cannot contain angle brackets (< or >).
+	Description string `json:"description,omitempty"`
+
+	// Specifies the type of resource on which to create the VPC flow log.
+	// The value can be Port, VPC, and Network.
+	ResourceType string `json:"resource_type" required:"true"`
+
+	// Specifies the unique resource ID.
+	ResourceID string `json:"resource_id" required:"true"`
+
+	//Specifies the type of traffic to log. The value can be all, accept and reject.
+	TrafficType string `json:"traffic_type" required:"true"`
+
+	// Specifies the log group ID.
+	LogGroupID string `json:"log_group_id" required:"true"`
+
+	// Specifies the log topic ID.
+	LogTopicID string `json:"log_topic_id" required:"true"`
+}
+
+type CreateOptsBuilder interface {
+	ToCreateMap() (map[string]interface{}, error)
+}
+
+func (opts CreateOpts) ToCreateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "flow_log")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(CreateURL(client), b, &r.Body, &golangsdk.RequestOpts{OkCodes: []int{200}})
+	return
+}
+
+func Delete(client *golangsdk.ServiceClient, flId string) (r DeleteResult) {
+	url := DeleteURL(client, flId)
+	_, r.Err = client.Delete(url, nil)
+	return
+}
+
+func Get(client *golangsdk.ServiceClient, flId string) (r GetResult) {
+	url := GetURL(client, flId)
+	_, r.Err = client.Get(url, &r.Body, &golangsdk.RequestOpts{})
+	return
+}
+
+type UpdateOpts struct {
+	// Specifies the VPC flow log name. The value is a string of no more than 64
+	// characters that can contain letters, digits, underscores (_), hyphens (-) and periods (.).
+	Name string `json:"name,omitempty"`
+
+	// Provides supplementary information about the VPC flow log.
+	// The value is a string of no more than 255 characters and cannot contain angle brackets (< or >).
+	Description string `json:"description,omitempty"`
+
+	// Specifies whether to enable the VPC flow log function.
+	AdminState bool `json:"admin_state"`
+}
+
+type UpdateOptsBuilder interface {
+	ToUpdateMap() (map[string]interface{}, error)
+}
+
+func (opts UpdateOpts) ToUpdateMap() (map[string]interface{}, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "flow_log")
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func Update(client *golangsdk.ServiceClient, flId string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Put(UpdateURL(client, flId), b, &r.Body, &golangsdk.RequestOpts{OkCodes: []int{200}})
+	return
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/flowlogs/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/flowlogs/results.go
@@ -1,0 +1,123 @@
+package flowlogs
+
+import (
+	"github.com/huaweicloud/golangsdk"
+	"github.com/huaweicloud/golangsdk/pagination"
+)
+
+// VPC flow log struct
+type FlowLog struct {
+	// Specifies the VPC flow log UUID.
+	ID string `json:"id"`
+
+	// Specifies the VPC flow log name.
+	Name string `json:"name"`
+
+	// Provides supplementary information about the VPC flow log.
+	Description string `json:"description"`
+
+	// Specifies the type of resource on which to create the VPC flow log.
+	ResourceType string `json:"resource_type"`
+
+	// Specifies the unique resource ID.
+	ResourceID string `json:"resource_id"`
+
+	// Specifies the type of traffic to log.
+	TrafficType string `json:"traffic_type"`
+
+	// Specifies the log group ID..
+	LogGroupID string `json:"log_group_id"`
+
+	// Specifies the log topic ID.
+	LogTopicID string `json:"log_topic_id"`
+
+	// Specifies the VPC flow log status, the value can be ACTIVE, DOWN or ERROR.
+	Status string `json:"status"`
+
+	// Specifies the project ID.
+	TenantID string `json:"tenant_id"`
+
+	// Specifies whether to enable the VPC flow log function.
+	AdminState bool `json:"admin_state"`
+
+	// Specifies the time when the VPC flow log was created.
+	CreatedAt string `json:"created_at"`
+
+	// Specifies the time when the VPC flow log was updated.
+	UpdatedAt string `json:"updated_at"`
+}
+
+// FlowLogPage is the page returned by a pager when traversing over a collection
+// of flow logs.
+type FlowLogPage struct {
+	pagination.LinkedPageBase
+}
+
+// NextPageURL is invoked when a paginated collection of flow logs has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r FlowLogPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []golangsdk.Link `json:"flowlogs_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return golangsdk.ExtractNextURL(s.Links)
+}
+
+// IsEmpty checks whether a FlowLogPage struct is empty.
+func (r FlowLogPage) IsEmpty() (bool, error) {
+	is, err := ExtractFlowLogs(r)
+	return len(is) == 0, err
+}
+
+// ExtractFlowLogs accepts a Page struct, specifically a FlowLogPage struct,
+// and extracts the elements into a slice of FlowLog structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractFlowLogs(r pagination.Page) ([]FlowLog, error) {
+	var s struct {
+		FlowLogs []FlowLog `json:"flow_logs"`
+	}
+	err := (r.(FlowLogPage)).ExtractInto(&s)
+	return s.FlowLogs, err
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+type CreateResult struct {
+	commonResult
+}
+
+func (r CreateResult) Extract() (*FlowLog, error) {
+	var entity FlowLog
+	err := r.ExtractIntoStructPtr(&entity, "flow_log")
+	return &entity, err
+}
+
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+type GetResult struct {
+	commonResult
+}
+
+func (r GetResult) Extract() (*FlowLog, error) {
+	var entity FlowLog
+	err := r.ExtractIntoStructPtr(&entity, "flow_log")
+	return &entity, err
+}
+
+type UpdateResult struct {
+	commonResult
+}
+
+func (r UpdateResult) Extract() (*FlowLog, error) {
+	var entity FlowLog
+	err := r.ExtractIntoStructPtr(&entity, "flow_log")
+	return &entity, err
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/flowlogs/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/networking/v1/flowlogs/urls.go
@@ -1,0 +1,23 @@
+package flowlogs
+
+import "github.com/huaweicloud/golangsdk"
+
+func CreateURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(c.ProjectID, "fl/flow_logs")
+}
+
+func listURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(c.ProjectID, "fl/flow_logs")
+}
+
+func GetURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(c.ProjectID, "fl/flow_logs", id)
+}
+
+func UpdateURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(c.ProjectID, "fl/flow_logs", id)
+}
+
+func DeleteURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(c.ProjectID, "fl/flow_logs", id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -339,6 +339,7 @@ github.com/huaweicloud/golangsdk/openstack/mrs/v1/cluster
 github.com/huaweicloud/golangsdk/openstack/mrs/v1/job
 github.com/huaweicloud/golangsdk/openstack/networking/v1/bandwidths
 github.com/huaweicloud/golangsdk/openstack/networking/v1/eips
+github.com/huaweicloud/golangsdk/openstack/networking/v1/flowlogs
 github.com/huaweicloud/golangsdk/openstack/networking/v1/subnets
 github.com/huaweicloud/golangsdk/openstack/networking/v1/vpcs
 github.com/huaweicloud/golangsdk/openstack/networking/v2/extensions/elbaas


### PR DESCRIPTION
fixes #451

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccVpcFlowLogV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccVpcFlowLogV1_basic -timeout 720m
=== RUN   TestAccVpcFlowLogV1_basic
=== PAUSE TestAccVpcFlowLogV1_basic
=== CONT  TestAccVpcFlowLogV1_basic
--- PASS: TestAccVpcFlowLogV1_basic (230.74s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 230.761s
```