### PR TITLE
removed host attribute in sfs file system

### DIFF
--- a/docs/resources/sfs_file_system_v2.md
+++ b/docs/resources/sfs_file_system_v2.md
@@ -106,8 +106,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `export_location` - The address for accessing the shared file system.
 
-* `host` - The host name of the shared file system.
-
 * `share_access_id` - The UUID of the share access rule.
 
 * `access_rules_status` - The status of the share access rule.

--- a/flexibleengine/resource_flexibleengine_sfs_file_system_v2.go
+++ b/flexibleengine/resource_flexibleengine_sfs_file_system_v2.go
@@ -93,10 +93,6 @@ func resourceSFSFileSystemV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"host": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"volume_type": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -234,7 +230,6 @@ func resourceSFSFileSystemV2Read(d *schema.ResourceData, meta interface{}) error
 	d.Set("availability_zone", n.AvailabilityZone)
 	d.Set("region", GetRegion(d, config))
 	d.Set("export_location", n.ExportLocation)
-	d.Set("host", n.Host)
 
 	// NOTE: only support the following metadata key
 	var metaKeys = [3]string{"#sfs_crypt_key_id", "#sfs_crypt_domain_id", "#sfs_crypt_alias"}


### PR DESCRIPTION
fixes #420 

the `host` attribute is an internal attribute which is meaningless for users.
so, drop it.

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccSFSFileSystemV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccSFSFileSystemV2_basic -timeout 720m
=== RUN   TestAccSFSFileSystemV2_basic
--- PASS: TestAccSFSFileSystemV2_basic (55.96s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 55.976s
```