### PR TITLE
remove share_type attr in sfs data source

### DIFF
--- a/docs/resources/sfs_file_system_v2.md
+++ b/docs/resources/sfs_file_system_v2.md
@@ -99,9 +99,6 @@ In addition to all arguments above, the following attributes are exported:
 
 * `status` - The status of the shared file system.
 
-* `share_type` - The storage service type assigned for the shared file system, such as high-performance
-    storage (composed of SSDs) and large-capacity storage (composed of SATA disks).
-
 * `volume_type` - The volume type.
 
 * `export_location` - The address for accessing the shared file system.

--- a/flexibleengine/resource_flexibleengine_sfs_file_system_v2.go
+++ b/flexibleengine/resource_flexibleengine_sfs_file_system_v2.go
@@ -224,7 +224,6 @@ func resourceSFSFileSystemV2Read(d *schema.ResourceData, meta interface{}) error
 	d.Set("share_proto", n.ShareProto)
 	d.Set("size", n.Size)
 	d.Set("description", n.Description)
-	d.Set("share_type", n.ShareType)
 	d.Set("volume_type", n.VolumeType)
 	d.Set("is_public", n.IsPublic)
 	d.Set("availability_zone", n.AvailabilityZone)


### PR DESCRIPTION
`share_type` is not defined in schema, and `volume_type` has the same meaning with it, so we can remove it.

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccSFSFileSystemV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccSFSFileSystemV2_basic -timeout 720m
=== RUN   TestAccSFSFileSystemV2_basic
--- PASS: TestAccSFSFileSystemV2_basic (74.79s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 74.800s
```