### PR TITLE
configure provider with ConfigureContextFunc

### DIFF
--- a/flexibleengine/config_test.go
+++ b/flexibleengine/config_test.go
@@ -49,7 +49,7 @@ func TestAccServiceEndpoints_Global(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Summary)
 	}
 
 	var expectedURL, actualURL string
@@ -74,7 +74,7 @@ func TestAccServiceEndpoints_Management(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Summary)
 	}
 
 	var expectedURL, actualURL string
@@ -111,7 +111,7 @@ func TestAccServiceEndpoints_Compute(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Summary)
 	}
 
 	config := testProvider.Meta().(*Config)
@@ -188,7 +188,7 @@ func TestAccServiceEndpoints_Storage(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Summary)
 	}
 
 	config := testProvider.Meta().(*Config)
@@ -256,7 +256,7 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Summary)
 	}
 
 	config := testProvider.Meta().(*Config)
@@ -339,7 +339,7 @@ func TestAccServiceEndpoints_Database(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Summary)
 	}
 
 	var expectedURL, actualURL string
@@ -382,7 +382,7 @@ func TestAccServiceEndpoints_Security(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Summary)
 	}
 
 	var expectedURL, actualURL string
@@ -416,7 +416,7 @@ func TestAccServiceEndpoints_Application(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Summary)
 	}
 
 	var expectedURL, actualURL string
@@ -442,7 +442,7 @@ func TestAccServiceEndpoints_EnterpriseIntelligence(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Summary)
 	}
 
 	var expectedURL, actualURL string
@@ -493,7 +493,7 @@ func TestAccServiceEndpoints_Others(t *testing.T) {
 	raw := make(map[string]interface{})
 	diags := testProvider.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Detail)
+		t.Fatalf("Unexpected error when configure FlexibleEngine provider: %s", diags[0].Summary)
 	}
 
 	var expectedURL, actualURL string

--- a/flexibleengine/provider_test.go
+++ b/flexibleengine/provider_test.go
@@ -166,7 +166,7 @@ func TestAccProvider_caCertFile(t *testing.T) {
 
 	diags := p.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected err when specifying FlexibleEngine CA by file: %s", diags[0].Detail)
+		t.Fatalf("Unexpected err when specifying FlexibleEngine CA by file: %s", diags[0].Summary)
 	}
 }
 
@@ -190,7 +190,7 @@ func TestAccProvider_caCertString(t *testing.T) {
 
 	diags := p.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected err when specifying FlexibleEngine CA by string: %s", diags[0].Detail)
+		t.Fatalf("Unexpected err when specifying FlexibleEngine CA by string: %s", diags[0].Summary)
 	}
 }
 
@@ -222,7 +222,7 @@ func TestAccProvider_clientCertFile(t *testing.T) {
 
 	diags := p.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected err when specifying FlexibleEngine Client keypair by file: %s", diags[0].Detail)
+		t.Fatalf("Unexpected err when specifying FlexibleEngine Client keypair by file: %s", diags[0].Summary)
 	}
 }
 
@@ -252,7 +252,7 @@ func TestAccProvider_clientCertString(t *testing.T) {
 
 	diags := p.Configure(context.Background(), terraform.NewResourceConfigRaw(raw))
 	if diags.HasError() {
-		t.Fatalf("Unexpected err when specifying FlexibleEngine Client keypair by contents: %s", diags[0].Detail)
+		t.Fatalf("Unexpected err when specifying FlexibleEngine Client keypair by contents: %s", diags[0].Summary)
 	}
 }
 

--- a/flexibleengine/provider_test.go
+++ b/flexibleengine/provider_test.go
@@ -35,13 +35,31 @@ var (
 	OS_TENANT_NAME            = getTenantName()
 )
 
+// testAccProviders is a static map containing only the main provider instance.
+//
+// Deprecated: Terraform Plugin SDK version 2 uses TestCase.ProviderFactories
+// but supports this value in TestCase.Providers for backwards compatibility.
+// In the future Providers: testAccProviders will be changed to
+// ProviderFactories: testAccProviderFactories
 var testAccProviders map[string]*schema.Provider
+
+// testAccProviderFactories is a static map containing only the main provider instance
+var TestAccProviderFactories map[string]func() (*schema.Provider, error)
+
+// testAccProvider is the "main" provider instance
 var testAccProvider *schema.Provider
 
 func init() {
 	testAccProvider = Provider()
+
 	testAccProviders = map[string]*schema.Provider{
 		"flexibleengine": testAccProvider,
+	}
+
+	TestAccProviderFactories = map[string]func() (*schema.Provider, error){
+		"flexibleengine": func() (*schema.Provider, error) {
+			return testAccProvider, nil
+		},
 	}
 }
 
@@ -140,6 +158,10 @@ func TestProvider(t *testing.T) {
 	if err := Provider().InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
+}
+
+func TestProvider_impl(t *testing.T) {
+	var _ *schema.Provider = Provider()
 }
 
 // Steps for configuring FlexibleEngine with SSL validation are here:

--- a/flexibleengine/resource_flexibleengine_vpc_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_vpc_v1_test.go
@@ -19,9 +19,9 @@ func TestAccFlexibleEngineVpcV1_basic(t *testing.T) {
 	rNameUpdate := rName + "-updated"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckFlexibleEngineVpcV1Destroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckFlexibleEngineVpcV1Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcV1_basic(rName),


### PR DESCRIPTION

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestProvider'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestProvider -timeout 720m
=== RUN   TestProvider
--- PASS: TestProvider (0.01s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 0.027s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccFlexibleEngineVpcV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccFlexibleEngineVpcV1_basic -timeout 720m
=== RUN   TestAccFlexibleEngineVpcV1_basic
--- PASS: TestAccFlexibleEngineVpcV1_basic (40.75s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 40.767s
```