### PR TITLE
Add ability to set/update protection_status in a waf policy

### DIFF
--- a/docs/resources/waf_policy.md
+++ b/docs/resources/waf_policy.md
@@ -38,41 +38,41 @@ The following arguments are supported:
 
 * `domains` - (Optional, List) An array of domain IDs.
 
+* `protection_status` - (Optional, Object) Specifies the protection switches. The object structure is documented below.
+
+The `protection_status` block supports:
+
+* `basic_web_protection` - Specifies whether Basic Web Protection is enabled.
+
+* `general_check` - Specifies whether General Check in Basic Web Protection is enabled.
+
+* `crawler_engine` - Specifies whether the Search Engine switch in Basic Web Protection is enabled.
+
+* `crawler_scanner` - Specifies whether the Scanner switch in Basic Web Protection is enabled.
+
+* `crawler_script` - Specifies whether the Script Tool switch in Basic Web Protection is enabled.
+
+* `crawler_other` - Specifies whether detection of other crawlers in Basic Web Protection is enabled.
+
+* `webshell` - Specifies whether webshell detection in Basic Web Protection is enabled.
+
+* `cc_protection` - Specifies whether CC Attack Protection is enabled.
+
+* `precise_protection` - Specifies whether Precise Protection is enabled.
+
+* `blacklist` - Specifies whether Blacklist and Whitelist is enabled.
+
+* `data_masking` - Specifies whether Data Masking is enabled.
+
+* `false_alarm_masking` - Specifies whether False Alarm Masking is enabled.
+
+* `web_tamper_protection` - Specifies whether Web Tamper Protection is enabled.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The policy ID in UUID format.
-
-* `protection_status` - The protection switches. The object structure is documented below.
-
-The `protection_status` block supports:
-
-* `basic_web_protection` - Indicates whether Basic Web Protection is enabled.
-
-* `general_check` - Indicates whether General Check in Basic Web Protection is enabled.
-
-* `crawler_engine` - Indicates whether the Search Engine switch in Basic Web Protection is enabled.
-
-* `crawler_scanner` - Indicates whether the Scanner switch in Basic Web Protection is enabled.
-
-* `crawler_script` - Indicates whether the Script Tool switch in Basic Web Protection is enabled.
-
-* `crawler_other` - Indicates whether detection of other crawlers in Basic Web Protection is enabled.
-
-* `webshell` - Indicates whether webshell detection in Basic Web Protection is enabled.
-
-* `cc_protection` - Indicates whether CC Attack Protection is enabled.
-
-* `precise_protection` - Indicates whether Precise Protection is enabled.
-
-* `blacklist` - Indicates whether Blacklist and Whitelist is enabled.
-
-* `data_masking` - Indicates whether Data Masking is enabled.
-
-* `false_alarm_masking` - Indicates whether False Alarm Masking is enabled.
-
-* `web_tamper_protection` - Indicates whether Web Tamper Protection is enabled.
 
 ## Import
 

--- a/flexibleengine/resource_flexibleengine_waf_policy.go
+++ b/flexibleengine/resource_flexibleengine_waf_policy.go
@@ -67,59 +67,74 @@ func resourceWafPolicyV1() *schema.Resource {
 
 			"protection_status": {
 				Type:     schema.TypeList,
+				Optional: true,
 				Computed: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"basic_web_protection": {
 							Type:     schema.TypeBool,
+							Optional: true,
 							Computed: true,
 						},
 						"general_check": {
 							Type:     schema.TypeBool,
+							Optional: true,
 							Computed: true,
 						},
 						"crawler_engine": {
 							Type:     schema.TypeBool,
+							Optional: true,
 							Computed: true,
 						},
 						"crawler_scanner": {
 							Type:     schema.TypeBool,
+							Optional: true,
 							Computed: true,
 						},
 						"crawler_script": {
 							Type:     schema.TypeBool,
+							Optional: true,
 							Computed: true,
 						},
 						"crawler_other": {
 							Type:     schema.TypeBool,
+							Optional: true,
 							Computed: true,
 						},
 						"webshell": {
 							Type:     schema.TypeBool,
+							Optional: true,
 							Computed: true,
 						},
 						"cc_protection": {
 							Type:     schema.TypeBool,
+							Optional: true,
 							Computed: true,
 						},
 						"precise_protection": {
 							Type:     schema.TypeBool,
+							Optional: true,
 							Computed: true,
 						},
 						"blacklist": {
 							Type:     schema.TypeBool,
+							Optional: true,
 							Computed: true,
 						},
 						"data_masking": {
 							Type:     schema.TypeBool,
+							Optional: true,
 							Computed: true,
 						},
 						"false_alarm_masking": {
 							Type:     schema.TypeBool,
+							Optional: true,
 							Computed: true,
 						},
 						"web_tamper_protection": {
 							Type:     schema.TypeBool,
+							Optional: true,
 							Computed: true,
 						},
 					},
@@ -127,6 +142,48 @@ func resourceWafPolicyV1() *schema.Resource {
 			},
 		},
 	}
+}
+
+func buildWafPolicyOptions(d *schema.ResourceData) *policies.Options {
+	optionsRaw := d.Get("protection_status").([]interface{})
+	if len(optionsRaw) == 0 {
+		return nil
+	}
+
+	rawMap := optionsRaw[0].(map[string]interface{})
+	webattack := rawMap["basic_web_protection"].(bool)
+	common := rawMap["general_check"].(bool)
+	crawlerEngine := rawMap["crawler_engine"].(bool)
+	crawlerScanner := rawMap["crawler_scanner"].(bool)
+	crawlerScript := rawMap["crawler_script"].(bool)
+	crawlerOther := rawMap["crawler_other"].(bool)
+	webshell := rawMap["webshell"].(bool)
+
+	cc := rawMap["cc_protection"].(bool)
+	custom := rawMap["precise_protection"].(bool)
+	whiteblackip := rawMap["blacklist"].(bool)
+	privacy := rawMap["data_masking"].(bool)
+	ignore := rawMap["false_alarm_masking"].(bool)
+	antitamper := rawMap["web_tamper_protection"].(bool)
+
+	options := &policies.Options{
+		WebAttack:      &webattack,
+		Common:         &common,
+		CrawlerEngine:  &crawlerEngine,
+		CrawlerScanner: &crawlerScanner,
+		CrawlerScript:  &crawlerScript,
+		CrawlerOther:   &crawlerOther,
+		WebShell:       &webshell,
+		Cc:             &cc,
+		Custom:         &custom,
+		WhiteblackIp:   &whiteblackip,
+		Privacy:        &privacy,
+		Ignore:         &ignore,
+		AntiTamper:     &antitamper,
+	}
+
+	log.Printf("[DEBUG] get WAF policy options: %#v", options)
+	return options
 }
 
 func resourceWafPolicyV1Create(d *schema.ResourceData, meta interface{}) error {
@@ -147,7 +204,36 @@ func resourceWafPolicyV1Create(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] WAF policy created: %#v", policy)
 	d.SetId(policy.Id)
 
-	return resourceWafPolicyV1Update(d, meta)
+	// Update the policy as POST API only supports Name argument
+	var updateOpts policies.UpdateOpts
+
+	if v, ok := d.GetOk("level"); ok && v.(int) != policy.Level {
+		updateOpts.Level = v.(int)
+	}
+
+	if v, ok := d.GetOk("protection_mode"); ok && v.(string) != policy.Action.Category {
+		updateOpts.Action = &policies.Action{
+			Category: v.(string),
+		}
+	}
+	if v, ok := d.GetOk("full_detection"); ok && v.(bool) != policy.FullDetection {
+		detectionMode := v.(bool)
+		updateOpts.FullDetection = &detectionMode
+	}
+
+	if _, ok := d.GetOk("protection_status"); ok {
+		updateOpts.Options = buildWafPolicyOptions(d)
+	}
+
+	if updateOpts != (policies.UpdateOpts{}) {
+		log.Printf("[DEBUG] updateOpts: %#v", updateOpts)
+		_, err = policies.Update(wafClient, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return fmt.Errorf("error updating WAF policy: %s", err)
+		}
+	}
+
+	return resourceWafPolicyV1Read(d, meta)
 }
 
 func resourceWafPolicyV1Read(d *schema.ResourceData, meta interface{}) error {
@@ -159,7 +245,7 @@ func resourceWafPolicyV1Read(d *schema.ResourceData, meta interface{}) error {
 
 	n, err := policies.Get(wafClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "WAF Policy")
+		return CheckDeleted(d, err, "WAF policy")
 	}
 
 	log.Printf("[DEBUG] fetching WAF policy %s: %#v", d.Id(), n)
@@ -202,7 +288,7 @@ func resourceWafPolicyV1Update(d *schema.ResourceData, meta interface{}) error {
 	var updateOpts policies.UpdateOpts
 	var changed bool
 
-	if d.HasChange("name") && !d.IsNewResource() {
+	if d.HasChange("name") {
 		changed = true
 		updateOpts.Name = d.Get("name").(string)
 	}
@@ -216,12 +302,16 @@ func resourceWafPolicyV1Update(d *schema.ResourceData, meta interface{}) error {
 		detectionMode := d.Get("full_detection").(bool)
 		updateOpts.FullDetection = &detectionMode
 	}
+	if d.HasChange("protection_status") {
+		changed = true
+		updateOpts.Options = buildWafPolicyOptions(d)
+	}
 
 	if changed {
 		log.Printf("[DEBUG] updateOpts: %#v", updateOpts)
 		_, err = policies.Update(wafClient, d.Id(), updateOpts).Extract()
 		if err != nil {
-			return fmt.Errorf("error updating WAF Policy: %s", err)
+			return fmt.Errorf("error updating WAF policy: %s", err)
 		}
 	}
 
@@ -261,13 +351,13 @@ func resourceWafPolicyV1Delete(d *schema.ResourceData, meta interface{}) error {
 				d.SetId("")
 				return nil
 			}
-			return fmt.Errorf("error unbinding WAF Policy domain: %s", err)
+			return fmt.Errorf("error unbinding WAF policy domain: %s", err)
 		}
 	}
 
 	err = policies.Delete(wafClient, d.Id()).ExtractErr()
 	if err != nil {
-		return fmt.Errorf("error deleting WAF Policy: %s", err)
+		return fmt.Errorf("error deleting WAF policy: %s", err)
 	}
 
 	d.SetId("")

--- a/flexibleengine/resource_flexibleengine_waf_policy_test.go
+++ b/flexibleengine/resource_flexibleengine_waf_policy_test.go
@@ -52,6 +52,40 @@ func TestAccWafPolicyV1_basic(t *testing.T) {
 	})
 }
 
+func TestAccWafPolicyV1_status(t *testing.T) {
+	var policy policies.Policy
+	randName := acctest.RandString(5)
+	resourceName := "flexibleengine_waf_policy.policy_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckWafPolicyV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafPolicyV1_status(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafPolicyV1Exists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("policy-%s", randName)),
+					resource.TestCheckResourceAttr(resourceName, "protection_mode", "log"),
+					resource.TestCheckResourceAttr(resourceName, "level", "2"),
+					resource.TestCheckResourceAttr(resourceName, "full_detection", "false"),
+					resource.TestCheckResourceAttr(resourceName, "protection_status.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "protection_status.0.basic_web_protection", "true"),
+					resource.TestCheckResourceAttr(resourceName, "protection_status.0.crawler_engine", "true"),
+					resource.TestCheckResourceAttr(resourceName, "protection_status.0.webshell", "true"),
+					resource.TestCheckResourceAttr(resourceName, "protection_status.0.data_masking", "true"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckWafPolicyV1Destroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	wafClient, err := config.WafV1Client(OS_REGION_NAME)
@@ -120,6 +154,30 @@ resource "flexibleengine_waf_policy" "policy_1" {
   level           = 1
   protection_mode = "block"
   full_detection  = true
+}
+`, name)
+}
+
+func testAccWafPolicyV1_status(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_waf_policy" "policy_1" {
+  name = "policy-%s"
+
+  protection_status {
+    basic_web_protection  = true
+    general_check         = true
+    webshell              = true
+    crawler_engine        = true
+    crawler_other         = true
+    crawler_scanner       = true
+    crawler_script        = true
+    blacklist             = true
+    cc_protection         = true
+    data_masking          = true
+    precise_protection    = true
+    false_alarm_masking   = true
+    web_tamper_protection = true
+  }
 }
 `, name)
 }


### PR DESCRIPTION
fixes #592 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccWafPolicyV1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccWafPolicyV1 -timeout 720m
=== RUN   TestAccWafPolicyV1_basic
=== PAUSE TestAccWafPolicyV1_basic
=== RUN   TestAccWafPolicyV1_status
=== PAUSE TestAccWafPolicyV1_status
=== CONT  TestAccWafPolicyV1_basic
=== CONT  TestAccWafPolicyV1_status
--- PASS: TestAccWafPolicyV1_status (9.14s)
--- PASS: TestAccWafPolicyV1_basic (16.15s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 16.166s
```