### PR TITLE
add dli queue scale

### DIFF
--- a/docs/resources/dli_queue.md
+++ b/docs/resources/dli_queue.md
@@ -16,7 +16,8 @@ resource "flexibleengine_dli_queue" "queue" {
   name     = "terraform_dli_queue_test"
   cu_count = 16
   tags     = {
-    k1   =   "1"
+    foo = "bar"
+    key = "value"
   }
 }
 ```
@@ -25,8 +26,8 @@ resource "flexibleengine_dli_queue" "queue" {
 
 The following arguments are supported:
 
-* `cu_count` - (Required, Int, ForceNew) Minimum number of CUs that are bound to a queue. The value can be 16,
-  64, or 256. Changing this parameter will create a new resource.
+* `cu_count` - (Required, Int) Minimum number of CUs that are bound to a queue. Initial value can be `16`,
+  `64`, or `256`. When scale_out or scale_in, the number must be a multiple of 16
 
 * `name` - (Required, String, ForceNew) Name of a queue. Name of a newly created resource queue. 
     The name can contain only digits, letters, and underscores (_), 
@@ -53,5 +54,17 @@ The following arguments are supported:
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
+* `id` - Specifies a resource ID in UUID format.
 
 * `create_time` -  Time when a queue is created.
+
+## Timeouts
+This resource provides the following timeouts configuration options:
+- `update` - Default is 45 minute.
+
+## Import
+
+DLI queue can be imported by  `id`. For example,
+```
+terraform import flexibleengine_dli_queue.example  abc123
+```

--- a/flexibleengine/resource_flexibleengine_dli_queue_v1.go
+++ b/flexibleengine/resource_flexibleengine_dli_queue_v1.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"time"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
@@ -14,24 +16,32 @@ import (
 
 var regexp4Name = regexp.MustCompile(`^[a-z0-9_]{1,128}$`)
 
+const CU_16 = 16
+const RESOURCE_MODE_SHARED, RESOURCE_MODE_EXCLUSIVE = 0, 1
+const QUEUE_TYPE_SQL, QUEUE_TYPE_GENERAL = "sql", "general"
+
+const (
+	actionRestart  = "restart"
+	actionScaleOut = "scale_out"
+	actionScaleIn  = "scale_in"
+)
+
 func ResourceDliQueueV1() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceDliQueueCreate,
-		Read:   resourceDliQueueV1Read,
-		Delete: resourceDliQueueV1Delete,
-
+		Read:   resourceDliQueueRead,
+		Update: resourceDliQueueUpdate,
+		Delete: resourceDliQueueDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
-					v := val.(string)
-					if !regexp4Name.MatchString(v) {
-						errs = append(errs, fmt.Errorf("%q can contain only digits, lower letters, and underscores (_) ", key))
-					}
-					return
-				},
+				ValidateFunc: validation.StringMatch(regexp4Name,
+					"only contain digits, lower letters, and underscores (_)"),
 			},
 
 			"queue_type": {
@@ -39,7 +49,7 @@ func ResourceDliQueueV1() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Default:      "sql",
-				ValidateFunc: validation.StringInSlice([]string{"sql", "general"}, false),
+				ValidateFunc: validation.StringInSlice([]string{QUEUE_TYPE_SQL, QUEUE_TYPE_GENERAL}, false),
 			},
 
 			"description": {
@@ -51,15 +61,14 @@ func ResourceDliQueueV1() *schema.Resource {
 			"cu_count": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntInSlice([]int{16, 64, 256}),
+				ValidateFunc: validCuCount,
 			},
 
 			"resource_mode": {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.IntInSlice([]int{0, 1}),
+				ValidateFunc: validation.IntInSlice([]int{RESOURCE_MODE_SHARED, RESOURCE_MODE_EXCLUSIVE}),
 			},
 
 			"tags": {
@@ -72,7 +81,7 @@ func ResourceDliQueueV1() *schema.Resource {
 			},
 
 			"create_time": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeInt,
 				Computed: true,
 			},
 		},
@@ -108,8 +117,10 @@ func resourceDliQueueCreate(d *schema.ResourceData, meta interface{}) error {
 
 	//query queue detail,trriger read to refresh the state
 	d.SetId(queueName)
+	// This is a workaround to avoid issue: the queue is assigning, which is not available
+	time.Sleep(120 * time.Second) //lintignore:R018
 
-	return resourceDliQueueV1Read(d, meta)
+	return resourceDliQueueRead(d, meta)
 }
 
 func assembleTagsFromRecource(key string, d *schema.ResourceData) []tags.ResourceTag {
@@ -122,7 +133,7 @@ func assembleTagsFromRecource(key string, d *schema.ResourceData) []tags.Resourc
 
 }
 
-func resourceDliQueueV1Read(d *schema.ResourceData, meta interface{}) error {
+func resourceDliQueueRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	region := GetRegion(d, config)
 
@@ -132,13 +143,13 @@ func resourceDliQueueV1Read(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("creating dli client failed, err=%s", err)
 	}
 
-	queueName := d.Get("name").(string)
+	queueName := d.Id()
 
 	queryOpts := queues.ListOpts{
 		QueueType: d.Get("queue_type").(string),
 	}
 
-	log.Printf("[DEBUG] create dli queues using paramaters: %+v", queryOpts)
+	log.Printf("[DEBUG] query dli queues using paramaters: %+v", queryOpts)
 
 	queryAllResult := queues.List(dliClient, queryOpts)
 	if queryAllResult.Err != nil {
@@ -159,6 +170,7 @@ func resourceDliQueueV1Read(d *schema.ResourceData, meta interface{}) error {
 		d.Set("description", queueDetail.Description)
 		d.Set("cu_count", queueDetail.CuCount)
 		d.Set("resource_mode", queueDetail.ResourceMode)
+		d.Set("create_time", queueDetail.CreateTime)
 	}
 
 	return nil
@@ -182,13 +194,13 @@ func filterByQueueName(body interface{}, queueName string) (r *queues.Queue, err
 
 }
 
-func resourceDliQueueV1Delete(d *schema.ResourceData, meta interface{}) error {
+func resourceDliQueueDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	region := GetRegion(d, config)
 
 	client, err := config.DliV1Client(region)
 	if err != nil {
-		return fmt.Errorf("creating dli client failed, err=%s", err)
+		return fmt.Errorf("deleting dli client failed, err=%s", err)
 	}
 
 	queueName := d.Get("name").(string)
@@ -200,4 +212,67 @@ func resourceDliQueueV1Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	return nil
+}
+
+/*
+  support cu_count scaling
+*/
+func resourceDliQueueUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	client, err := config.DliV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating DliV1Client: %s", err)
+	}
+	opt := queues.ActionOpts{
+		QueueName: d.Id(),
+	}
+	if d.HasChange("cu_count") {
+		oldValue, newValue := d.GetChange("cu_count")
+		opt.CuCount = newValue.(int) - oldValue.(int)
+		opt.Action = buildScaleActionParam(oldValue.(int), newValue.(int))
+
+		log.Printf("[DEBUG]DLI queue Update Option: %#v", opt)
+		result := queues.ScaleOrRestart(client, opt)
+		if result.Err != nil {
+			return fmt.Errorf("update dli queues failed,queueName=%s,error:%s", opt.QueueName, result.Err)
+		}
+
+		updateStateConf := &resource.StateChangeConf{
+			Pending: []string{fmt.Sprintf("%d", oldValue)},
+			Target:  []string{fmt.Sprintf("%d", newValue)},
+			Refresh: func() (interface{}, string, error) {
+				getResult := queues.Get(client, d.Id())
+				queueDetail := getResult.Body.(*queues.Queue4Get)
+				return getResult, fmt.Sprintf("%d", queueDetail.CuCount), nil
+			},
+			Timeout:                   d.Timeout(schema.TimeoutUpdate),
+			Delay:                     30 * time.Second,
+			PollInterval:              20 * time.Second,
+			ContinuousTargetOccurence: 5,
+		}
+		_, err = updateStateConf.WaitForState()
+		if err != nil {
+			return fmt.Errorf("error waiting for dli.queue (%s) to be scale: %s", d.Id(), err)
+		}
+
+	}
+
+	return resourceDliQueueRead(d, meta)
+}
+
+func buildScaleActionParam(oldValue, newValue int) string {
+	if oldValue > newValue {
+		return actionScaleIn
+	} else {
+		return actionScaleOut
+	}
+}
+
+func validCuCount(val interface{}, key string) (warns []string, errs []error) {
+	diviNum := 16
+	warns, errs = validation.IntAtLeast(diviNum)(val, key)
+	if len(errs) > 0 {
+		return warns, errs
+	}
+	return validation.IntDivisibleBy(diviNum)(val, key)
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
-	github.com/huaweicloud/golangsdk v0.0.0-20210809113416-56e12cef30ca
+	github.com/huaweicloud/golangsdk v0.0.0-20210811022513-26588c1f3b5d
 	github.com/huaweicloud/terraform-provider-huaweicloud v1.26.2-0.20210804093218-08f1b9ceebbf
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jtolds/gls v4.20.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -219,6 +219,8 @@ github.com/huaweicloud/golangsdk v0.0.0-20210722084309-4039dc70b08a h1:pkd1CUV6r
 github.com/huaweicloud/golangsdk v0.0.0-20210722084309-4039dc70b08a/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/golangsdk v0.0.0-20210809113416-56e12cef30ca h1:HorbTsfgeR6HvpuP09mYylN0K6RUg+0a0iWKSWlVoy8=
 github.com/huaweicloud/golangsdk v0.0.0-20210809113416-56e12cef30ca/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
+github.com/huaweicloud/golangsdk v0.0.0-20210811022513-26588c1f3b5d h1:fqC6rGFyOK+qg0bEdAG7PD4GqhmHl3I1ON9LbhrBkAA=
+github.com/huaweicloud/golangsdk v0.0.0-20210811022513-26588c1f3b5d/go.mod h1:fcOI5u+0f62JtJd7zkCch/Z57BNC6bhqb32TKuiF4r0=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.26.2-0.20210804093218-08f1b9ceebbf h1:jVNm96UvD9ciV8e7+amE1pLlAb5nbR4AcsE/mI0wqSM=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.26.2-0.20210804093218-08f1b9ceebbf/go.mod h1:49qG++l2nfWmzxaAd8HT4aopPzKNVQq/XpDSBDVA5y0=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/dli/v1/queues/requests.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/dli/v1/queues/requests.go
@@ -67,6 +67,13 @@ type ListOpts struct {
 	Tags           string `q:"tags"`
 }
 
+type ActionOpts struct {
+	Action    string `json:"action" required:"true"` //Operations to be performed: restart; scale_out;scale_in
+	Force     bool   `json:"force,omitempty"`        //when action= restart,can Specifies whether to forcibly restart
+	CuCount   int    `json:"cu_count,omitempty"`     // Number of CUs to be scaled in or out.
+	QueueName string `json:"-" required:"true"`
+}
+
 // CreateOptsBuilder allows extensions to add additional parameters to the
 // Create request.
 type CreateOptsBuilder interface {
@@ -174,4 +181,15 @@ func Get(c *golangsdk.ServiceClient, queueName string) (r GetResult) {
 	}
 
 	return r
+}
+
+func ScaleOrRestart(c *golangsdk.ServiceClient, opts ActionOpts) (r PutResult) {
+	requstbody, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = c.Put(ActionURL(c, opts.QueueName), requstbody, &r.Body, reqOpt)
+	return
 }

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/dli/v1/queues/results.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/dli/v1/queues/results.go
@@ -110,3 +110,7 @@ type GetResult struct {
 type DeleteResult struct {
 	golangsdk.Result
 }
+
+type PutResult struct {
+	golangsdk.Result
+}

--- a/vendor/github.com/huaweicloud/golangsdk/openstack/dli/v1/queues/urls.go
+++ b/vendor/github.com/huaweicloud/golangsdk/openstack/dli/v1/queues/urls.go
@@ -4,6 +4,7 @@ import "github.com/huaweicloud/golangsdk"
 
 const (
 	resourcePath = "queues"
+	actionPath   = "action"
 )
 
 func createURL(c *golangsdk.ServiceClient) string {
@@ -16,4 +17,8 @@ func resourceURL(c *golangsdk.ServiceClient, queueName string) string {
 
 func queryAllURL(c *golangsdk.ServiceClient) string {
 	return c.ServiceURL(resourcePath)
+}
+
+func ActionURL(c *golangsdk.ServiceClient, queueName string) string {
+	return c.ServiceURL(resourcePath, queueName, actionPath)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -154,7 +154,7 @@ github.com/hashicorp/terraform-plugin-sdk/v2/plugin
 github.com/hashicorp/terraform-plugin-sdk/v2/terraform
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/golangsdk v0.0.0-20210809113416-56e12cef30ca
+# github.com/huaweicloud/golangsdk v0.0.0-20210811022513-26588c1f3b5d
 ## explicit
 github.com/huaweicloud/golangsdk
 github.com/huaweicloud/golangsdk/internal


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Dli queue service  support scale and import 

## PR Checklist

* [X] Tests added/passed.
* [X] Documentation updated.
* [X] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./flexibleengine' TESTARGS='-run=TestAccDliQueueV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run=TestAccDliQueueV1_basic -timeout 720m
=== RUN   TestAccDliQueueV1_basic
=== PAUSE TestAccDliQueueV1_basic
=== CONT  TestAccDliQueueV1_basic
--- PASS: TestAccDliQueueV1_basic (717.89s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 717.943s
```
