### PR TITLE
fix: support up to six load balancers can be added to an AS group

### DIFF
--- a/docs/resources/as_group_v1.md
+++ b/docs/resources/as_group_v1.md
@@ -2,7 +2,7 @@
 subcategory: "Auto Scaling (AS)"
 ---
 
-# flexibleengine\_as\_group_v1
+# flexibleengine_as_group_v1
 
 Manages a V1 Autoscaling Group resource within flexibleengine.
 
@@ -114,12 +114,11 @@ The following arguments are supported:
     from 0 to 86400, and is 900 by default.
 
 * `lb_listener_id` - (Optional) The ELB listener IDs. The system supports up to
-    three ELB listeners, the IDs of which are separated using a comma (,).
+    six ELB listeners, the IDs of which are separated using a comma (,).
 
 * `lbaas_listeners` - (Optional) An array of one or more enhanced load balancer.
-    The system supports the binding of up to three load balancers. The field is
-    alternative to lb_listener_id.  The lbaas_listeners object structure is
-	documented below.
+    The system supports the binding of up to six load balancers. The field is
+    alternative to `lb_listener_id`.  The object structure is documented below.
 
 * `available_zones` - (Optional) The availability zones in which to create
     the instances in the autoscaling group.

--- a/flexibleengine/resource_flexibleengine_as_group_v1.go
+++ b/flexibleengine/resource_flexibleengine_as_group_v1.go
@@ -79,8 +79,9 @@ func resourceASGroup() *schema.Resource {
 				Description:  "The system supports the binding of up to three ELB listeners, the IDs of which are separated using a comma.",
 			},
 			"lbaas_listeners": {
-				Type:     schema.TypeList,
-				Optional: true,
+				Type:          schema.TypeList,
+				Optional:      true,
+				ConflictsWith: []string{"lb_listener_id"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"pool_id": {
@@ -533,7 +534,7 @@ func resourceASGroupRead(d *schema.ResourceData, meta interface{}) error {
 			listeners[i]["protocol_port"] = listener.ProtocolPort
 			listeners[i]["weight"] = listener.Weight
 		}
-		d.Set("listeners", listeners)
+		d.Set("lbaas_listeners", listeners)
 	}
 
 	var opts instances.ListOptsBuilder
@@ -692,10 +693,10 @@ func resourceASGroupValidateCoolDownTime(v interface{}, k string) (ws []string, 
 func resourceASGroupValidateListenerId(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	split := strings.Split(value, ",")
-	if len(split) <= 3 {
+	if len(split) <= 6 {
 		return
 	}
-	errors = append(errors, fmt.Errorf("%q supports binding up to 3 ELB listeners which are separated by a comma.", k))
+	errors = append(errors, fmt.Errorf("%q supports binding up to 6 ELB listeners which are separated by a comma.", k))
 	return
 }
 

--- a/flexibleengine/resource_flexibleengine_as_lifecycle_hook_test.go
+++ b/flexibleengine/resource_flexibleengine_as_lifecycle_hook_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccASLifecycleHook_basic(t *testing.T) {
 	var hook lifecyclehooks.Hook
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
-	resourceGroupName := "flexibleengine_as_group_v1.hth_as_group"
+	resourceGroupName := "flexibleengine_as_group_v1.as_group"
 	resourceHookName := "flexibleengine_as_lifecycle_hook_v1.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -143,7 +143,7 @@ resource "flexibleengine_smn_topic_v2" "test" {
 resource "flexibleengine_smn_topic_v2" "update" {
   name = "%s-update"
 }
-`, testASV1Group_basic, rName, rName)
+`, testASV1Group_basic(rName), rName, rName)
 }
 
 func testASLifecycleHook_basic(rName string) string {
@@ -153,7 +153,7 @@ func testASLifecycleHook_basic(rName string) string {
 resource "flexibleengine_as_lifecycle_hook_v1" "test" {
   name                   = "%s"
   type                   = "ADD"
-  scaling_group_id       = flexibleengine_as_group_v1.hth_as_group.id
+  scaling_group_id       = flexibleengine_as_group_v1.as_group.id
   notification_topic_urn = flexibleengine_smn_topic_v2.test.topic_urn
   notification_message   = "This is a test message"
 }
@@ -167,7 +167,7 @@ func testASLifecycleHook_update(rName string) string {
 resource "flexibleengine_as_lifecycle_hook_v1" "test" {
   name                   = "%s"
   type                   = "REMOVE"
-  scaling_group_id       = flexibleengine_as_group_v1.hth_as_group.id
+  scaling_group_id       = flexibleengine_as_group_v1.as_group.id
   notification_topic_urn = flexibleengine_smn_topic_v2.update.topic_urn
   notification_message   = "This is a update message"
   default_result         = "CONTINUE"


### PR DESCRIPTION
fixes #524 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccASV1Group_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccASV1Group_basic -timeout 720m
=== RUN   TestAccASV1Group_basic
--- PASS: TestAccASV1Group_basic (77.88s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 77.890s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccASLifecycleHook_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccASLifecycleHook_basic -timeout 720m
=== RUN   TestAccASLifecycleHook_basic
=== PAUSE TestAccASLifecycleHook_basic
=== CONT  TestAccASLifecycleHook_basic
--- PASS: TestAccASLifecycleHook_basic (93.22s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 93.232s
```