### PR TITLE
config: add validation of domain name

### DIFF
--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -342,10 +342,8 @@ func (c *Config) getDomainID() (string, error) {
 
 	identityClient.ResourceBase = identityClient.Endpoint + "auth/"
 
-	opts := domains.ListOpts{
-		Name: c.DomainName,
-	}
-	allPages, err := domains.List(identityClient, &opts).AllPages()
+	// the List request does not support query options
+	allPages, err := domains.List(identityClient, nil).AllPages()
 	if err != nil {
 		return "", fmt.Errorf("List domains failed, err=%s", err)
 	}
@@ -357,6 +355,10 @@ func (c *Config) getDomainID() (string, error) {
 
 	if len(all) == 0 {
 		return "", fmt.Errorf("domain was not found")
+	}
+
+	if c.DomainName != "" && c.DomainName != all[0].Name {
+		return "", fmt.Errorf("domain %s was not found, got %s", c.DomainName, all[0].Name)
 	}
 
 	return all[0].ID, nil


### PR DESCRIPTION
when the domain name if not correct, the following error will be raised:
```
Error: Unable to find IAM domain ID with name xxxxx
```