### PR TITLE
feat: add data source to get available compute flavors

### DIFF
--- a/docs/data-sources/compute_flavors_v2.md
+++ b/docs/data-sources/compute_flavors_v2.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Elastic Cloud Server (ECS)"
+---
+
+# flexibleengine_compute_flavors_v2
+
+Use this data source to get the available Compute Flavors.
+
+## Example Usage
+
+```hcl
+data "flexibleengine_compute_flavors_v2" "flavors" {
+  availability_zone = "eu-west-0a"
+  performance_type  = "normal"
+  cpu_core          = 2
+  memory_size       = 4
+}
+
+# Create ECS instance with the first matched flavor
+resource "flexibleengine_compute_instance_v2" "instance" {
+  flavor_id = data.flexibleengine_compute_flavors_v2.flavors.flavors[0]
+  ...
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the flavors.
+  If omitted, the provider-level region will be used.
+
+* `availability_zone` - (Optional, String) Specifies the AZ name.
+
+* `performance_type` - (Optional, String) Specifies the ECS flavor type.
+
+* `generation` - (Optional, String) Specifies the generation of an ECS type.
+
+* `cpu_core` - (Optional, Int) Specifies the number of vCPUs in the ECS flavor.
+
+* `memory_size` - (Optional, Int) Specifies the memory size(GB) in the ECS flavor.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a data source ID in UUID format.
+
+* `flavors` - A list of flavors.

--- a/docs/resources/compute_instance_v2.md
+++ b/docs/resources/compute_instance_v2.md
@@ -14,7 +14,7 @@ Manages a V2 VM instance resource within FlexibleEngine.
 resource "flexibleengine_compute_instance_v2" "basic" {
   name            = "basic"
   image_id        = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  flavor_id       = "3"
+  flavor_id       = "s3.large.2"
   key_pair        = "my_key_pair_name"
   security_groups = ["default"]
 
@@ -40,7 +40,7 @@ resource "flexibleengine_blockstorage_volume_v2" "myvol" {
 resource "flexibleengine_compute_instance_v2" "myinstance" {
   name            = "myinstance"
   image_id        = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  flavor_id       = "3"
+  flavor_id       = "s3.large.2"
   key_pair        = "my_key_pair_name"
   security_groups = ["default"]
 
@@ -60,7 +60,7 @@ resource "flexibleengine_compute_volume_attach_v2" "attached" {
 ```hcl
 resource "flexibleengine_compute_instance_v2" "boot-from-volume" {
   name            = "boot-from-volume"
-  flavor_id       = "3"
+  flavor_id       = "s3.large.2"
   key_pair        = "my_key_pair_name"
   security_groups = ["default"]
 
@@ -91,7 +91,7 @@ resource "flexibleengine_blockstorage_volume_v2" "myvol" {
 
 resource "flexibleengine_compute_instance_v2" "boot-from-volume" {
   name            = "bootfromvolume"
-  flavor_id       = "3"
+  flavor_id       = "s3.large.2"
   key_pair        = "my_key_pair_name"
   security_groups = ["default"]
 
@@ -115,7 +115,7 @@ resource "flexibleengine_compute_instance_v2" "boot-from-volume" {
 resource "flexibleengine_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   image_id        = "<image-id>"
-  flavor_id       = "3"
+  flavor_id       = "s3.large.2"
   key_pair        = "my_key_pair_name"
   security_groups = ["default"]
 
@@ -148,7 +148,7 @@ resource "flexibleengine_blockstorage_volume_v2" "volume_1" {
 resource "flexibleengine_compute_instance_v2" "instance_1" {
   name            = "instance_1"
   image_id        = "<image-id>"
-  flavor_id       = "3"
+  flavor_id       = "s3.large.2"
   key_pair        = "my_key_pair_name"
   security_groups = ["default"]
 
@@ -180,7 +180,7 @@ resource "flexibleengine_networking_floatingip_v2" "myip" {
 resource "flexibleengine_compute_instance_v2" "multi-net" {
   name            = "multi-net"
   image_id        = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  flavor_id       = "3"
+  flavor_id       = "s3.large.2"
   key_pair        = "my_key_pair_name"
   security_groups = ["default"]
 
@@ -206,7 +206,7 @@ resource "flexibleengine_compute_floatingip_associate_v2" "myip" {
 resource "flexibleengine_compute_instance_v2" "multi-eph" {
   name            = "multi_eph"
   image_id        = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  flavor_id       = "3"
+  flavor_id       = "s3.large.2"
   key_pair        = "my_key_pair_name"
   security_groups = ["default"]
 
@@ -242,7 +242,7 @@ resource "flexibleengine_compute_instance_v2" "multi-eph" {
 resource "flexibleengine_compute_instance_v2" "instance_1" {
   name            = "basic"
   image_id        = "ad091b52-742f-469e-8f3c-fd81cadf0743"
-  flavor_id       = "3"
+  flavor_id       = "s3.large.2"
   key_pair        = "my_key_pair_name"
   security_groups = ["default"]
   user_data       = "#cloud-config\nhostname: instance_1.example.com\nfqdn: instance_1.example.com"

--- a/flexibleengine/data_source_flexibleengine_compute_flavors.go
+++ b/flexibleengine/data_source_flexibleengine_compute_flavors.go
@@ -1,0 +1,129 @@
+package flexibleengine
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/chnsz/golangsdk/openstack/ecs/v1/flavors"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode"
+)
+
+func dataSourceEcsFlavors() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceEcsFlavorsRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"performance_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"generation": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"cpu_core": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"memory_size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"flavors": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceEcsFlavorsRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	ecsClient, err := config.ComputeV1Client(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating FlexibleEngine ECS client: %s", err)
+	}
+
+	listOpts := &flavors.ListOpts{
+		AvailabilityZone: d.Get("availability_zone").(string),
+	}
+
+	pages, err := flavors.List(ecsClient, listOpts).AllPages()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	allFlavors, err := flavors.ExtractFlavors(pages)
+	if err != nil {
+		return diag.Errorf("Unable to retrieve flavors: %s ", err)
+	}
+
+	cpu := d.Get("cpu_core").(int)
+	mem := int64(d.Get("memory_size").(int)) * 1024
+	pType := d.Get("performance_type").(string)
+	gen := d.Get("generation").(string)
+	az := d.Get("availability_zone").(string)
+
+	var ids []string
+	for _, flavor := range allFlavors {
+		vCpu, _ := strconv.Atoi(flavor.Vcpus)
+		if cpu > 0 && vCpu != cpu {
+			continue
+		}
+
+		if mem > 0 && flavor.Ram != mem {
+			continue
+		}
+
+		if pType != "" && flavor.OsExtraSpecs.PerformanceType != pType {
+			continue
+		}
+
+		if gen != "" && flavor.OsExtraSpecs.Generation != gen {
+			continue
+		}
+
+		if az != "" {
+			status := flavor.OsExtraSpecs.OperationStatus
+			azStatusRaw := flavor.OsExtraSpecs.OperationAz
+			azStatusList := strings.Split(azStatusRaw, ",")
+			if strings.Contains(azStatusRaw, az) {
+				for i := 0; i < len(azStatusList); i++ {
+					azStatus := azStatusList[i]
+					if azStatus == (az+"(abandon)") || azStatus == (az+"(sellout)") || azStatus == (az+"obt_sellout") {
+						continue
+					}
+				}
+			} else if status == "abandon" || strings.Contains(status, "sellout") {
+				continue
+			}
+		}
+
+		ids = append(ids, flavor.ID)
+	}
+
+	if len(ids) < 1 {
+		return diag.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	d.SetId(hashcode.Strings(ids))
+	d.Set("flavors", ids)
+	d.Set("region", GetRegion(d, config))
+
+	return nil
+}

--- a/flexibleengine/data_source_flexibleengine_compute_flavors_test.go
+++ b/flexibleengine/data_source_flexibleengine_compute_flavors_test.go
@@ -1,0 +1,50 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccEcsFlavorsDataSource_basic(t *testing.T) {
+	resourceName := "data.flexibleengine_compute_flavors_v2.this"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEcsFlavorsDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEcsFlavorDataSourceID(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckEcsFlavorDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find compute flavors data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Compute Flavors data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+const testAccEcsFlavorsDataSource_basic = `
+data "flexibleengine_compute_flavors_v2" "this" {
+  performance_type = "normal"
+  cpu_core         = 2
+  memory_size      = 4
+}
+`

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -184,6 +184,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_blockstorage_volume_v2":             dataSourceBlockStorageVolumeV2(),
 			"flexibleengine_compute_availability_zones_v2":      dataSourceComputeAvailabilityZonesV2(),
 			"flexibleengine_compute_instance_v2":                dataSourceComputeInstance(),
+			"flexibleengine_compute_flavors_v2":                 dataSourceEcsFlavors(),
 			"flexibleengine_images_image_v2":                    dataSourceImagesImageV2(),
 			"flexibleengine_networking_network_v2":              dataSourceNetworkingNetworkV2(),
 			"flexibleengine_networking_secgroup_v2":             dataSourceNetworkingSecGroupV2(),

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/flavors/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/flavors/requests.go
@@ -1,0 +1,43 @@
+package flavors
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToFlavorListMap() (string, error)
+}
+
+//ListOpts allows the filtering and sorting of paginated collections through the API.
+type ListOpts struct {
+	// Specifies the AZ name.
+	AvailabilityZone string `q:"availability_zone"`
+}
+
+// ToFlavorListMap formats a ListOpts into a query string.
+func (opts ListOpts) ToFlavorListMap() (string, error) {
+	s, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return s.String(), err
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// flavors.
+func List(c *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		queryString, err := opts.ToFlavorListMap()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += queryString
+	}
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return FlavorsPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/flavors/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/flavors/results.go
@@ -1,0 +1,114 @@
+package flavors
+
+import (
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+type Flavor struct {
+	// Specifies the ID of ECS specifications.
+	ID string `json:"id"`
+
+	// Specifies the name of the ECS specifications.
+	Name string `json:"name"`
+
+	// Specifies the number of CPU cores in the ECS specifications.
+	Vcpus string `json:"vcpus"`
+
+	// Specifies the memory size (MB) in the ECS specifications.
+	Ram int64 `json:"ram"`
+
+	// Specifies the system disk size in the ECS specifications.
+	// The value 0 indicates that the disk size is not limited.
+	Disk string `json:"disk"`
+
+	// Specifies shortcut links for ECS flavors.
+	Links []Link `json:"links"`
+
+	// Specifies extended ECS specifications.
+	OsExtraSpecs OsExtraSpecs `json:"os_extra_specs"`
+
+	// Reserved
+	Swap string `json:"swap"`
+
+	// Reserved
+	FlvEphemeral int64 `json:"OS-FLV-EXT-DATA:ephemeral"`
+
+	// Reserved
+	FlvDisabled bool `json:"OS-FLV-DISABLED:disabled"`
+
+	// Reserved
+	RxtxFactor int64 `json:"rxtx_factor"`
+
+	// Reserved
+	RxtxQuota string `json:"rxtx_quota"`
+
+	// Reserved
+	RxtxCap string `json:"rxtx_cap"`
+
+	// Reserved
+	AccessIsPublic bool `json:"os-flavor-access:is_public"`
+}
+
+type Link struct {
+	// Specifies the shortcut link marker name.
+	Rel string `json:"rel"`
+
+	// Provides the corresponding shortcut link.
+	Href string `json:"href"`
+
+	// Specifies the shortcut link type.
+	Type string `json:"type"`
+}
+
+type OsExtraSpecs struct {
+	// Specifies the ECS specifications types
+	PerformanceType string `json:"ecs:performancetype"`
+
+	// Specifies the resource type.
+	ResourceType string `json:"resource_type"`
+
+	// Specifies the generation of an ECS type
+	Generation string `json:"ecs:generation"`
+
+	// Specifies a virtualization type
+	VirtualizationEnvTypes string `json:"ecs:virtualization_env_types"`
+
+	// Indicates whether the GPU is passthrough.
+	PciPassthroughEnableGpu string `json:"pci_passthrough:enable_gpu"`
+
+	// Indicates the technology used on the G1 and G2 ECSs,
+	// including GPU virtualization and GPU passthrough.
+	PciPassthroughGpuSpecs string `json:"pci_passthrough:gpu_specs"`
+
+	// Indicates the model and quantity of passthrough-enabled GPUs on P1 ECSs.
+	PciPassthroughAlias string `json:"pci_passthrough:alias"`
+
+	// Indicates the status of the flavor in region level.
+	OperationStatus string `json:"cond:operation:status"`
+
+	// Indicates the status of the flavor in az level.
+	OperationAz string `json:"cond:operation:az"`
+}
+
+// FlavorsPage is the page returned by a pager when traversing over a
+// collection of flavor.
+type FlavorsPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty checks whether a FlavorsPage struct is empty.
+func (r FlavorsPage) IsEmpty() (bool, error) {
+	is, err := ExtractFlavors(r)
+	return len(is) == 0, err
+}
+
+// ExtractFlavors accepts a Page struct, specifically a FlavorsPage struct,
+// and extracts the elements into a slice of flavor structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractFlavors(r pagination.Page) ([]Flavor, error) {
+	var s struct {
+		Flavors []Flavor `json:"flavors"`
+	}
+	err := (r.(FlavorsPage)).ExtractInto(&s)
+	return s.Flavors, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/flavors/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/flavors/urls.go
@@ -1,0 +1,7 @@
+package flavors
+
+import "github.com/chnsz/golangsdk"
+
+func listURL(sc *golangsdk.ServiceClient) string {
+	return sc.ServiceURL("cloudservers", "flavors")
+}

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode/hashcode.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode/hashcode.go
@@ -1,0 +1,35 @@
+package hashcode
+
+import (
+	"bytes"
+	"fmt"
+	"hash/crc32"
+)
+
+// String hashes a string to a unique hashcode.
+//
+// crc32 returns a uint32, but for our use we need
+// and non negative integer. Here we cast to an integer
+// and invert it if the result is negative.
+func String(s string) int {
+	v := int(crc32.ChecksumIEEE([]byte(s)))
+	if v >= 0 {
+		return v
+	}
+	if -v >= 0 {
+		return -v
+	}
+	// v == MinInt
+	return 0
+}
+
+// Strings hashes a list of strings to a unique hashcode.
+func Strings(strings []string) string {
+	var buf bytes.Buffer
+
+	for _, s := range strings {
+		buf.WriteString(fmt.Sprintf("%s-", s))
+	}
+
+	return fmt.Sprintf("%d", String(buf.String()))
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -117,6 +117,7 @@ github.com/chnsz/golangsdk/openstack/dws/cluster
 github.com/chnsz/golangsdk/openstack/ecs/v1/auto_recovery
 github.com/chnsz/golangsdk/openstack/ecs/v1/block_devices
 github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers
+github.com/chnsz/golangsdk/openstack/ecs/v1/flavors
 github.com/chnsz/golangsdk/openstack/ecs/v1/tags
 github.com/chnsz/golangsdk/openstack/identity/v2/tenants
 github.com/chnsz/golangsdk/openstack/identity/v2/tokens
@@ -306,6 +307,7 @@ github.com/hashicorp/yamux
 # github.com/huaweicloud/terraform-provider-huaweicloud v1.28.1
 ## explicit
 github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config
+github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode
 github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv
 github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/pathorcontents
 # github.com/jen20/awspolicyequivalence v1.1.0


### PR DESCRIPTION
refer to #560

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccEcsFlavorsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccEcsFlavorsDataSource_basic -timeout 720m
=== RUN   TestAccEcsFlavorsDataSource_basic
=== PAUSE TestAccEcsFlavorsDataSource_basic
=== CONT  TestAccEcsFlavorsDataSource_basic
--- PASS: TestAccEcsFlavorsDataSource_basic (9.15s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 9.163s
```