### PR TITLE
feat: add vcpus and memory arguments into rds flavors data source

### DIFF
--- a/docs/data-sources/rds_flavors_v3.md
+++ b/docs/data-sources/rds_flavors_v3.md
@@ -2,7 +2,7 @@
 subcategory: "Relational Database Service (RDS)"
 ---
 
-# flexibleengine\_rds\_flavors\_v3
+# flexibleengine_rds_flavors_v3
 
 Use this data source to get available FlexibleEngine rds flavors.
 
@@ -18,23 +18,23 @@ data "flexibleengine_rds_flavors_v3" "flavor" {
 
 ## Argument Reference
 
-* `db_type` - (Required) Specifies the DB engine. Value: MySQL, PostgreSQL, SQLServer.
+* `db_type` - (Required, String) Specifies the DB engine. Value: MySQL, PostgreSQL, SQLServer.
 
-* `db_version` -
-  (Required)
-  Specifies the database version. MySQL databases support MySQL 5.6
-  and 5.7. PostgreSQL databases support
-  PostgreSQL 9.5 and 9.6. Microsoft SQL Server
-  databases support 2014_SE, 2016_SE, and 2016_EE.
+* `db_version` - (Required, String) Specifies the database version. MySQL databases support MySQL 5.6
+  and 5.7. PostgreSQL databases support PostgreSQL 9.5 and 9.6. Microsoft SQL Server databases support
+  2014_SE, 2016_SE, and 2016_EE.
 
-* `instance_mode` - (Required) The mode of instance. Value: ha(indicates primary/standby instance), single(indicates single instance)
+* `instance_mode` - (Required, String) The mode of instance. Value: ha(indicates primary/standby instance), single(indicates single instance)
+
+* `vcpus` - (Optional, Int) Specifies the number of vCPUs in the RDS flavor.
+
+* `memory` - (Optional, Int) Specifies the memory size(GB) in the RDS flavor.
 
 ## Attributes Reference
 
 In addition, the following attributes are exported:
 
-* `flavors` -
-  Indicates the flavors information. Structure is documented below.
+* `flavors` - Indicates the flavors information. Structure is documented below.
 
 The `flavors` block contains:
 


### PR DESCRIPTION
refer to #560 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccRdsFlavorV3DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccRdsFlavorV3DataSource_basic -timeout 720m
=== RUN   TestAccRdsFlavorV3DataSource_basic
--- PASS: TestAccRdsFlavorV3DataSource_basic (9.77s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 9.788s
```