### PR TITLE
feat: support to query an available BMS flavor by vcpus

### DIFF
--- a/docs/data-sources/compute_bms_flavors_v2.md
+++ b/docs/data-sources/compute_bms_flavors_v2.md
@@ -4,50 +4,45 @@ subcategory: "Bare Metal Server (BMS)"
 
 # Data Source: flexibleengine_compute_bms_flavors_v2
 
-`flexibleengine_compute_bms_flavors_v2` used to query flavors of BMSs.
+Use this data source to get an available BMS Flavor.
 
 ## Example Usage
 
 ```hcl
-    
-    variable "flavor_id" { }
-    variable "disk_size" { }
-
-    data "flexibleengine_compute_bms_flavors_v2" "Query_BMS_flavors" 
-    {
-        id = "${var.bms_id}",
-        min_disk = "${var.disk_size}",
-        sort_key = "id",
-        sort_dir = "desc",
-    }
-    
+data "flexibleengine_compute_bms_flavors_v2" "BMS_flavor" {
+  vcpus = 32
+}
 ```
 
 ## Argument Reference
 
 The arguments of this data source act as filters for querying the BMSs details.
 
-* `name` - (Optional) - The name of the BMS flavor.
+* `name` (Optional) - Specifies the name of the BMS flavor.
 
-* `id` (Optional) - The BMS flavor id.
+* `vcpus` (Optional) - Specifies the number of CPU cores in the BMS flavor.
 
-* `min_ram` (Optional) - The minimum memory size in MB. Only the BMSs with the memory size greater than or equal to the minimum size can be queried.
+* `min_ram` (Optional) - Specifies the minimum memory size in MB. Only the BMSs with the memory size
+  greater than or equal to the minimum size can be queried.
 
-* `min_disk` (Optional) - The minimum disk size in GB. Only the BMSs with a disk size greater than or equal to the minimum size can be queried.
+* `min_disk` (Optional) - Specifies the minimum disk size in GB. Only the BMSs with a disk size
+  greater than or equal to the minimum size can be queried.
 
-* `sort_key` (Optional) - The sorting field. The default value is **flavorid**. The other values are **name**, **memory_mb**, **vcpus**, **root_gb**, or **flavorid**.
+* `sort_key` (Optional) - The sorting field. The default value is **flavorid**.
+  The available values are **name**, **memory_mb**, **vcpus**, **root_gb**, or **flavorid**.
 
-* `sort_dir` (Optional) - The sorting order, which can be **ascending** (**asc**) or **descending** (**desc**). The default value is **asc**.
+* `sort_dir` (Optional) - The sorting order, which can be **asc** (ascending) or **desc** (descending).
+  The default value is **asc**.
 
 ## Attributes Reference
 
 All of the argument attributes are also exported as result attributes. 
 
-* `ram` - It is the memory size (in MB) of the flavor.
+* `id` - The BMS flavor id.
 
-* `vcpus` - It is the number of CPU cores in the BMS flavor.
+* `ram` - The memory size (in MB) of the BMS flavor.
 
-* `disk` - Specifies the disk size (GB) in the BMS flavor.
+* `disk` - The disk size (GB) in the BMS flavor.
 
 * `swap` -  This is a reserved attribute.
 

--- a/flexibleengine/data_source_flexibleengine_compute_bms_flavor_v2_test.go
+++ b/flexibleengine/data_source_flexibleengine_compute_bms_flavor_v2_test.go
@@ -16,9 +16,12 @@ func TestAccBMSV2FlavorDataSource_basic(t *testing.T) {
 			{
 				Config: testAccBMSV2FlavorDataSource_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBMSV2FlavorDataSourceID("data.flexibleengine_compute_bms_flavors_v2.flavor"),
+					testAccCheckBMSV2FlavorDataSourceID("data.flexibleengine_compute_bms_flavors_v2.byName"),
+					testAccCheckBMSV2FlavorDataSourceID("data.flexibleengine_compute_bms_flavors_v2.byCPU"),
 					resource.TestCheckResourceAttr(
-						"data.flexibleengine_compute_bms_flavors_v2.flavor", "name", OS_BMS_FLAVOR_NAME),
+						"data.flexibleengine_compute_bms_flavors_v2.byName", "name", OS_BMS_FLAVOR_NAME),
+					resource.TestCheckResourceAttr(
+						"data.flexibleengine_compute_bms_flavors_v2.byCPU", "vcpus", "32"),
 				),
 			},
 		},
@@ -41,7 +44,11 @@ func testAccCheckBMSV2FlavorDataSourceID(n string) resource.TestCheckFunc {
 }
 
 var testAccBMSV2FlavorDataSource_basic = fmt.Sprintf(`
-data "flexibleengine_compute_bms_flavors_v2" "flavor" {
+data "flexibleengine_compute_bms_flavors_v2" "byName" {
   name = "%s"
+}
+
+data "flexibleengine_compute_bms_flavors_v2" "byCPU" {
+  vcpus = 32
 }
 `, OS_BMS_FLAVOR_NAME)


### PR DESCRIPTION
refer to #560 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccBMSV2FlavorDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccBMSV2FlavorDataSource_basic -timeout 720m
=== RUN   TestAccBMSV2FlavorDataSource_basic
--- PASS: TestAccBMSV2FlavorDataSource_basic (9.15s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 9.168s
```