### PR TITLE
enhance: improve on nat gateway resource

### DIFF
--- a/docs/resources/nat_gateway_v2.md
+++ b/docs/resources/nat_gateway_v2.md
@@ -10,11 +10,11 @@ Manages a V2 nat gateway resource within FlexibleEngine.
 
 ```hcl
 resource "flexibleengine_nat_gateway_v2" "nat_1" {
-  name   = "nat_test"
+  name        = "nat_test"
   description = "test for terraform"
-  spec = "3"
-  router_id = "2c1fe4bd-ebad-44ca-ae9d-e94e63847b75"
-  internal_network_id = "dc8632e2-d9ff-41b1-aa0c-d455557314a0"
+  spec        = "3"
+  vpc_id      = "2c1fe4bd-ebad-44ca-ae9d-e94e63847b75"
+  subnet_id   = "dc8632e2-d9ff-41b1-aa0c-d455557314a0"
 }
 ```
 
@@ -22,34 +22,46 @@ resource "flexibleengine_nat_gateway_v2" "nat_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to obtain the V2 nat client.
-    If omitted, the `region` argument of the provider is used. Changing this
-    creates a new nat gateway.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the Nat gateway resource.
+  If omitted, the provider-level region will be used. Changing this creates a new nat gateway.
 
-* `name` - (Required) The name of the nat gateway.
+* `name` - (Required, String) Specifies the nat gateway name. The name can contain only digits, letters,
+  underscores (_), and hyphens(-).
 
-* `description` - (Optional) The description of the nat gateway.
+* `spec` - (Required, String) Specifies the nat gateway type. The value can be:
+  + `1`: small type, which supports up to 10,000 SNAT connections.
+  + `2`: medium type, which supports up to 50,000 SNAT connections.
+  + `3`: large type, which supports up to 200,000 SNAT connections.
+  + `4`: extra-large type, which supports up to 1,000,000 SNAT connections.
 
-* `spec` - (Required) The specification of the nat gateway, valid values are "1",
-    "2", "3", "4" (for Small, Medium, Large, Extra-Large)
+* `vpc_id` - (Required, String, ForceNew) Specifies the ID of the VPC this nat gateway belongs to.
+  Changing this creates a new nat gateway.
 
-* `router_id` - (Required) ID of the router/VPC this nat gateway belongs to. Changing
-    this creates a new nat gateway.
+* `subnet_id` - (Required, String, ForceNew) Specifies the subnet ID of the downstream interface
+  (the next hop of the DVR) of the NAT gateway. Changing this creates a new nat gateway.
 
-* `internal_network_id` - (Required) ID of the subnet (!) this nat gateway connects to.
-    Changing this creates a new nat gateway.
-
-* `tenant_id` - (Optional) The target tenant/project ID in which to allocate the nat
-    gateway. Changing this creates a new nat gateway .
+* `description` - (Optional, String) Specifies the description of the nat gateway.
+  The value contains 0 to 255 characters, and angle brackets (<) and (>) are not allowed.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
-* `region` - See Argument Reference above.
-* `name` - See Argument Reference above.
-* `description` - See Argument Reference above.
-* `spec` - See Argument Reference above.
-* `tenant_id` - See Argument Reference above.
-* `router_id` - See Argument Reference above.
-* `internal_network_id` - See Argument Reference above.
+* `id` - The resource ID in UUID format.
+
+* `status` - The status of the nat gateway.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `delete` - Default is 10 minute.
+
+## Import
+
+Nat gateway can be imported using the following format:
+
+```
+$ terraform import flexibleengine_nat_gateway_v2.nat_1 d126fb87-43ce-4867-a2ff-cf34af3765d9
+```


### PR DESCRIPTION
* support importing the resource
* use vpc_id and subnet_id to replace router_id and internal_network_id

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccNatGateway_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccNatGateway_basic -timeout 720m
=== RUN   TestAccNatGateway_basic
=== PAUSE TestAccNatGateway_basic
=== CONT  TestAccNatGateway_basic
--- PASS: TestAccNatGateway_basic (97.41s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 97.420s
```