### PR TITLE
feat: new data source for nat gateway

### DIFF
--- a/docs/data-sources/nat_gateway_v2.md
+++ b/docs/data-sources/nat_gateway_v2.md
@@ -1,0 +1,38 @@
+---
+subcategory: "NAT Gateway (NAT)"
+---
+
+# flexibleengine_nat_gateway_v2
+
+Use this data source to get the information of an available FlexibleEngine NAT gateway.
+
+## Example Usage
+
+```hcl
+data "flexibleengine_nat_gateway_v2" "natgateway" {
+  name = "test_natgateway"
+}
+```
+
+## Argument Reference
+
+* `id` - (Optional, String) Specifies the ID of the NAT gateway.
+
+* `name` - (Optional, String) Specifies the NAT gateway name. The name can contain only digits, letters,
+  underscores (_), and hyphens(-).
+
+* `vpc_id` - (Optional, String) Specifies the ID of the VPC this NAT gateway belongs to.
+
+* `subnet_id` - (Optional, String) Specifies the subnet ID of the downstream interface (the next hop of the DVR) of the
+  NAT gateway.
+
+* `spec` - (Optional, String) The NAT gateway type. The value can be:
+  + `1`: small type, which supports up to 10,000 SNAT connections.
+  + `2`: medium type, which supports up to 50,000 SNAT connections.
+  + `3`: large type, which supports up to 200,000 SNAT connections.
+  + `4`: extra-large type, which supports up to 1,000,000 SNAT connections.
+
+* `description` - (Optional, String) Specifies the description of the NAT gateway. The value contains 0 to 255
+  characters, and angle brackets (<) and (>) are not allowed.
+
+* `status` - (Optional, String) Specifies the status of the NAT gateway.

--- a/flexibleengine/data_source_flexibleengine_nat_gateway_v2.go
+++ b/flexibleengine/data_source_flexibleengine_nat_gateway_v2.go
@@ -1,0 +1,104 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/chnsz/golangsdk/openstack/networking/v2/extensions/natgateways"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceNatGatewayV2() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNatGatewayV2Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"spec": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceNatGatewayV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	natClient, err := config.natV2Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine nat client: %s", err)
+	}
+
+	listOpts := natgateways.ListOpts{
+		ID:                d.Get("id").(string),
+		Name:              d.Get("name").(string),
+		Description:       d.Get("description").(string),
+		Spec:              d.Get("spec").(string),
+		RouterID:          d.Get("vpc_id").(string),
+		InternalNetworkID: d.Get("subnet_id").(string),
+		Status:            d.Get("status").(string),
+	}
+
+	pages, err := natgateways.List(natClient, listOpts).AllPages()
+	if err != nil {
+		return err
+	}
+
+	allNatGateways, err := natgateways.ExtractNatGateways(pages)
+
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve natgateways: %s", err)
+	}
+
+	if len(allNatGateways) < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	if len(allNatGateways) > 1 {
+		return fmt.Errorf("Your query returned more than one result." +
+			" Please try a more specific search criteria")
+	}
+
+	natgateway := allNatGateways[0]
+
+	log.Printf("[DEBUG] Retrieved Natgateway %s: %+v", natgateway.ID, natgateway)
+
+	d.SetId(natgateway.ID)
+	d.Set("name", natgateway.Name)
+	d.Set("description", natgateway.Description)
+	d.Set("spec", natgateway.Spec)
+	d.Set("vpc_id", natgateway.RouterID)
+	d.Set("subnet_id", natgateway.InternalNetworkID)
+	d.Set("status", natgateway.Status)
+
+	return nil
+}

--- a/flexibleengine/data_source_flexibleengine_nat_gateway_v2_test.go
+++ b/flexibleengine/data_source_flexibleengine_nat_gateway_v2_test.go
@@ -1,0 +1,79 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccNatGatewayDataSource_basic(t *testing.T) {
+	natgateway := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNatGatewayV2DataSource_basic(natgateway),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNatGatewayV2DataSourceID("data.flexibleengine_nat_gateway_v2.nat_by_name"),
+					testAccCheckNatGatewayV2DataSourceID("data.flexibleengine_nat_gateway_v2.nat_by_id"),
+					resource.TestCheckResourceAttr(
+						"data.flexibleengine_nat_gateway_v2.nat_by_name", "name", natgateway),
+					resource.TestCheckResourceAttr(
+						"data.flexibleengine_nat_gateway_v2.nat_by_id", "name", natgateway),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckNatGatewayV2DataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find natgateway data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("NatGateway data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+func testAccNatGatewayV2DataSource_basic(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc_v1" "vpc_1" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "subnet_1" {
+  name       = "%s"
+  cidr       = "192.168.199.0/24"
+  gateway_ip = "192.168.199.1"
+  vpc_id     = flexibleengine_vpc_v1.vpc_1.id
+}
+
+resource "flexibleengine_nat_gateway_v2" "nat_1" {
+  name        = "%s"
+  description = "test for terraform"
+  spec        = "1"
+  vpc_id      = flexibleengine_vpc_v1.vpc_1.id
+  subnet_id   = flexibleengine_vpc_subnet_v1.subnet_1.id
+}
+
+data "flexibleengine_nat_gateway_v2" "nat_by_name" {
+  name = flexibleengine_nat_gateway_v2.nat_1.name
+}
+
+data "flexibleengine_nat_gateway_v2" "nat_by_id" {
+  id = flexibleengine_nat_gateway_v2.nat_1.id
+}
+`, name, name, name)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -198,6 +198,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_vpc_route_v2":                       dataSourceVPCRouteV2(),
 			"flexibleengine_vpc_route_ids_v2":                   dataSourceVPCRouteIdsV2(),
 			"flexibleengine_vpc_peering_connection_v2":          dataSourceVpcPeeringConnectionV2(),
+			"flexibleengine_nat_gateway_v2":                     dataSourceNatGatewayV2(),
 			"flexibleengine_sfs_file_system_v2":                 dataSourceSFSFileSystemV2(),
 			"flexibleengine_compute_bms_flavors_v2":             dataSourceBMSFlavorV2(),
 			"flexibleengine_compute_bms_nic_v2":                 dataSourceBMSNicV2(),


### PR DESCRIPTION
fixes #624 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccNatGatewayDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccNatGatewayDataSource_basic -timeout 720m
=== RUN   TestAccNatGatewayDataSource_basic
=== PAUSE TestAccNatGatewayDataSource_basic
=== CONT  TestAccNatGatewayDataSource_basic
--- PASS: TestAccNatGatewayDataSource_basic (66.04s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 66.052s
```