### PR TITLE
fix: make some acceptance tests happy

### DIFF
--- a/docs/data-sources/images_image_v2.md
+++ b/docs/data-sources/images_image_v2.md
@@ -45,7 +45,6 @@ data "flexibleengine_images_image_v2" "ubuntu" {
 are exported:
 
 * `checksum` - The checksum of the data associated with the image.
-* `created_at` - The date the image was created.
 * `container_format`: The format of the image's container.
 * `disk_format`: The format of the image's disk.
 * `file` - The URL for uploading and downloading the image file.
@@ -57,5 +56,5 @@ are exported:
 * `schema` - The path to the JSON-schema that represent
    the image or image
 * `size_bytes` - The size of the image (in bytes).
-* `tags` - See Argument Reference above.
-* `update_at` - The date the image was last updated.
+* `created_at` - The date the image was created.
+* `updated_at` - The date the image was last updated.

--- a/docs/data-sources/networking_secgroup_v2.md
+++ b/docs/data-sources/networking_secgroup_v2.md
@@ -31,6 +31,6 @@ data "flexibleengine_networking_secgroup_v2" "secgroup" {
 `id` is set to the ID of the found security group. In addition, the following
 attributes are exported:
 
+* `region` - See Argument Reference above.
 * `name` - See Argument Reference above.
 * `description`- The description of the security group.
-* `region` - See Argument Reference above.

--- a/docs/resources/images_image_v2.md
+++ b/docs/resources/images_image_v2.md
@@ -72,7 +72,6 @@ The following attributes are exported:
 
 * `checksum` - The checksum of the data associated with the image.
 * `container_format` - See Argument Reference above.
-* `created_at` - The date the image was created.
 * `disk_format` - See Argument Reference above.
 * `file` - the trailing path after the glance
    endpoint that represent the location of the image
@@ -93,8 +92,9 @@ The following attributes are exported:
 * `status` - The status of the image. It can be "queued", "active"
    or "saving".
 * `tags` - See Argument Reference above.
-* `update_at` - The date the image was last updated.
 * `visibility` - See Argument Reference above.
+* `created_at` - The date the image was created.
+* `updated_at` - The date the image was last updated.
 
 ## Import
 

--- a/flexibleengine/data_source_flexibleengine_images_image_v2.go
+++ b/flexibleengine/data_source_flexibleengine_images_image_v2.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"sort"
+	"time"
 
 	"github.com/chnsz/golangsdk/openstack/imageservice/v2/images"
 
@@ -120,7 +121,10 @@ func dataSourceImagesImageV2() *schema.Resource {
 				Type:     schema.TypeMap,
 				Computed: true,
 			},
-
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"updated_at": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -202,7 +206,6 @@ func dataSourceImagesImageV2Attributes(d *schema.ResourceData, image *images.Ima
 
 	d.SetId(image.ID)
 	d.Set("name", image.Name)
-	d.Set("tags", image.Tags)
 	d.Set("container_format", image.ContainerFormat)
 	d.Set("disk_format", image.DiskFormat)
 	d.Set("min_disk_gb", image.MinDiskGigabytes)
@@ -213,10 +216,10 @@ func dataSourceImagesImageV2Attributes(d *schema.ResourceData, image *images.Ima
 	d.Set("checksum", image.Checksum)
 	d.Set("size_bytes", image.SizeBytes)
 	d.Set("metadata", image.Metadata)
-	d.Set("created_at", image.CreatedAt)
-	d.Set("updated_at", image.UpdatedAt)
 	d.Set("file", image.File)
 	d.Set("schema", image.Schema)
+	d.Set("created_at", image.CreatedAt.Format(time.RFC3339))
+	d.Set("updated_at", image.UpdatedAt.Format(time.RFC3339))
 
 	return nil
 }

--- a/flexibleengine/data_source_flexibleengine_networking_secgroup_v2.go
+++ b/flexibleengine/data_source_flexibleengine_networking_secgroup_v2.go
@@ -28,6 +28,10 @@ func dataSourceNetworkingSecGroupV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"tenant_id": {
 				Type:     schema.TypeString,
 				Optional: true,

--- a/flexibleengine/data_source_flexibleengine_networking_secgroup_v2_test.go
+++ b/flexibleengine/data_source_flexibleengine_networking_secgroup_v2_test.go
@@ -65,8 +65,8 @@ func testAccCheckNetworkingSecGroupV2DataSourceID(n string) resource.TestCheckFu
 
 const testAccFlexibleEngineNetworkingSecGroupV2DataSource_group = `
 resource "flexibleengine_networking_secgroup_v2" "secgroup_1" {
-        name        = "flexibleengine_acctest_secgroup"
-	description = "My neutron security group for flexibleengine acctest"
+  name        = "flexibleengine_acctest_secgroup"
+  description = "My neutron security group for flexibleengine acctest"
 }
 `
 
@@ -74,7 +74,7 @@ var testAccFlexibleEngineNetworkingSecGroupV2DataSource_basic = fmt.Sprintf(`
 %s
 
 data "flexibleengine_networking_secgroup_v2" "secgroup_1" {
-	name = "${flexibleengine_networking_secgroup_v2.secgroup_1.name}"
+  name = flexibleengine_networking_secgroup_v2.secgroup_1.name
 }
 `, testAccFlexibleEngineNetworkingSecGroupV2DataSource_group)
 
@@ -82,6 +82,6 @@ var testAccFlexibleEngineNetworkingSecGroupV2DataSource_secGroupID = fmt.Sprintf
 %s
 
 data "flexibleengine_networking_secgroup_v2" "secgroup_1" {
-	secgroup_id = "${flexibleengine_networking_secgroup_v2.secgroup_1.id}"
+  secgroup_id = flexibleengine_networking_secgroup_v2.secgroup_1.id
 }
 `, testAccFlexibleEngineNetworkingSecGroupV2DataSource_group)

--- a/flexibleengine/resource_flexibleengine_images_image_v2.go
+++ b/flexibleengine/resource_flexibleengine_images_image_v2.go
@@ -53,11 +53,6 @@ func resourceImagesImageV2() *schema.Resource {
 				ValidateFunc: resourceImagesImageV2ValidateContainerFormat,
 			},
 
-			"created_at": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"disk_format": {
 				Type:             schema.TypeString,
 				Required:         true,
@@ -153,7 +148,11 @@ func resourceImagesImageV2() *schema.Resource {
 				Set:      schema.HashString,
 			},
 
-			"update_at": {
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -267,8 +266,6 @@ func resourceImagesImageV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("checksum", img.Checksum)
 	d.Set("size_bytes", img.SizeBytes)
 	d.Set("metadata", img.Metadata)
-	d.Set("created_at", img.CreatedAt)
-	d.Set("update_at", img.UpdatedAt)
 	d.Set("container_format", img.ContainerFormat)
 	d.Set("disk_format", img.DiskFormat)
 	d.Set("min_disk_gb", img.MinDiskGigabytes)
@@ -280,6 +277,9 @@ func resourceImagesImageV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("tags", img.Tags)
 	d.Set("visibility", img.Visibility)
 	d.Set("region", GetRegion(d, config))
+
+	d.Set("created_at", img.CreatedAt.Format(time.RFC3339))
+	d.Set("updated_at", img.UpdatedAt.Format(time.RFC3339))
 
 	return nil
 }


### PR DESCRIPTION
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccImagesImageV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccImagesImageV2_basic -timeout 720m
=== RUN   TestAccImagesImageV2_basic
--- PASS: TestAccImagesImageV2_basic (543.96s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 543.971s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccOrangeCloudImagesV2ImageDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccOrangeCloudImagesV2ImageDataSource_basic -timeout 720m
=== RUN   TestAccOrangeCloudImagesV2ImageDataSource_basic
--- PASS: TestAccOrangeCloudImagesV2ImageDataSource_basic (417.91s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 417.921s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccFlexibleEngineNetworkingSecGroupV2DataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccFlexibleEngineNetworkingSecGroupV2DataSource -timeout 720m
=== RUN   TestAccFlexibleEngineNetworkingSecGroupV2DataSource_basic
--- PASS: TestAccFlexibleEngineNetworkingSecGroupV2DataSource_basic (26.29s)
=== RUN   TestAccFlexibleEngineNetworkingSecGroupV2DataSource_secGroupID
--- PASS: TestAccFlexibleEngineNetworkingSecGroupV2DataSource_secGroupID (26.39s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 52.695s
```