### PR TITLE
fix: support to update iam project name and update test case

### DIFF
--- a/flexibleengine/resource_flexibleengine_identity_project_v3.go
+++ b/flexibleengine/resource_flexibleengine_identity_project_v3.go
@@ -59,7 +59,7 @@ func resourceIdentityProjectV3Create(d *schema.ResourceData, meta interface{}) e
 	config := meta.(*Config)
 	identityClient, err := config.identityV3Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating OpenStack identity client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
 	}
 
 	createOpts := projects.CreateOpts{
@@ -72,11 +72,10 @@ func resourceIdentityProjectV3Create(d *schema.ResourceData, meta interface{}) e
 	project, err := projects.Create(identityClient, createOpts).Extract()
 
 	if err != nil {
-		return fmt.Errorf("Error creating project")
+		return fmt.Errorf("Error creating project: %s", err)
 	}
 
 	d.SetId(project.ID)
-	log.Printf("[INFO] Project ID: %s", project.ID)
 
 	return resourceIdentityProjectV3Read(d, meta)
 }
@@ -110,20 +109,20 @@ func resourceIdentityProjectV3Update(d *schema.ResourceData, meta interface{}) e
 	config := meta.(*Config)
 	identityClient, err := config.identityV3Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating OpenStack identity client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
 	}
 
 	var hasChange bool
 	var updateOpts projects.UpdateOpts
 
+	if d.HasChange("name") {
+		hasChange = true
+		updateOpts.Name = d.Get("name").(string)
+	}
+
 	if d.HasChange("description") {
 		hasChange = true
 		updateOpts.Description = d.Get("description").(string)
-	}
-
-	if d.HasChange("name") {
-		hasChange = true
-		updateOpts.Description = d.Get("name").(string)
 	}
 
 	if hasChange {
@@ -146,7 +145,7 @@ func resourceIdentityProjectV3Delete(d *schema.ResourceData, meta interface{}) e
 	// config := meta.(*Config)
 	// identityClient, err := config.identityV3Client(GetRegion(d, config))
 	// if err != nil {
-	// 	return fmt.Errorf("Error creating OpenStack identity client: %s", err)
+	// 	return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
 	// }
 
 	// err = projects.Delete(identityClient, d.Id()).ExtractErr()

--- a/flexibleengine/resource_flexibleengine_identity_project_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_identity_project_v3_test.go
@@ -13,11 +13,12 @@ import (
 
 func TestAccIdentityProjectV3_basic(t *testing.T) {
 	var project projects.Project
-	var projectName = fmt.Sprintf("eu-west-0-ACCPTTEST-%s", acctest.RandString(5))
+	var projectName = fmt.Sprintf("%s_ACCPTTEST-%s", OS_REGION_NAME, acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckIdentityProjectV3Destroy,


### PR DESCRIPTION
fix some tiny bugs in flexibleengine_identity_project_v3 resource.

as the project can not be deleted, the acceptance testing will raise the following error:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccIdentityProjectV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccIdentityProjectV3_basic -timeout 720m
=== RUN   TestAccIdentityProjectV3_basic
    TestAccIdentityProjectV3_basic: testing_new.go:70: Error running post-test destroy, there may be dangling resources: Project still exists
--- FAIL: TestAccIdentityProjectV3_basic (12.75s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 12.760s
FAIL
GNUmakefile:17: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```