### PR TITLE
fix(cce): extend delay and pollInterval to get node ID

### DIFF
--- a/flexibleengine/resource_flexibleengine_cce_cluster_v3.go
+++ b/flexibleengine/resource_flexibleengine_cce_cluster_v3.go
@@ -330,12 +330,12 @@ func resourceCCEClusterV3Create(d *schema.ResourceData, meta interface{}) error 
 	log.Printf("[DEBUG] Waiting for flexibleengine CCE cluster (%s) to become available", create.Metadata.Id)
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"Creating"},
-		Target:     []string{"Available"},
-		Refresh:    waitForCCEClusterActive(cceClient, create.Metadata.Id),
-		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
-		MinTimeout: 3 * time.Second,
+		Pending:      []string{"Creating"},
+		Target:       []string{"Available"},
+		Refresh:      waitForCCEClusterActive(cceClient, create.Metadata.Id),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        120 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
 
 	_, err = stateConf.WaitForState()
@@ -454,12 +454,12 @@ func resourceCCEClusterV3Delete(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("Error deleting flexibleengine CCE Cluster: %s", err)
 	}
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"Deleting", "Available", "Unavailable"},
-		Target:     []string{"Deleted"},
-		Refresh:    waitForCCEClusterDelete(cceClient, d.Id()),
-		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
-		MinTimeout: 3 * time.Second,
+		Pending:      []string{"Deleting", "Available", "Unavailable"},
+		Target:       []string{"Deleted"},
+		Refresh:      waitForCCEClusterDelete(cceClient, d.Id()),
+		Timeout:      d.Timeout(schema.TimeoutDelete),
+		Delay:        60 * time.Second,
+		PollInterval: 10 * time.Second,
 	}
 
 	_, err = stateConf.WaitForState()


### PR DESCRIPTION
the result of acceptance testing is as follows:

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCCENodeV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCCENodeV3_basic -timeout 720m
=== RUN   TestAccCCENodeV3_basic
--- PASS: TestAccCCENodeV3_basic (748.73s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 748.748s
```