### PR TITLE
feat: improve on dcs data sources

### DIFF
--- a/docs/data-sources/dcs_az_v1.md
+++ b/docs/data-sources/dcs_az_v1.md
@@ -1,10 +1,12 @@
 ---
-subcategory: "Distributed Cache Service (DCS)"
+subcategory: "Deprecated"
 ---
 
-# flexibleengine\_dcs\_az_v1
+# flexibleengine_dcs_az_v1
 
 Use this data source to get the ID of an available Flexibleengine dcs az.
+
+!> **Warning:** It has been deprecated, you can use the availability zone code directly, e.g. eu-west-0b.
 
 ## Example Usage
 
@@ -19,11 +21,11 @@ data "flexibleengine_dcs_az_v1" "az1" {
 
 ## Argument Reference
 
-* `name` - (Required) Indicates the name of an AZ.
+* `name` - (Optional) Indicates the name of an AZ.
 
 * `code` - (Optional) Indicates the code of an AZ.
 
-* `port` - (Required) Indicates the port number of an AZ.
+* `port` - (Optional) Indicates the port number of an AZ.
 
 
 ## Attributes Reference

--- a/docs/data-sources/dcs_maintainwindow_v1.md
+++ b/docs/data-sources/dcs_maintainwindow_v1.md
@@ -2,29 +2,29 @@
 subcategory: "Distributed Cache Service (DCS)"
 ---
 
-# flexibleengine\_dcs\_maintainwindow_v1
+# flexibleengine_dcs_maintainwindow_v1
 
-Use this data source to get the ID of an available Flexibleengine dcs maintainwindow.
+Use this data source to get the ID of an available Flexibleengine DCS maintainwindow.
 
 ## Example Usage
 
 ```hcl
 
 data "flexibleengine_dcs_maintainwindow_v1" "maintainwindow1" {
-seq = 1
+  default = true
 }
 
 ```
 
 ## Argument Reference
 
-* `seq` - (Required) Indicates the sequential number of a maintenance time window.
+* `default` - (Optional) Specifies whether a maintenance time window is set to the default time segment.
 
-* `begin` - (Optional) Indicates the time at which a maintenance time window starts.
+* `seq` - (Optional) Specifies the sequential number of a maintenance time window.
 
-* `end` - (Required) Indicates the time at which a maintenance time window ends.
+* `begin` - (Optional) Specifies the time at which a maintenance time window starts.
 
-* `default` - (Required) Indicates whether a maintenance time window is set to the default time segment.
+* `end` - (Optional) Specifies the time at which a maintenance time window ends.
 
 ## Attributes Reference
 

--- a/docs/data-sources/dcs_product_v1.md
+++ b/docs/data-sources/dcs_product_v1.md
@@ -2,45 +2,38 @@
 subcategory: "Distributed Cache Service (DCS)"
 ---
 
-# flexibleengine\_dcs\_product_v1
+# flexibleengine_dcs_product_v1
 
 Use this data source to get the ID of an available Flexibleengine dcs product.
 
 ## Example Usage
 
 ```hcl
-
 data "flexibleengine_dcs_product_v1" "product1" {
-  engine = "kafka"
-  version = "1.1.0"
-  instance_type = "cluster"
-  partition_num = 300
-  storage = 600
-  storage_spec_code = "dcs.physical.storage.high"
+  engine = "redis"
+}
+
+data "flexibleengine_dcs_product_v1" "product2" {
+  spec_code = "redis.cluster.xu1.large.r1.8"
 }
 ```
 
 ## Argument Reference
 
-* `engine` - (Required) Indicates the name of a message engine.
+* `engine` - (Optional, String) The engine of the cache instance. Valid values are *redis* and *memcached*.
+  Default value is *redis*.
 
-* `version` - (Optional) Indicates the version of a message engine.
+* `engine_version` - (Optional, String) The version of a cache engine.
+  It is valid when the engine is *redis*, the value can be `3.0`or `4.0;5.0`.
 
-* `instance_type` - (Required) Indicates an instance type. Options: "single" and "cluster"
+* `spec_code` - (Optional, String) Specifies the DCS instance specification code. You can log in to the DCS console,
+  click *Buy DCS Instance*, and find the corresponding instance specification.
 
-* `vm_specification` - (Optional) Indicates VM specifications.
-
-* `storage` - (Optional) Indicates the message storage space.
-
-* `bandwidth` - (Optional) Indicates the baseline bandwidth of a Kafka instance.
-
-* `partition_num` - (Optional) Indicates the maximum number of topics that can be created for a Kafka instance.
-
-* `storage_spec_code` - (Optional) Indicates an I/O specification.
-
-* `io_type` - (Optional) Indicates an I/O type.
-
-* `node_num` - (Optional) Indicates the number of nodes in a cluster.
+* `cache_mode` - (Optional, String) The mode of a cache engine. The valid values are as follows:
+  + `single` - Single-node.
+  + `ha` - Master/Standby.
+  + `cluster` - Redis Cluster.
+  + `proxy` - Proxy Cluster.
 
 
 ## Attributes Reference
@@ -49,11 +42,6 @@ data "flexibleengine_dcs_product_v1" "product1" {
 are exported:
 
 * `engine` - See Argument Reference above.
-* `version` - See Argument Reference above.
-* `instance_type` - See Argument Reference above.
-* `vm_specification` - See Argument Reference above.
-* `bandwidth` - See Argument Reference above.
-* `partition_num` - See Argument Reference above.
-* `storage_spec_code` - See Argument Reference above.
-* `io_type` - See Argument Reference above.
-* `node_num` - See Argument Reference above.
+* `engine_version` - See Argument Reference above.
+* `spec_code` - See Argument Reference above.
+* `cache_mode` - See Argument Reference above.

--- a/flexibleengine/data_source_flexibleengine_dcs_az_v1.go
+++ b/flexibleengine/data_source_flexibleengine_dcs_az_v1.go
@@ -11,6 +11,8 @@ import (
 func dataSourceDcsAZV1() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceDcsAZV1Read,
+		DeprecationMessage: "this data source is deprecated. " +
+			"You can use the availability zone code directly, e.g. eu-west-0b.",
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/flexibleengine/data_source_flexibleengine_dcs_maintainwindow_v1_test.go
+++ b/flexibleengine/data_source_flexibleengine_dcs_maintainwindow_v1_test.go
@@ -44,6 +44,6 @@ func testAccCheckDcsMaintainWindowV1DataSourceID(n string) resource.TestCheckFun
 
 var testAccDcsMaintainWindowV1DataSource_basic = fmt.Sprintf(`
 data "flexibleengine_dcs_maintainwindow_v1" "maintainwindow1" {
-seq = 1
+  seq = 1
 }
 `)

--- a/flexibleengine/data_source_flexibleengine_dcs_product_v1.go
+++ b/flexibleengine/data_source_flexibleengine_dcs_product_v1.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/chnsz/golangsdk/openstack/dcs/v1/products"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	hw_utils "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 func dataSourceDcsProductV1() *schema.Resource {
@@ -14,6 +16,23 @@ func dataSourceDcsProductV1() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"spec_code": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"engine": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "redis",
+				ValidateFunc: validation.StringInSlice([]string{
+					"redis", "memcached",
+				}, false),
+			},
+			"engine_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"cache_mode": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -33,24 +52,30 @@ func dataSourceDcsProductV1Read(d *schema.ResourceData, meta interface{}) error 
 	if err != nil {
 		return err
 	}
-	log.Printf("[DEBUG] Dcs get products : %+v", v)
-	var FilteredPd []products.Product
-	for _, pd := range v.Products {
-		spec_code := d.Get("spec_code").(string)
-		if spec_code != "" && pd.SpecCode != spec_code {
-			continue
-		}
-		FilteredPd = append(FilteredPd, pd)
+	log.Printf("[DEBUG] get %d DCS products", len(v.Products))
+
+	filteredPds, err := hw_utils.FilterSliceWithField(v.Products, map[string]interface{}{
+		"SpecCode":      d.Get("spec_code").(string),
+		"Engine":        d.Get("engine").(string),
+		"EngineVersion": d.Get("engine_version").(string),
+		"CacheMode":     d.Get("cache_mode").(string),
+	})
+	if err != nil {
+		return fmt.Errorf("Error while filtering data : %s", err)
 	}
 
-	if len(FilteredPd) < 1 {
-		return fmt.Errorf("Your query returned no results. Please change your filters and try again.")
+	if len(filteredPds) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your filters and try again")
 	}
 
-	pd := FilteredPd[0]
+	pd := filteredPds[0].(products.Product)
+	log.Printf("[DEBUG] DCS product : %+v", pd)
+
 	d.SetId(pd.ProductID)
 	d.Set("spec_code", pd.SpecCode)
-	log.Printf("[DEBUG] Dcs product : %+v", pd)
+	d.Set("engine", pd.Engine)
+	d.Set("engine_version", pd.EngineVersion)
+	d.Set("cache_mode", pd.CacheMode)
 
 	return nil
 }

--- a/flexibleengine/data_source_flexibleengine_dcs_product_v1_test.go
+++ b/flexibleengine/data_source_flexibleengine_dcs_product_v1_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAccDcsProductV1DataSource_basic(t *testing.T) {
+	dataSourceName := "data.flexibleengine_dcs_product_v1.product1"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -16,9 +18,8 @@ func TestAccDcsProductV1DataSource_basic(t *testing.T) {
 			{
 				Config: testAccDcsProductV1DataSource_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDcsProductV1DataSourceID("data.flexibleengine_dcs_product_v1.product1"),
-					resource.TestCheckResourceAttr(
-						"data.flexibleengine_dcs_product_v1.product1", "spec_code", "dcs.single_node"),
+					testAccCheckDcsProductV1DataSourceID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "spec_code", "dcs.single_node"),
 				),
 			},
 		},
@@ -42,6 +43,6 @@ func testAccCheckDcsProductV1DataSourceID(n string) resource.TestCheckFunc {
 
 var testAccDcsProductV1DataSource_basic = fmt.Sprintf(`
 data "flexibleengine_dcs_product_v1" "product1" {
-spec_code = "dcs.single_node"
+  spec_code = "dcs.single_node"
 }
 `)

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -214,7 +214,6 @@ func Provider() *schema.Provider {
 			"flexibleengine_vbs_backup_policy_v2":               dataSourceVBSBackupPolicyV2(),
 			"flexibleengine_vbs_backup_v2":                      dataSourceVBSBackupV2(),
 			"flexibleengine_cts_tracker_v1":                     dataSourceCTSTrackerV1(),
-			"flexibleengine_dcs_az_v1":                          dataSourceDcsAZV1(),
 			"flexibleengine_dcs_maintainwindow_v1":              dataSourceDcsMaintainWindowV1(),
 			"flexibleengine_dcs_product_v1":                     dataSourceDcsProductV1(),
 			"flexibleengine_cce_node_v3":                        dataSourceCceNodesV3(),
@@ -233,6 +232,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_vpcep_endpoints":                    dataSourceVPCEPEndpoints(),
 
 			// Deprecated data source
+			"flexibleengine_dcs_az_v1":      dataSourceDcsAZV1(),
 			"flexibleengine_dds_flavor_v3":  dataSourceDDSFlavorV3(),
 			"flexibleengine_rds_flavors_v1": dataSourceRdsFlavorV1(),
 		},

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,12 @@ go 1.14
 
 require (
 	github.com/aws/aws-sdk-go v1.25.3
-	github.com/chnsz/golangsdk v0.0.0-20211019093707-47c835c53b0e
+	github.com/chnsz/golangsdk v0.0.0-20211129061956-055d0ed2e3f8
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
-	github.com/huaweicloud/terraform-provider-huaweicloud v1.28.1
+	github.com/huaweicloud/terraform-provider-huaweicloud v1.31.0
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/chnsz/golangsdk v0.0.0-20210910073247-d53db78c6984 h1:fmhHRkpEwQQ0YiJ
 github.com/chnsz/golangsdk v0.0.0-20210910073247-d53db78c6984/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chnsz/golangsdk v0.0.0-20211019093707-47c835c53b0e h1:Rhy/5nOHqwRDUy5SsquUPIPfFrY9vDOynuu5W938P7w=
 github.com/chnsz/golangsdk v0.0.0-20211019093707-47c835c53b0e/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20211129061956-055d0ed2e3f8 h1:NeMqYMGL6S6oaBZMQdJm/hCZfvfaYplJ2RItLRq1Qec=
+github.com/chnsz/golangsdk v0.0.0-20211129061956-055d0ed2e3f8/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -224,6 +226,8 @@ github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.28.1 h1:f81kcxwLs4pjbtgEcKe49KMYfsBJhemCIxhk0zqggkM=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.28.1/go.mod h1:Ofk7+YCQkKVH+AUELqNHPmouTh2UPzhNbaQMyc+DG1I=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.31.0 h1:ojdPzQunq4l86dADA4s3/I8gsArfAH1HDl6eJ8RCeSI=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.31.0/go.mod h1:38XygHPvTdGcklj9f3oKXOw8Q+Q1eqSCf4y3cz9jzJo=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/queues/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/queues/requests.go
@@ -17,7 +17,7 @@ type CreateOpts struct {
 	// all
 	// NOTE:
 	// If the type is not specified, the default value sql is used.
-	QueueType string `json:"queue_type ,omitempty"`
+	QueueType string `json:"queue_type,omitempty"`
 
 	// Description of a queue.
 	Description string `json:"description,omitempty"`

--- a/vendor/github.com/chnsz/golangsdk/openstack/kms/v1/keys/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/kms/v1/keys/requests.go
@@ -14,6 +14,8 @@ type CreateOpts struct {
 	Realm string `json:"realm,omitempty"`
 	// Purpose of a CMK (The default value is Encrypt_Decrypt)
 	KeyUsage string `json:"key_usage,omitempty"`
+	// Key Algorithm
+	KeySpec string `json:"key_spec,omitempty"`
 	// Enterprise project id
 	EnterpriseProjectID string `json:"enterprise_project_id,omitempty"`
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/kms/v1/keys/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/kms/v1/keys/results.go
@@ -17,6 +17,8 @@ type Key struct {
 	DomainID string `json:"domain_id"`
 	// Alias of a CMK
 	KeyAlias string `json:"key_alias"`
+	// Key algorithm
+	KeySpec string `json:"key_spec"`
 	// Region where a CMK resides
 	Realm string `json:"realm"`
 	// Description of a CMK

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/vpcs/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/vpcs/requests.go
@@ -115,6 +115,7 @@ type CreateOptsBuilder interface {
 type CreateOpts struct {
 	Name                string `json:"name,omitempty"`
 	CIDR                string `json:"cidr,omitempty"`
+	Description         string `json:"description,omitempty"`
 	EnterpriseProjectID string `json:"enterprise_project_id,omitempty"`
 }
 
@@ -156,9 +157,10 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts contains the values used when updating a vpc.
 type UpdateOpts struct {
-	CIDR             string `json:"cidr,omitempty"`
-	Name             string `json:"name,omitempty"`
-	EnableSharedSnat *bool  `json:"enable_shared_snat,omitempty"`
+	Name             string  `json:"name,omitempty"`
+	CIDR             string  `json:"cidr,omitempty"`
+	Description      *string `json:"description,omitempty"`
+	EnableSharedSnat *bool   `json:"enable_shared_snat,omitempty"`
 }
 
 // ToVpcUpdateMap builds an update body based on UpdateOpts.

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/vpcs/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/vpcs/results.go
@@ -27,6 +27,9 @@ type Vpc struct {
 	// unique.
 	Name string `json:"name"`
 
+	// Description provides supplementary information about the VPC
+	Description string `json:"description"`
+
 	//Specifies the range of available subnets in the VPC.
 	CIDR string `json:"cidr"`
 

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/requests.go
@@ -424,3 +424,14 @@ func GetRDSJob(client *golangsdk.ServiceClient, opts RDSJobBuilder) (r RDSJobRes
 	})
 	return
 }
+
+func ListEngine(client *golangsdk.ServiceClient, dbName string) (*Engine, error) {
+	var rst golangsdk.Result
+	_, err := client.Get(engineURL(client, dbName), &rst.Body, nil)
+	if err == nil {
+		var s Engine
+		err := rst.ExtractInto(&s)
+		return &s, err
+	}
+	return nil, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/results.go
@@ -291,3 +291,12 @@ func (r RDSJobResult) Extract() (ListJob, error) {
 	err := r.ExtractInto(&s)
 	return s, err
 }
+
+type Engine struct {
+	Versions []VersionInfo `json:"dataStores"`
+}
+
+type VersionInfo struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/rds/v3/instances/urls.go
@@ -21,3 +21,7 @@ func updateURL(c *golangsdk.ServiceClient, instancesId string, updata string) st
 func jobURL(c *golangsdk.ServiceClient) string {
 	return c.ServiceURL("jobs")
 }
+
+func engineURL(c *golangsdk.ServiceClient, dbName string) string {
+	return c.ServiceURL("datastores", dbName)
+}

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config/endpoints.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config/endpoints.go
@@ -78,6 +78,11 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Version:          "v2",
 		WithOutProjectID: true,
 	},
+	"ccev1": {
+		Name:             "cce",
+		Version:          "api/v1",
+		WithOutProjectID: true,
+	},
 	"cce": {
 		Name:    "cce",
 		Version: "api/v3/projects",
@@ -164,11 +169,6 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Name:    "nat",
 		Version: "v2",
 	},
-	"elb": {
-		Name:             "elb",
-		Version:          "v1.0",
-		WithOutProjectID: true,
-	},
 	"elbv2": {
 		Name:             "elb",
 		Version:          "v2.0",
@@ -178,7 +178,7 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Name:    "elb",
 		Version: "v3",
 	},
-	"loadbalancer": {
+	"elb": {
 		Name:    "elb",
 		Version: "v2",
 	},
@@ -219,6 +219,10 @@ var allServiceCatalog = map[string]ServiceCatalog{
 	"geminidb": {
 		Name:    "gaussdb-nosql",
 		Version: "v3",
+	},
+	"geminidbv31": {
+		Name:    "gaussdb-nosql",
+		Version: "v3.1",
 	},
 	"gaussdb": {
 		Name:    "gaussdb",
@@ -282,13 +286,25 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Name:    "dws",
 		Version: "v1.0",
 	},
+	"dwsV2": {
+		Name:    "dws",
+		Version: "v2",
+	},
 	"dli": {
 		Name:    "dli",
 		Version: "v1.0",
 	},
+	"dliv2": {
+		Name:    "dli",
+		Version: "v2.0",
+	},
 	"disv2": {
 		Name:    "dis",
 		Version: "v2",
+	},
+	"disv3": {
+		Name:    "dis",
+		Version: "v3",
 	},
 	"css": {
 		Name:    "css",

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/build_param_util.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/build_param_util.go
@@ -1,0 +1,304 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+type funcSkipOpt func(optn string, jsonTags []string, tag reflect.StructTag) bool
+
+type exchangeParam struct {
+	OptNameMap *map[string]string
+	SkipOpt    funcSkipOpt
+}
+
+func (e *exchangeParam) toSchemaOptName(name string) string {
+	if e.OptNameMap != nil {
+		if n, ok := (*e.OptNameMap)[name]; ok {
+			return n
+		}
+	}
+	return strings.ToLower(name)
+}
+
+func (e *exchangeParam) BuildCUParam(opts interface{}, d *schema.ResourceData) ([]string, error) {
+	var skippedFields []string
+
+	optsValue := reflect.ValueOf(opts)
+	if optsValue.Kind() != reflect.Ptr {
+		return skippedFields, fmt.Errorf("parameter of opts should be a pointer")
+	}
+	optsValue = optsValue.Elem()
+	if optsValue.Kind() != reflect.Struct {
+		return skippedFields, fmt.Errorf("parameter must be a pointer to a struct")
+	}
+
+	optsType := reflect.TypeOf(opts)
+	optsType = optsType.Elem()
+	value := make(map[string]interface{})
+
+	for i := 0; i < optsValue.NumField(); i++ {
+		v := optsValue.Field(i)
+		f := optsType.Field(i)
+		tag := getParamTag("json", f.Tag)
+		if tag == "" {
+			return skippedFields, fmt.Errorf("can not convert for item %v: without of json tag", v)
+		}
+		tags := strings.Split(tag, ",")
+		fieldn := tags[0]
+		optn := e.toSchemaOptName(fieldn)
+
+		// Only check the parameters in top struct.
+		// If the parameters in sub-struct need skip, it will miss.
+		// If it happens, need refactor here.
+		if e.SkipOpt(optn, tags, f.Tag) {
+			skippedFields = append(skippedFields, fieldn)
+			continue
+		}
+		optv := d.Get(optn)
+		if optv == nil {
+			log.Printf("[DEBUG] opt:%s is not set", optn)
+			continue
+		}
+		value[optn] = optv
+	}
+	if len(value) == 0 {
+		log.Printf("[WARN]no parameter was set")
+		return skippedFields, nil
+	}
+	return skippedFields, e.buildStruct(&optsValue, optsType, value)
+}
+
+func (e *exchangeParam) buildStruct(optsValue *reflect.Value, optsType reflect.Type, value map[string]interface{}) error {
+	log.Printf("[DEBUG] buildStruct:: optsValue=%v, optsType=%v, value=%#v\n", optsValue, optsType, value)
+
+	for i := 0; i < optsValue.NumField(); i++ {
+		v := optsValue.Field(i)
+		f := optsType.Field(i)
+		tag := f.Tag.Get("json")
+		if tag == "" {
+			return fmt.Errorf("can not convert for item %v: without of json tag", v)
+		}
+		fieldn := strings.Split(tag, ",")[0]
+		optn := e.toSchemaOptName(fieldn)
+		log.Printf("[DEBUG] buildStruct:: convert for opt:%s", optn)
+
+		optv, ok := value[optn]
+		if !ok {
+			log.Printf("[DEBUG] field:%s was not supplied", fieldn)
+			continue
+		}
+
+		switch v.Kind() {
+		case reflect.String:
+			v.SetString(optv.(string))
+		case reflect.Int:
+			v.SetInt(int64(optv.(int)))
+		case reflect.Int64:
+			v.SetInt(optv.(int64))
+		case reflect.Bool:
+			v.SetBool(optv.(bool))
+		case reflect.Slice:
+			s := optv.([]interface{})
+
+			switch v.Type().Elem().Kind() {
+			case reflect.String:
+				t := make([]string, len(s))
+				for i, iv := range s {
+					t[i] = iv.(string)
+				}
+				v.Set(reflect.ValueOf(t))
+			case reflect.Struct:
+				t := reflect.MakeSlice(f.Type, len(s), len(s))
+				for i, iv := range s {
+					rv := t.Index(i)
+					err := e.buildStruct(&rv, f.Type.Elem(), iv.(map[string]interface{}))
+					if err != nil {
+						return err
+					}
+				}
+				v.Set(t)
+
+			default:
+				return fmt.Errorf("unknown type of item %v: %v", v, v.Type().Elem().Kind())
+			}
+		case reflect.Struct:
+			log.Printf("[DEBUG] buildStruct:: convert struct for opt:%s, value:%#v", optn, optv)
+			var p map[string]interface{}
+			ok := true
+
+			// If the type of parameter is Struct, then the corresponding type in Schema is TypeList
+			if v0, ok0 := optv.([]interface{}); ok0 {
+				p, ok = v0[0].(map[string]interface{})
+			} else {
+				p, ok = optv.(map[string]interface{})
+			}
+			if !ok {
+				return fmt.Errorf("can not convert to (map[string]interface{}) for opt:%s, value:%#v", optn, optv)
+			}
+
+			err := e.buildStruct(&v, f.Type, p)
+			if err != nil {
+				return err
+			}
+
+		default:
+			return fmt.Errorf("unknown type of item %v: %v", v, v.Kind())
+		}
+	}
+	return nil
+}
+
+func (e *exchangeParam) BuildResourceData(resp interface{}, d *schema.ResourceData) error {
+	value, err := e.convertToMap(resp)
+	if err != nil {
+		return err
+	}
+
+	optsValue := reflect.ValueOf(resp)
+	if optsValue.Kind() == reflect.Ptr {
+		optsValue = optsValue.Elem()
+	}
+
+	optsType := reflect.TypeOf(resp)
+	if optsType.Kind() == reflect.Ptr {
+		optsType = optsType.Elem()
+	}
+
+	for i := 0; i < optsValue.NumField(); i++ {
+		v := optsValue.Field(i)
+		f := optsType.Field(i)
+		tag := f.Tag.Get("json")
+		if tag == "" {
+			return fmt.Errorf("can not convert for item %v: without of json tag", v)
+		}
+		fieldn := strings.Split(tag, ",")[0]
+		optn := e.toSchemaOptName(fieldn)
+		if optn == "id" {
+			continue
+		}
+		optv := value[optn]
+		log.Printf("[DEBUG BuildResourceData: set for opt:%s, value:%#v", optn, optv)
+
+		switch v.Kind() {
+		default:
+			err := d.Set(optn, optv) //lintignore:R001
+			if err != nil {
+				return err
+			}
+		case reflect.Struct:
+			//The corresponding schema of Struct is TypeList in Terrafrom
+			err := d.Set(optn, []interface{}{optv}) //lintignore:R001
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (e *exchangeParam) convertToMap(resp interface{}) (map[string]interface{}, error) {
+	b, err := json.Marshal(resp)
+	if err != nil {
+		return nil, fmt.Errorf("refreshResourceData:: marshal failed:%v", err)
+	}
+
+	m := regexp.MustCompile(`"[a-z0-9A-Z_]+":`)
+	nb := m.ReplaceAllFunc(
+		b,
+		func(src []byte) []byte {
+			k := fmt.Sprintf("%s", src[1:len(src)-2])
+			return []byte(fmt.Sprintf("\"%s\":", e.toSchemaOptName(k)))
+		},
+	)
+	log.Printf("[DEBUG]befor change b =%s, b=%#v", b, b)
+	log.Printf("[DEBUG] after change nb=%s, nb=%#v", nb, nb)
+
+	p := make(map[string]interface{})
+	err = json.Unmarshal(nb, &p)
+	if err != nil {
+		return nil, fmt.Errorf("refreshResourceData:: unmarshal failed:%v", err)
+	}
+	log.Printf("[DEBUG]refreshResourceData:: raw data = %#v\n", p)
+	return p, nil
+}
+
+func getParamTag(key string, tag reflect.StructTag) string {
+	if v, ok := tag.Lookup(key); ok {
+		return v
+	}
+	return "tag_not_set"
+}
+
+func hasFilledOpt(d *schema.ResourceData, param string) bool {
+	_, b := d.GetOk(param)
+	return b
+}
+
+func BuildCreateParam(opts interface{}, d *schema.ResourceData, nameMap *map[string]string) ([]string, error) {
+	var f funcSkipOpt
+
+	f = func(optn string, jsonTags []string, tag reflect.StructTag) bool {
+		if getParamTag("required", tag) == "true" {
+			return false
+		}
+
+		// For Create operation, it should not pass the parameter in the request, which match all the following situations.
+		// a. Parameter is optional, which means it is not set 'required' in the tag.
+		// b. Parameter's default value is allowed, which menas it is not set 'omitempty' in the tag of 'json'. The default value is like this, '0' for int and 'false' for bool
+		// c. Parameter is not set default value in schema. It did not find a way to check whether it was set default value in the schema. so, add a new tag of "no_default" to mark it.
+		// d. User did not set that parameter in the configuration file, which means the return value of 'hasFilledOpt' is false.
+		if (len(jsonTags) == 1 || jsonTags[1] == "-") && getParamTag("no_default", tag) == "y" && !hasFilledOpt(d, optn) {
+			return true
+		}
+
+		return false
+	}
+
+	e := &exchangeParam{
+		OptNameMap: nameMap,
+		SkipOpt:    f,
+	}
+	return e.BuildCUParam(opts, d)
+}
+
+func BuildUpdateParam(opts interface{}, d *schema.ResourceData, nameMap *map[string]string) ([]string, error) {
+	hasUpdatedItems := false
+
+	var f funcSkipOpt
+	f = func(optn string, jsonTags []string, tag reflect.StructTag) bool {
+		v := d.HasChange(optn)
+		if !hasUpdatedItems && v {
+			hasUpdatedItems = true
+		}
+
+		// filter the unchanged parameters
+		return !v
+	}
+
+	e := &exchangeParam{
+		OptNameMap: nameMap,
+		SkipOpt:    f,
+	}
+	notPassFileds, err := e.BuildCUParam(opts, d)
+	if err != nil {
+		return notPassFileds, err
+	}
+	if !hasUpdatedItems {
+		return notPassFileds, fmt.Errorf("no changes happened")
+	}
+	return notPassFileds, nil
+}
+
+func RefreshResourceData(resource interface{}, d *schema.ResourceData, nameMap *map[string]string) error {
+	e := &exchangeParam{
+		OptNameMap: nameMap,
+	}
+	return e.BuildResourceData(resource, d)
+}

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/diff_suppress_funcs.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/diff_suppress_funcs.go
@@ -1,0 +1,114 @@
+package utils
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	awspolicy "github.com/jen20/awspolicyequivalence"
+)
+
+func SuppressEquivalentAwsPolicyDiffs(k, old, new string, d *schema.ResourceData) bool {
+	equivalent, err := awspolicy.PoliciesAreEquivalent(old, new)
+	if err != nil {
+		return false
+	}
+
+	return equivalent
+}
+
+// Suppress all changes
+func SuppressDiffAll(k, old, new string, d *schema.ResourceData) bool {
+	return true
+}
+
+// Suppress changes if we get a string with or without cases
+func SuppressCaseDiffs(k, old, new string, d *schema.ResourceData) bool {
+	return strings.ToLower(old) == strings.ToLower(new)
+}
+
+// Suppress changes if we get a computed min_disk_gb if value is unspecified (default 0)
+func SuppressMinDisk(k, old, new string, d *schema.ResourceData) bool {
+	return new == "0" || old == new
+}
+
+// Suppress changes if we get a fixed ip when not expecting one, if we have a floating ip (generates fixed ip).
+func SuppressComputedFixedWhenFloatingIp(k, old, new string, d *schema.ResourceData) bool {
+	if v, ok := d.GetOk("floating_ip"); ok && v != "" {
+		return new == "" || old == new
+	}
+	return false
+}
+
+func SuppressLBWhitelistDiffs(k, old, new string, d *schema.ResourceData) bool {
+	if len(old) != len(new) {
+		return false
+	}
+	old_array := strings.Split(old, ",")
+	new_array := strings.Split(new, ",")
+	sort.Strings(old_array)
+	sort.Strings(new_array)
+
+	return reflect.DeepEqual(old_array, new_array)
+}
+
+func SuppressSnatFiplistDiffs(k, old, new string, d *schema.ResourceData) bool {
+	if len(old) != len(new) {
+		return false
+	}
+	old_array := strings.Split(old, ",")
+	new_array := strings.Split(new, ",")
+	sort.Strings(old_array)
+	sort.Strings(new_array)
+
+	return reflect.DeepEqual(old_array, new_array)
+}
+
+// Suppress changes if we get a string with or without new line
+func SuppressNewLineDiffs(k, old, new string, d *schema.ResourceData) bool {
+	return strings.Trim(old, "\n") == strings.Trim(new, "\n")
+}
+
+func SuppressEquivilentTimeDiffs(k, old, new string, d *schema.ResourceData) bool {
+	oldTime, err := time.Parse(time.RFC3339, old)
+	if err != nil {
+		return false
+	}
+
+	newTime, err := time.Parse(time.RFC3339, new)
+	if err != nil {
+		return false
+	}
+
+	return oldTime.Equal(newTime)
+}
+
+func CompareJsonTemplateAreEquivalent(tem1, tem2 string) (bool, error) {
+	var obj1 interface{}
+	err := json.Unmarshal([]byte(tem1), &obj1)
+	if err != nil {
+		return false, err
+	}
+
+	canonicalJson1, _ := json.Marshal(obj1)
+
+	var obj2 interface{}
+	err = json.Unmarshal([]byte(tem2), &obj2)
+	if err != nil {
+		return false, err
+	}
+
+	canonicalJson2, _ := json.Marshal(obj2)
+
+	equal := bytes.Compare(canonicalJson1, canonicalJson2) == 0
+	if !equal {
+		log.Printf("[DEBUG] Canonical template are not equal.\nFirst: %s\nSecond: %s\n",
+			canonicalJson1, canonicalJson2)
+	}
+	return equal, nil
+}

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/filter.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/filter.go
@@ -1,0 +1,104 @@
+package utils
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"strings"
+)
+
+const (
+	matchRuleByNumLt = -1 // number value match by : less than
+	matchRuleByNumEq = 0  // number value match by : equal to
+	matchRuleByNumGt = 1  // number value match by : greater than
+)
+
+// FilterSliceWithField can filter the slice all through a map filter.
+// If the field is a nested value, using dot(.) to split them, e.g. "SubBlock.SubField".
+// If value in the map is zero, it will be ignored.
+func FilterSliceWithField(all interface{}, filter map[string]interface{}) ([]interface{}, error) {
+	return filterSliceWithFieldRaw(all, filter, true)
+}
+
+// FilterSliceWithZeroField can filter the slice all through a map filter.
+func FilterSliceWithZeroField(all interface{}, filter map[string]interface{}) ([]interface{}, error) {
+	return filterSliceWithFieldRaw(all, filter, false)
+}
+
+func filterSliceWithFieldRaw(all interface{}, filter map[string]interface{}, ignoreZero bool) ([]interface{}, error) {
+	var result []interface{}
+	var matched bool
+
+	allValue := reflect.ValueOf(all)
+	if allValue.Kind() != reflect.Slice {
+		return nil, fmt.Errorf("options type is not a slice")
+	}
+
+	newFilter := filter
+	if ignoreZero {
+		for key, val := range filter {
+			keyValue := reflect.ValueOf(val)
+			if keyValue.IsZero() {
+				log.Printf("[DEBUG] ignore zero field %s", key)
+				delete(newFilter, key)
+			}
+		}
+	}
+
+	for i := 0; i < allValue.Len(); i++ {
+		refValue := allValue.Index(i)
+		if refValue.Kind() == reflect.Ptr {
+			refValue = refValue.Elem()
+		}
+		if refValue.Kind() != reflect.Struct {
+			return nil, fmt.Errorf("object in slice is not a struct")
+		}
+
+		matched = true
+		for key, val := range newFilter {
+			actual, err := getStructField(refValue, key)
+			if err != nil {
+				return nil, fmt.Errorf("get slice field %s failed: %s", key, err)
+			}
+
+			if actual != val {
+				log.Printf("[DEBUG] can not match slice[%d] field %s: expect %v, but got %v", i, key, val, actual)
+				matched = false
+				break
+			}
+		}
+
+		if matched {
+			result = append(result, refValue.Interface())
+		}
+	}
+	return result, nil
+}
+
+func getStructField(v reflect.Value, field string) (interface{}, error) {
+	var subField interface{}
+	var err error
+	structValue := v
+
+	parts := strings.Split(field, ".")
+	for _, key := range parts {
+		subField, err = getStructFieldRaw(structValue, key)
+		if err != nil {
+			return nil, err
+		}
+		structValue = reflect.ValueOf(subField)
+	}
+	return subField, nil
+}
+
+func getStructFieldRaw(v reflect.Value, field string) (interface{}, error) {
+	if v.Kind() == reflect.Struct {
+		value := reflect.Indirect(v).FieldByName(field)
+		if value.IsValid() {
+			return value.Interface(), nil
+		}
+
+		return nil, fmt.Errorf("reflect: can not find the field %s", field)
+	}
+	return nil, fmt.Errorf("reflect: Value is not a struct")
+}

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/formatByConfig.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/formatByConfig.go
@@ -1,0 +1,17 @@
+package utils
+
+import "regexp"
+
+const REPLACE_REG = "(?i)huaweicloud"
+
+var PackageName string
+
+var re = regexp.MustCompile(REPLACE_REG)
+
+func BuildNewFormatByConfig(format string) string {
+	newFormat := format
+	if PackageName != "" {
+		newFormat = re.ReplaceAllString(format, PackageName)
+	}
+	return newFormat
+}

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/tags.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/tags.go
@@ -1,0 +1,102 @@
+package utils
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// UpdateResourceTags is a helper to update the tags for a resource.
+// It expects the tags field to be named "tags"
+func UpdateResourceTags(conn *golangsdk.ServiceClient, d *schema.ResourceData, resourceType, id string) error {
+	if d.HasChange("tags") {
+		oRaw, nRaw := d.GetChange("tags")
+		oMap := oRaw.(map[string]interface{})
+		nMap := nRaw.(map[string]interface{})
+
+		// remove old tags
+		if len(oMap) > 0 {
+			taglist := ExpandResourceTags(oMap)
+			err := tags.Delete(conn, resourceType, id, taglist).ExtractErr()
+			if err != nil {
+				return err
+			}
+		}
+
+		// set new tags
+		if len(nMap) > 0 {
+			taglist := ExpandResourceTags(nMap)
+			err := tags.Create(conn, resourceType, id, taglist).ExtractErr()
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+//This is a help to query tags of resource, then set to state. The schema argument name must be: tags
+func SetResourceTagsToState(d *schema.ResourceData, client *golangsdk.ServiceClient, resourceType string) error {
+	// set tags
+	if resourceTags, err := tags.Get(client, resourceType, d.Id()).Extract(); err == nil {
+		tagmap := TagsToMap(resourceTags.Tags)
+		if err := d.Set("tags", tagmap); err != nil {
+			return fmt.Errorf("error saving tags to state for CSS cluster (%s): %s", d.Id(), err)
+		}
+	} else {
+		log.Printf("[WARN] Error fetching tags of CSS cluster (%s): %s", d.Id(), err)
+	}
+	return nil
+}
+
+// TagsToMap returns the list of tags into a map.
+func TagsToMap(tags []tags.ResourceTag) map[string]string {
+	result := make(map[string]string)
+	for _, val := range tags {
+		result[val.Key] = val.Value
+	}
+
+	// ignore system tags to keep the tags consistent with what the user set
+	delete(result, "CCE-Dynamic-Provisioning-Node")
+
+	return result
+}
+
+// ExpandResourceTags returns the tags for the given map of data.
+func ExpandResourceTags(tagmap map[string]interface{}) []tags.ResourceTag {
+	var taglist []tags.ResourceTag
+
+	for k, v := range tagmap {
+		tag := tags.ResourceTag{
+			Key:   k,
+			Value: v.(string),
+		}
+		taglist = append(taglist, tag)
+	}
+
+	return taglist
+}
+
+// GetDNSZoneTagType returns resource tag type of DNS zone by zoneType
+func GetDNSZoneTagType(zoneType string) (string, error) {
+	if zoneType == "public" {
+		return "DNS-public_zone", nil
+	} else if zoneType == "private" {
+		return "DNS-private_zone", nil
+	}
+	return "", fmt.Errorf("invalid zone type: %s", zoneType)
+}
+
+// GetDNSRecordSetTagType returns resource tag type of DNS record set by zoneType
+func GetDNSRecordSetTagType(zoneType string) (string, error) {
+	if zoneType == "public" {
+		return "DNS-public_recordset", nil
+	} else if zoneType == "private" {
+		return "DNS-private_recordset", nil
+	}
+	return "", fmt.Errorf("invalid zone type: %s", zoneType)
+}

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/type_convert.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/type_convert.go
@@ -1,0 +1,6 @@
+package utils
+
+// returns a pointer to the bool value
+func Bool(v bool) *bool {
+	return &v
+}

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/utils.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/utils.go
@@ -1,0 +1,261 @@
+package utils
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/rts/v1/stacks"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"gopkg.in/yaml.v2"
+)
+
+// ConvertStructToMap converts an instance of struct to a map object, and
+// changes each key of fileds to the value of 'nameMap' if the key in it
+// or to its corresponding lowercase.
+func ConvertStructToMap(obj interface{}, nameMap map[string]string) (map[string]interface{}, error) {
+	b, err := json.Marshal(obj)
+	if err != nil {
+		return nil, fmt.Errorf("Error converting struct to map, marshal failed:%v", err)
+	}
+
+	m, err := regexp.Compile(`"[a-z0-9A-Z_]+":`)
+	if err != nil {
+		return nil, fmt.Errorf("Error converting struct to map, compile regular express failed")
+	}
+	nb := m.ReplaceAllFunc(
+		b,
+		func(src []byte) []byte {
+			k := fmt.Sprintf("%s", src[1:len(src)-2])
+			v, ok := nameMap[k]
+			if !ok {
+				v = strings.ToLower(k)
+			}
+			return []byte(fmt.Sprintf("\"%s\":", v))
+		},
+	)
+	log.Printf("[DEBUG]convertStructToMap:: before change b =%s", b)
+	log.Printf("[DEBUG]convertStructToMap:: after change nb=%s", nb)
+
+	p := make(map[string]interface{})
+	err = json.Unmarshal(nb, &p)
+	if err != nil {
+		return nil, fmt.Errorf("Error converting struct to map, unmarshal failed:%v", err)
+	}
+	log.Printf("[DEBUG]convertStructToMap:: map= %#v\n", p)
+	return p, nil
+}
+
+// ExpandToStringList takes the result for an array of strings and returns a []string
+func ExpandToStringList(v []interface{}) []string {
+	s := make([]string, 0, len(v))
+	for _, val := range v {
+		if strVal, ok := val.(string); ok && strVal != "" {
+			s = append(s, strVal)
+		}
+	}
+
+	return s
+}
+
+// ExpandToIntList takes the result for an array of intgers and returns a []int
+func ExpandToIntList(v []interface{}) []int {
+	s := make([]int, 0, len(v))
+	for _, val := range v {
+		if intVal, ok := val.(int); ok {
+			s = append(s, intVal)
+		}
+	}
+	return s
+}
+
+// ExpandToStringListBySet takes the result for a set of strings and returns a []string
+func ExpandToStringListBySet(v *schema.Set) []string {
+	s := make([]string, 0, v.Len())
+	for _, val := range v.List() {
+		if strVal, ok := val.(string); ok && strVal != "" {
+			s = append(s, strVal)
+		}
+	}
+
+	return s
+}
+
+// Takes list of pointers to strings. Expand to an array
+// of raw strings and returns a []interface{}
+func flattenToStringList(list []*string) []interface{} {
+	vs := make([]interface{}, 0, len(list))
+	for _, v := range list {
+		vs = append(vs, *v)
+	}
+	return vs
+}
+
+func pointersMapToStringList(pointers map[string]*string) map[string]interface{} {
+	list := make(map[string]interface{}, len(pointers))
+	for i, v := range pointers {
+		list[i] = *v
+	}
+	return list
+}
+
+// Takes a value containing JSON string and passes it through
+// the JSON parser to normalize it, returns either a parsing
+// error or normalized JSON string.
+func NormalizeJsonString(jsonString interface{}) (string, error) {
+	var j interface{}
+
+	if jsonString == nil || jsonString.(string) == "" {
+		return "", nil
+	}
+
+	s := jsonString.(string)
+
+	err := json.Unmarshal([]byte(s), &j)
+	if err != nil {
+		return s, err
+	}
+
+	// The error is intentionally ignored here to allow empty policies to passthrough validation.
+	// This covers any interpolated values
+	bytes, _ := json.Marshal(j)
+
+	return string(bytes[:]), nil
+}
+
+// Takes a value containing YAML string and passes it through
+// the YAML parser. Returns either a parsing
+// error or original YAML string.
+func checkYamlString(yamlString interface{}) (string, error) {
+	var y interface{}
+
+	if yamlString == nil || yamlString.(string) == "" {
+		return "", nil
+	}
+
+	s := yamlString.(string)
+
+	err := yaml.Unmarshal([]byte(s), &y)
+	if err != nil {
+		return s, err
+	}
+
+	return s, nil
+}
+
+func NormalizeStackTemplate(templateString interface{}) (string, error) {
+	if looksLikeJsonString(templateString) {
+		return NormalizeJsonString(templateString.(string))
+	}
+
+	return checkYamlString(templateString)
+}
+
+func FlattenStackOutputs(stackOutputs []*stacks.Output) map[string]string {
+	outputs := make(map[string]string, len(stackOutputs))
+	for _, o := range stackOutputs {
+		outputs[*o.OutputKey] = *o.OutputValue
+	}
+	return outputs
+}
+
+// FlattenStackParameters is flattening list of
+// stack Parameters and only returning existing
+// parameters to avoid clash with default values
+func FlattenStackParameters(stackParams map[string]string,
+	originalParams map[string]interface{}) map[string]string {
+	params := make(map[string]string, len(stackParams))
+	for key, value := range stackParams {
+		_, isConfigured := originalParams[key]
+		if isConfigured {
+			params[key] = value
+		}
+	}
+	return params
+}
+
+// StrSliceContains checks if a given string is contained in a slice
+// When anybody asks why Go needs generics, here you go.
+func StrSliceContains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func JsonMarshal(t interface{}) ([]byte, error) {
+	buffer := &bytes.Buffer{}
+	enc := json.NewEncoder(buffer)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(t)
+	return buffer.Bytes(), err
+}
+
+// RemoveDuplicateElem removes duplicate elements from slice
+func RemoveDuplicateElem(s []string) []string {
+	result := []string{}
+	tmpMap := map[string]byte{}
+	for _, e := range s {
+		l := len(tmpMap)
+		tmpMap[e] = 0
+		if len(tmpMap) != l {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+func RemoveNil(data map[string]interface{}) map[string]interface{} {
+	withoutNil := make(map[string]interface{})
+
+	for k, v := range data {
+		if v == nil {
+			continue
+		}
+
+		switch v.(type) {
+		case map[string]interface{}:
+			withoutNil[k] = RemoveNil(v.(map[string]interface{}))
+		default:
+			withoutNil[k] = v
+		}
+	}
+
+	return withoutNil
+}
+
+func IsResourceNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	_, ok := err.(golangsdk.ErrDefault404)
+	return ok
+}
+
+// Method FormatTimeStampRFC3339 is used to unify the time format to RFC-3339 and return a time string.
+func FormatTimeStampRFC3339(timestamp int64) string {
+	createTime := time.Unix(timestamp, 0)
+	return createTime.Format(time.RFC3339)
+}
+
+// Method EncodeBase64String is used to encode a string by base64.
+func EncodeBase64String(str string) string {
+	strByte := []byte(str)
+	return base64.StdEncoding.EncodeToString(strByte)
+}
+
+// Method EncodeBase64IfNot is used to encode a string by base64 if it not a base64 string.
+func EncodeBase64IfNot(str string) string {
+	if _, err := base64.StdEncoding.DecodeString(str); err != nil {
+		return base64.StdEncoding.EncodeToString([]byte(str))
+	}
+	return str
+}

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/validators.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/validators.go
@@ -1,0 +1,243 @@
+package utils
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+var ValidateSubnetV2IPv6Mode = validation.StringInSlice([]string{
+	"slaac", "dhcpv6-stateful", "dhcpv6-stateless",
+}, false)
+
+func ValidateTrueOnly(v interface{}, k string) (ws []string, errors []error) {
+	if b, ok := v.(bool); ok && b {
+		return
+	}
+	if v, ok := v.(string); ok && v == "true" {
+		return
+	}
+	errors = append(errors, fmt.Errorf("%q must be true", k))
+	return
+}
+
+func ValidateJsonString(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := NormalizeJsonString(v); err != nil {
+		errors = append(errors, fmt.Errorf("%q contains an invalid JSON: %s", k, err))
+	}
+	return
+}
+
+func looksLikeJsonString(s interface{}) bool {
+	return regexp.MustCompile(`^\s*{`).MatchString(s.(string))
+}
+
+func ValidateStackTemplate(v interface{}, k string) (ws []string, errors []error) {
+	if looksLikeJsonString(v) {
+		if _, err := NormalizeJsonString(v); err != nil {
+			errors = append(errors, fmt.Errorf("%q contains an invalid JSON: %s", k, err))
+		}
+	} else {
+		if _, err := checkYamlString(v); err != nil {
+			errors = append(errors, fmt.Errorf("%q contains an invalid YAML: %s", k, err))
+		}
+	}
+	return
+}
+
+//lintignore:V001
+func ValidateName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if len(value) > 64 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 64 characters: %q", k, value))
+	}
+
+	pattern := `^[\.\-_A-Za-z0-9]+$`
+	if !regexp.MustCompile(pattern).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q doesn't comply with restrictions (%q): %q",
+			k, pattern, value))
+	}
+
+	return
+}
+
+//lintignore:V001
+func ValidateString64WithChinese(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if len(value) > 64 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 64 characters: %q", k, value))
+	}
+
+	pattern := "^[\\-._A-Za-z0-9\u4e00-\u9fa5]+$"
+	if !regexp.MustCompile(pattern).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q doesn't comply with restrictions (%q): %q",
+			k, pattern, value))
+	}
+
+	return
+}
+
+func ValidateCIDR(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	_, ipnet, err := net.ParseCIDR(value)
+	if err != nil {
+		errors = append(errors, fmt.Errorf(
+			"%q must contain a valid CIDR, got error parsing: %s", k, err))
+		return
+	}
+
+	if ipnet == nil || value != ipnet.String() {
+		errors = append(errors, fmt.Errorf(
+			"%q must contain a valid network CIDR, got %q", k, value))
+	}
+
+	return
+}
+
+func ValidateIPRange(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	ipAddresses := strings.Split(value, "-")
+	if len(ipAddresses) != 2 {
+		errors = append(errors, fmt.Errorf(
+			"%q must be a valid network IP address range, such as 0.0.0.0-255.255.255.0, but got %q", k, value))
+		return
+	}
+	for _, address := range ipAddresses {
+		ipnet := net.ParseIP(address)
+		if ipnet == nil || address != ipnet.String() {
+			errors = append(errors, fmt.Errorf("%q must contains valid network IP address, got %q", k, address))
+		}
+	}
+	if len(errors) == 0 {
+		if ipAddresses[0] == ipAddresses[1] {
+			errors = append(errors, fmt.Errorf("Two network IP address of %q cannot equal, got %q", k, value))
+		}
+		// Split the IP address into a string array for comparison.
+		startAddress := strings.Split(ipAddresses[0], ".")
+		endAddress := strings.Split(ipAddresses[1], ".")
+		// Verify the correctness of the IP address range: The starting IP address must be less than the ending IP address.
+		// The For loop compares the four parts of the IPv4 address in turn.
+		for i := 0; i < len(startAddress); i++ {
+			if startAddress[i] > endAddress[i] {
+				errors = append(errors, fmt.Errorf(
+					"%q starting IP address cannot be greater than the ending IP address, got %q", k, value))
+				return
+			} else if startAddress[i] < endAddress[i] {
+				return
+			}
+		}
+	}
+
+	return
+}
+
+func ValidateIP(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	ipnet := net.ParseIP(value)
+
+	if ipnet == nil || value != ipnet.String() {
+		errors = append(errors, fmt.Errorf(
+			"%q must contain a valid network IP address, got %q", k, value))
+	}
+
+	return
+}
+
+//lintignore:V001
+func ValidateVBSPolicyName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if strings.HasPrefix(strings.ToLower(value), "default") {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot start with default: %q", k, value))
+	}
+
+	if len(value) > 64 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 64 characters: %q", k, value))
+	}
+	pattern := `^[\.\-_A-Za-z0-9]+$`
+	if !regexp.MustCompile(pattern).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q doesn't comply with restrictions (%q): %q",
+			k, pattern, value))
+	}
+	return
+}
+
+//lintignore:V001
+func ValidateVBSTagKey(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	if len(value) > 36 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 36 characters: %q", k, value))
+	}
+	pattern := `^[\.\-_A-Za-z0-9]+$`
+	if !regexp.MustCompile(pattern).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q doesn't comply with restrictions (%q): %q",
+			k, pattern, value))
+	}
+	return
+}
+
+//lintignore:V001
+func ValidateVBSTagValue(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	if len(value) > 43 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 43 characters: %q", k, value))
+	}
+	pattern := `^[\.\-_A-Za-z0-9]+$`
+	if !regexp.MustCompile(pattern).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q doesn't comply with restrictions (%q): %q",
+			k, pattern, value))
+	}
+	return
+}
+
+//lintignore:V001
+func ValidateVBSBackupName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if strings.HasPrefix(strings.ToLower(value), "autobk") {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot start with autobk: %q", k, value))
+	}
+
+	if len(value) > 64 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 64 characters: %q", k, value))
+	}
+	pattern := `^[\.\-_A-Za-z0-9]+$`
+	if !regexp.MustCompile(pattern).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q doesn't comply with restrictions (%q): %q",
+			k, pattern, value))
+	}
+	return
+}
+
+//lintignore:V001
+func ValidateVBSBackupDescription(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if len(value) > 64 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 64 characters: %q", k, value))
+	}
+	pattern := `^[^<>]+$`
+	if !regexp.MustCompile(pattern).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q doesn't comply with restrictions (%q): %q",
+			k, pattern, value))
+	}
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -58,7 +58,7 @@ github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 github.com/bgentry/go-netrc/netrc
-# github.com/chnsz/golangsdk v0.0.0-20211019093707-47c835c53b0e
+# github.com/chnsz/golangsdk v0.0.0-20211129061956-055d0ed2e3f8
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal
@@ -305,7 +305,7 @@ github.com/hashicorp/terraform-plugin-sdk/v2/plugin
 github.com/hashicorp/terraform-plugin-sdk/v2/terraform
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/terraform-provider-huaweicloud v1.28.1
+# github.com/huaweicloud/terraform-provider-huaweicloud v1.31.0
 ## explicit
 github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config
 github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -311,6 +311,7 @@ github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config
 github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode
 github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv
 github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/pathorcontents
+github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils
 # github.com/jen20/awspolicyequivalence v1.1.0
 ## explicit
 github.com/jen20/awspolicyequivalence


### PR DESCRIPTION
- feat: add more filter params for dcs product
- return default dcs maintain window first
- deprecate flexibleengine_dcs_az_v1 data source

the testing results are as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDcsProductV1DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDcsProductV1DataSource_basic -timeout 720m
=== RUN   TestAccDcsProductV1DataSource_basic
--- PASS: TestAccDcsProductV1DataSource_basic (8.97s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 9.010s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDcsMaintainWindowV1DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDcsMaintainWindowV1DataSource_basic -timeout 720m
=== RUN   TestAccDcsMaintainWindowV1DataSource_basic
--- PASS: TestAccDcsMaintainWindowV1DataSource_basic (7.06s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 7.070s
```
