### PR TITLE
feat: support to obtain client IP address on elb listener

### DIFF
--- a/docs/resources/lb_listener_v2.md
+++ b/docs/resources/lb_listener_v2.md
@@ -126,6 +126,23 @@ The following arguments are supported:
 * `http2_enable` - (Optional, Bool) Specifies whether to use HTTP/2. The default value is false.
     This parameter is valid only when the protocol is set to *TERMINATED_HTTPS*.
 
+* `transparent_client_ip_enable` - (Optional, Bool) Specifies whether to pass source IP addresses of the clients to backend servers.
+  + For TCP and UDP listeners, the value can be true or false, and the default value is false.
+  + For HTTP and HTTPS listeners, the value can only be true.
+
+* `idle_timeout` - (Optional, Int) Specifies the idle timeout duration, in seconds.
+  + For TCP listeners, the value ranges from 10 to 4000, and the default value is 300.
+  + For HTTP and HTTPS listeners, the value ranges from 1 to 300, and the default value is 60.
+  + For UDP listeners, this parameter does not take effect.
+
+* `request_timeout` - (Optional, Int) Specifies the timeout duration for waiting for a request from a client,
+  in seconds. This parameter is available only for HTTP and HTTPS listeners. The value ranges from 1 to 300,
+  and the default value is 60.
+
+* `response_timeout` - (Optional, Int) Specifies the timeout duration for waiting for a request from a backend
+  server, in seconds. This parameter is available only for HTTP and HTTPS listeners. The value ranges from 1 to 300,
+  and the default value is 60.
+
 * `default_tls_container_ref` - (Optional) A reference to a Barbican Secrets
     container which stores TLS information. This is required if the protocol
     is `TERMINATED_HTTPS`. See

--- a/docs/resources/lb_listener_v2.md
+++ b/docs/resources/lb_listener_v2.md
@@ -104,20 +104,20 @@ The following arguments are supported:
     If omitted, the `region` argument of the provider is used.
     Changing this creates a new listener.
 
+* `loadbalancer_id` - (Required) The load balancer on which to provision this
+    listener. Changing this creates a new listener.
+
 * `protocol` - (Required) The protocol - can either be TCP, UDP, HTTP or TERMINATED_HTTPS.
     Changing this creates a new listener.
 
 * `protocol_port` - (Required) The port on which to listen for client traffic.
     Changing this creates a new listener.
 
-* `loadbalancer_id` - (Required) The load balancer on which to provision this
-    listener. Changing this creates a new listener.
+* `default_pool_id` - (Optional) The ID of the default pool with which the
+    listener is associated. Changing this creates a new listener.
 
 * `name` - (Optional) Human-readable name for the listener. Does not have
     to be unique.
-
-* `default_pool_id` - (Optional) The ID of the default pool with which the
-    listener is associated. Changing this creates a new listener.
 
 * `description` - (Optional) Human-readable description for the listener.
 
@@ -168,13 +168,6 @@ The following arguments are supported:
   </tr>
 </table>
 
-* `admin_state_up` - (Optional) The administrative state of the listener.
-    A valid value is true (UP) or false (DOWN).
-
-* `tenant_id` - (Optional) The UUID of the tenant who owns the listener.
-    Only administrative users can specify a tenant UUID other than their own.
-    Changing this creates a new listener.
-
 ## Attributes Reference
 
 The following attributes are exported:
@@ -182,7 +175,6 @@ The following attributes are exported:
 * `id` - The unique ID for the listener.
 * `protocol` - See Argument Reference above.
 * `protocol_port` - See Argument Reference above.
-* `tenant_id` - See Argument Reference above.
 * `name` - See Argument Reference above.
 * `default_port_id` - See Argument Reference above.
 * `description` - See Argument Reference above.
@@ -190,5 +182,4 @@ The following attributes are exported:
 * `default_tls_container_ref` - See Argument Reference above.
 * `sni_container_refs` - See Argument Reference above.
 * `tls_ciphers_policy` - See Argument Reference above.
-* `admin_state_up` - See Argument Reference above.
 * `tags` - See Argument Reference above.

--- a/flexibleengine/resource_flexibleengine_lb_listener_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_listener_v2.go
@@ -5,20 +5,23 @@ import (
 	"log"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/common/tags"
+	listeners_v3 "github.com/chnsz/golangsdk/openstack/elb/v3/listeners"
 	"github.com/chnsz/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners"
 )
 
 func resourceListenerV2() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceListenerV2Create,
-		Read:   resourceListenerV2Read,
-		Update: resourceListenerV2Update,
-		Delete: resourceListenerV2Delete,
+		Create: resourceListenerCreate,
+		Read:   resourceListenerRead,
+		Update: resourceListenerUpdate,
+		Delete: resourceListenerDelete,
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
@@ -74,7 +77,12 @@ func resourceListenerV2() *schema.Resource {
 			"http2_enable": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+			},
+
+			"transparent_client_ip_enable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
 			},
 
 			"default_tls_container_ref": {
@@ -92,6 +100,25 @@ func resourceListenerV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+			},
+
+			"idle_timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(0, 4000),
+			},
+			"request_timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(1, 300),
+			},
+			"response_timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntBetween(1, 300),
 			},
 			"tags": tagsSchema(),
 
@@ -111,11 +138,16 @@ func resourceListenerV2() *schema.Resource {
 	}
 }
 
-func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
+func resourceListenerCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.ElbV2Client(GetRegion(d, config))
+	region := GetRegion(d, config)
+	lbClient, err := config.ElbV2Client(region)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
+	}
+	v3Client, err := config.ElbV3Client(region)
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine ELB v3 client: %s", err)
 	}
 
 	http2Enable := d.Get("http2_enable").(bool)
@@ -125,20 +157,33 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 			sniContainerRefs = append(sniContainerRefs, v.(string))
 		}
 	}
-	createOpts := listeners.CreateOpts{
-		Protocol:               listeners.Protocol(d.Get("protocol").(string)),
+	createOpts := listeners_v3.CreateOpts{
+		Protocol:               listeners_v3.Protocol(d.Get("protocol").(string)),
 		ProtocolPort:           d.Get("protocol_port").(int),
 		LoadbalancerID:         d.Get("loadbalancer_id").(string),
 		Name:                   d.Get("name").(string),
 		DefaultPoolID:          d.Get("default_pool_id").(string),
 		Description:            d.Get("description").(string),
 		DefaultTlsContainerRef: d.Get("default_tls_container_ref").(string),
-		SniContainerRefs:       sniContainerRefs,
 		TlsCiphersPolicy:       d.Get("tls_ciphers_policy").(string),
+		SniContainerRefs:       sniContainerRefs,
 		Http2Enable:            &http2Enable,
 	}
 
-	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	if transparentIP := d.Get("transparent_client_ip_enable").(bool); transparentIP {
+		createOpts.TransparentClientIP = &transparentIP
+	}
+	if v1, ok := d.GetOk("idle_timeout"); ok {
+		createOpts.KeepaliveTimeout = golangsdk.IntToPointer(v1.(int))
+	}
+	if v2, ok := d.GetOk("request_timeout"); ok {
+		createOpts.ClientTimeout = golangsdk.IntToPointer(v2.(int))
+	}
+	if v3, ok := d.GetOk("response_timeout"); ok {
+		createOpts.MemberTimeout = golangsdk.IntToPointer(v3.(int))
+	}
+
+	log.Printf("[DEBUG] Create v3 Options: %#v", createOpts)
 
 	// Wait for LoadBalancer to become active before continuing
 	lbID := createOpts.LoadbalancerID
@@ -148,10 +193,10 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	log.Printf("[DEBUG] Attempting to create listener")
-	var listener *listeners.Listener
+	log.Printf("[DEBUG] Attempting to create listener with v3 API")
+	var listener *listeners_v3.Listener
 	err = resource.Retry(timeout, func() *resource.RetryError {
-		listener, err = listeners.Create(lbClient, createOpts).Extract()
+		listener, err = listeners_v3.Create(v3Client, createOpts).Extract()
 		if err != nil {
 			return checkForRetryableError(err)
 		}
@@ -178,37 +223,47 @@ func resourceListenerV2Create(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	return resourceListenerV2Read(d, meta)
+	return resourceListenerRead(d, meta)
 }
 
-func resourceListenerV2Read(d *schema.ResourceData, meta interface{}) error {
+func resourceListenerRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	region := GetRegion(d, config)
 	lbClient, err := config.ElbV2Client(region)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
+	v3Client, err := config.ElbV3Client(region)
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine ELB v3 client: %s", err)
+	}
 
-	listener, err := listeners.Get(lbClient, d.Id()).Extract()
+	listener, err := listeners_v3.Get(v3Client, d.Id()).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "listener")
 	}
 
 	log.Printf("[DEBUG] Retrieved listener %s: %#v", d.Id(), listener)
 
-	d.SetId(listener.ID)
-	d.Set("region", region)
-	d.Set("name", listener.Name)
-	d.Set("protocol", listener.Protocol)
-	d.Set("description", listener.Description)
-	d.Set("protocol_port", listener.ProtocolPort)
-	d.Set("http2_enable", listener.Http2Enable)
-	d.Set("default_pool_id", listener.DefaultPoolID)
-	if err := d.Set("sni_container_refs", listener.SniContainerRefs); err != nil {
-		return fmt.Errorf("[DEBUG] Error saving sni_container_refs to state for FlexibleEngine listener (%s): %s", d.Id(), err)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", listener.Name),
+		d.Set("description", listener.Description),
+		d.Set("protocol", listener.Protocol),
+		d.Set("protocol_port", listener.ProtocolPort),
+		d.Set("http2_enable", listener.Http2Enable),
+		d.Set("transparent_client_ip_enable", listener.TransparentClientIP),
+		d.Set("default_pool_id", listener.DefaultPoolID),
+		d.Set("sni_container_refs", listener.SniContainerRefs),
+		d.Set("tls_ciphers_policy", listener.TlsCiphersPolicy),
+		d.Set("default_tls_container_ref", listener.DefaultTlsContainerRef),
+		d.Set("idle_timeout", listener.KeepaliveTimeout),
+		d.Set("request_timeout", listener.ClientTimeout),
+		d.Set("response_timeout", listener.MemberTimeout),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return mErr
 	}
-	d.Set("tls_ciphers_policy", listener.TlsCiphersPolicy)
-	d.Set("default_tls_container_ref", listener.DefaultTlsContainerRef)
 
 	// fetch tags
 	if resourceTags, err := tags.Get(lbClient, "listeners", d.Id()).Extract(); err == nil {
@@ -221,22 +276,32 @@ func resourceListenerV2Read(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
+func resourceListenerUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	elbV2Client, err := config.ElbV2Client(GetRegion(d, config))
+	region := GetRegion(d, config)
+	lbClient, err := config.ElbV2Client(region)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
+	v3Client, err := config.ElbV3Client(region)
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine ELB v3 client: %s", err)
+	}
 
-	var updateOpts listeners.UpdateOpts
+	// Wait for LoadBalancer to become active before continuing
+	lbID := d.Get("loadbalancer_id").(string)
+	timeout := d.Timeout(schema.TimeoutUpdate)
+	err = waitForLBV2LoadBalancer(lbClient, lbID, "ACTIVE", nil, timeout)
+	if err != nil {
+		return err
+	}
+
+	var updateOpts listeners_v3.UpdateOpts
 	if d.HasChange("name") {
 		updateOpts.Name = d.Get("name").(string)
 	}
 	if d.HasChange("description") {
 		updateOpts.Description = d.Get("description").(string)
-	}
-	if d.HasChange("default_tls_container_ref") {
-		updateOpts.DefaultTlsContainerRef = d.Get("default_tls_container_ref").(string)
 	}
 	if d.HasChange("sni_container_refs") {
 		var sniContainerRefs []string
@@ -245,27 +310,36 @@ func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
 				sniContainerRefs = append(sniContainerRefs, v.(string))
 			}
 		}
-		updateOpts.SniContainerRefs = sniContainerRefs
+		updateOpts.SniContainerRefs = &sniContainerRefs
+	}
+	if d.HasChange("default_tls_container_ref") {
+		tlsContainerRef := d.Get("default_tls_container_ref").(string)
+		updateOpts.DefaultTlsContainerRef = &tlsContainerRef
 	}
 	if d.HasChange("tls_ciphers_policy") {
-		updateOpts.TlsCiphersPolicy = d.Get("tls_ciphers_policy").(string)
+		tlsPolicy := d.Get("tls_ciphers_policy").(string)
+		updateOpts.TlsCiphersPolicy = &tlsPolicy
 	}
 	if d.HasChange("http2_enable") {
 		http2 := d.Get("http2_enable").(bool)
 		updateOpts.Http2Enable = &http2
 	}
+	if d.HasChange("transparent_client_ip_enable") {
+		transparentIPEnable := d.Get("transparent_client_ip_enable").(bool)
+		updateOpts.TransparentClientIP = &transparentIPEnable
+	}
 
-	// Wait for LoadBalancer to become active before continuing
-	lbID := d.Get("loadbalancer_id").(string)
-	timeout := d.Timeout(schema.TimeoutUpdate)
-	err = waitForLBV2LoadBalancer(elbV2Client, lbID, "ACTIVE", nil, timeout)
-	if err != nil {
-		return err
+	if d.HasChange("idle_timeout") {
+		updateOpts.KeepaliveTimeout = golangsdk.IntToPointer(d.Get("idle_timeout").(int))
+	}
+	if d.HasChanges("request_timeout", "response_timeout") {
+		updateOpts.ClientTimeout = golangsdk.IntToPointer(d.Get("request_timeout").(int))
+		updateOpts.MemberTimeout = golangsdk.IntToPointer(d.Get("response_timeout").(int))
 	}
 
 	log.Printf("[DEBUG] Updating listener %s with options: %#v", d.Id(), updateOpts)
 	err = resource.Retry(timeout, func() *resource.RetryError {
-		_, err = listeners.Update(elbV2Client, d.Id(), updateOpts).Extract()
+		_, err = listeners_v3.Update(v3Client, d.Id(), updateOpts).Extract()
 		if err != nil {
 			return checkForRetryableError(err)
 		}
@@ -277,26 +351,26 @@ func resourceListenerV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for LoadBalancer to become active again before continuing
-	err = waitForLBV2LoadBalancer(elbV2Client, lbID, "ACTIVE", nil, timeout)
+	err = waitForLBV2LoadBalancer(lbClient, lbID, "ACTIVE", nil, timeout)
 	if err != nil {
 		return err
 	}
 
 	// update tags
 	if d.HasChange("tags") {
-		tagErr := UpdateResourceTags(elbV2Client, d, "listeners", d.Id())
+		tagErr := UpdateResourceTags(lbClient, d, "listeners", d.Id())
 		if tagErr != nil {
 			return fmt.Errorf("Error updating tags of elb listener:%s, err:%s", d.Id(), tagErr)
 		}
 	}
 
-	return resourceListenerV2Read(d, meta)
+	return resourceListenerRead(d, meta)
 
 }
 
-func resourceListenerV2Delete(d *schema.ResourceData, meta interface{}) error {
+func resourceListenerDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	elbV2Client, err := config.ElbV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
@@ -304,14 +378,14 @@ func resourceListenerV2Delete(d *schema.ResourceData, meta interface{}) error {
 	// Wait for LoadBalancer to become active before continuing
 	lbID := d.Get("loadbalancer_id").(string)
 	timeout := d.Timeout(schema.TimeoutDelete)
-	err = waitForLBV2LoadBalancer(elbV2Client, lbID, "ACTIVE", nil, timeout)
+	err = waitForLBV2LoadBalancer(lbClient, lbID, "ACTIVE", nil, timeout)
 	if err != nil {
 		return err
 	}
 
 	log.Printf("[DEBUG] Deleting listener %s", d.Id())
 	err = resource.Retry(timeout, func() *resource.RetryError {
-		err = listeners.Delete(elbV2Client, d.Id()).ExtractErr()
+		err = listeners.Delete(lbClient, d.Id()).ExtractErr()
 		if err != nil {
 			return checkForRetryableError(err)
 		}
@@ -323,13 +397,13 @@ func resourceListenerV2Delete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Wait for LoadBalancer to become active again before continuing
-	err = waitForLBV2LoadBalancer(elbV2Client, lbID, "ACTIVE", nil, timeout)
+	err = waitForLBV2LoadBalancer(lbClient, lbID, "ACTIVE", nil, timeout)
 	if err != nil {
 		return err
 	}
 
 	// Wait for Listener to delete
-	err = waitForLBV2Listener(elbV2Client, d.Id(), "DELETED", nil, timeout)
+	err = waitForLBV2Listener(lbClient, d.Id(), "DELETED", nil, timeout)
 	if err != nil {
 		return err
 	}

--- a/flexibleengine/resource_flexibleengine_lb_listener_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_lb_listener_v2_test.go
@@ -141,7 +141,6 @@ resource "flexibleengine_lb_listener_v2" "listener_1" {
   name            = "listener_1_updated"
   protocol        = "HTTP"
   protocol_port   = 8080
-  admin_state_up  = "true"
   loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
 
   tags = {

--- a/flexibleengine/resource_flexibleengine_lb_listener_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_lb_listener_v2_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/chnsz/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -12,6 +13,7 @@ import (
 func TestAccLBV2Listener_basic(t *testing.T) {
 	var listener listeners.Listener
 	resourceName := "flexibleengine_lb_listener_v2.listener_1"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -19,18 +21,21 @@ func TestAccLBV2Listener_basic(t *testing.T) {
 		CheckDestroy: testAccCheckLBV2ListenerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: TestAccLBV2ListenerConfig_basic,
+				Config: testAccLBV2ListenerConfig_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLBV2ListenerExists(resourceName, &listener),
-					resource.TestCheckResourceAttr(resourceName, "name", "listener_1"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("listener-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "http2_enable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "transparent_client_ip_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 				),
 			},
 			{
-				Config: TestAccLBV2ListenerConfig_update,
+				Config: testAccLBV2ListenerConfig_update(rName),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "name", "listener_1_updated"),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("listener-%s_updated", rName)),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform_update"),
 				),
@@ -42,6 +47,7 @@ func TestAccLBV2Listener_basic(t *testing.T) {
 func TestAccLBV2Listener_withCert(t *testing.T) {
 	var listener listeners.Listener
 	resourceName := "flexibleengine_lb_listener_v2.listener_1"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -49,10 +55,37 @@ func TestAccLBV2Listener_withCert(t *testing.T) {
 		CheckDestroy: testAccCheckLBV2ListenerDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: TestAccLBV2ListenerConfig_cert,
+				Config: testAccLBV2ListenerConfig_cert(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLBV2ListenerExists(resourceName, &listener),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("listener-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "TERMINATED_HTTPS"),
 					resource.TestCheckResourceAttr(resourceName, "http2_enable", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLBV2Listener_v3(t *testing.T) {
+	var listener listeners.Listener
+	resourceName := "flexibleengine_lb_listener_v2.listener_1"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLBV2ListenerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLBV2ListenerConfig_v3(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLBV2ListenerExists(resourceName, &listener),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("listener-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "TCP"),
+					resource.TestCheckResourceAttr(resourceName, "http2_enable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "transparent_client_ip_enable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "idle_timeout", "500"),
 				),
 			},
 		},
@@ -61,7 +94,7 @@ func TestAccLBV2Listener_withCert(t *testing.T) {
 
 func testAccCheckLBV2ListenerDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+	elbClient, err := config.ElbV2Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}
@@ -71,7 +104,7 @@ func testAccCheckLBV2ListenerDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := listeners.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := listeners.Get(elbClient, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("Listener still exists: %s", rs.Primary.ID)
 		}
@@ -92,12 +125,12 @@ func testAccCheckLBV2ListenerExists(n string, listener *listeners.Listener) reso
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+		elbClient, err := config.ElbV2Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 		}
 
-		found, err := listeners.Get(networkingClient, rs.Primary.ID).Extract()
+		found, err := listeners.Get(elbClient, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
@@ -112,14 +145,15 @@ func testAccCheckLBV2ListenerExists(n string, listener *listeners.Listener) reso
 	}
 }
 
-var TestAccLBV2ListenerConfig_basic = fmt.Sprintf(`
+func testAccLBV2ListenerConfig_basic(name string) string {
+	return fmt.Sprintf(`
 resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
-  name          = "loadbalancer_1"
+  name          = "lb-%s"
   vip_subnet_id = "%s"
 }
 
 resource "flexibleengine_lb_listener_v2" "listener_1" {
-  name            = "listener_1"
+  name            = "listener-%s"
   protocol        = "HTTP"
   protocol_port   = 8080
   loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
@@ -129,16 +163,18 @@ resource "flexibleengine_lb_listener_v2" "listener_1" {
     owner = "terraform"
   }
 }
-`, OS_SUBNET_ID)
+`, name, OS_SUBNET_ID, name)
+}
 
-var TestAccLBV2ListenerConfig_update = fmt.Sprintf(`
+func testAccLBV2ListenerConfig_update(name string) string {
+	return fmt.Sprintf(`
 resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
-  name          = "loadbalancer_1"
+  name          = "lb-%s"
   vip_subnet_id = "%s"
 }
 
 resource "flexibleengine_lb_listener_v2" "listener_1" {
-  name            = "listener_1_updated"
+  name            = "listener-%s_updated"
   protocol        = "HTTP"
   protocol_port   = 8080
   loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
@@ -148,16 +184,18 @@ resource "flexibleengine_lb_listener_v2" "listener_1" {
     owner = "terraform_update"
   }
 }
-`, OS_SUBNET_ID)
+`, name, OS_SUBNET_ID, name)
+}
 
-var TestAccLBV2ListenerConfig_cert = fmt.Sprintf(`
+func testAccLBV2ListenerConfig_cert(name string) string {
+	return fmt.Sprintf(`
 resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
-  name          = "loadbalancer_cert"
+  name          = "lb-%s"
   vip_subnet_id = "%s"
 }
 
 resource "flexibleengine_lb_certificate_v2" "certificate_1" {
-  name        = "cert"
+  name        = "cert-%s"
   domain      = "www.elb.com"
   private_key = <<EOT
 -----BEGIN RSA PRIVATE KEY-----
@@ -216,11 +254,35 @@ EOT
 }
 
 resource "flexibleengine_lb_listener_v2" "listener_1" {
-  name                      = "listener_cert"
+  name                      = "listener-%s"
   protocol                  = "TERMINATED_HTTPS"
   protocol_port             = 8080
   http2_enable              = true
   loadbalancer_id           = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
   default_tls_container_ref = flexibleengine_lb_certificate_v2.certificate_1.id
 }
-`, OS_SUBNET_ID)
+`, name, OS_SUBNET_ID, name, name)
+}
+
+func testAccLBV2ListenerConfig_v3(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
+  name          = "lb-%s"
+  vip_subnet_id = "%s"
+}
+
+resource "flexibleengine_lb_listener_v2" "listener_1" {
+  name            = "listener-%s"
+  protocol        = "TCP"
+  protocol_port   = 443
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
+  idle_timeout    = 500
+  transparent_client_ip_enable = true
+
+  tags = {
+    key   = "value"
+    owner = "terraform"
+  }
+}
+`, name, OS_SUBNET_ID, name)
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/listeners/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/listeners/requests.go
@@ -1,0 +1,222 @@
+package listeners
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// Type Protocol represents a listener protocol.
+type Protocol string
+
+// Supported attributes for create/update operations.
+const (
+	ProtocolTCP   Protocol = "TCP"
+	ProtocolUDP   Protocol = "UDP"
+	ProtocolHTTP  Protocol = "HTTP"
+	ProtocolHTTPS Protocol = "HTTPS"
+)
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOptsBuilder interface {
+	ToListenerCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOpts represents options for creating a listener.
+type CreateOpts struct {
+	// The administrative state of the Listener. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// the ID of the CA certificate used by the listener.
+	CAContainerRef string `json:"client_ca_tls_container_ref,omitempty"`
+
+	// The ID of the default pool with which the Listener is associated.
+	DefaultPoolID string `json:"default_pool_id,omitempty"`
+
+	// A reference to a Barbican container of TLS secrets.
+	DefaultTlsContainerRef string `json:"default_tls_container_ref,omitempty"`
+
+	// Human-readable description for the Listener.
+	Description string `json:"description,omitempty"`
+
+	// whether to use HTTP2.
+	Http2Enable *bool `json:"http2_enable,omitempty"`
+
+	// The load balancer on which to provision this listener.
+	LoadbalancerID string `json:"loadbalancer_id" required:"true"`
+
+	// Human-readable name for the Listener. Does not have to be unique.
+	Name string `json:"name,omitempty"`
+
+	// ProjectID is only required if the caller has an admin role and wants
+	// to create a pool for another project.
+	ProjectID string `json:"project_id,omitempty"`
+
+	// The protocol - can either be TCP, HTTP or HTTPS.
+	Protocol Protocol `json:"protocol" required:"true"`
+
+	// The port on which to listen for client traffic.
+	ProtocolPort int `json:"protocol_port" required:"true"`
+
+	// A list of references to TLS secrets.
+	SniContainerRefs []string `json:"sni_container_refs,omitempty"`
+
+	// Specifies the security policy used by the listener.
+	TlsCiphersPolicy string `json:"tls_ciphers_policy,omitempty"`
+
+	// Whether enable member retry
+	EnableMemberRetry *bool `json:"enable_member_retry,omitempty"`
+
+	// The keepalive timeout of the Listener.
+	KeepaliveTimeout *int `json:"keepalive_timeout,omitempty"`
+
+	// The client timeout of the Listener.
+	ClientTimeout *int `json:"client_timeout,omitempty"`
+
+	// The member timeout of the Listener.
+	MemberTimeout *int `json:"member_timeout,omitempty"`
+
+	// The ipgroup of the Listener.
+	IpGroup *IpGroup `json:"ipgroup,omitempty"`
+
+	// The http insert headers of the Listener.
+	InsertHeaders *InsertHeaders `json:"insert_headers,omitempty"`
+
+	// Transparent client ip enable
+	TransparentClientIP *bool `json:"transparent_client_ip_enable,omitempty"`
+
+	// Enhance L7policy enable
+	EnhanceL7policy *bool `json:"enhance_l7policy_enable,omitempty"`
+}
+
+type IpGroup struct {
+	IpGroupId string `json:"ipgroup_id" required:"true"`
+	Enable    bool   `json:"enable_ipgroup" required:"true"`
+	Type      string `json:"type" required:"true"`
+}
+
+type InsertHeaders struct {
+	ForwardedELBIP   *bool `json:"X-Forwarded-ELB-IP,omitempty"`
+	ForwardedPort    *bool `json:"X-Forwarded-Port,omitempty"`
+	ForwardedForPort *bool `json:"X-Forwarded-For-Port,omitempty"`
+	ForwardedHost    *bool `json:"X-Forwarded-Host" required:"true"`
+}
+
+// ToListenerCreateMap builds a request body from CreateOpts.
+func (opts CreateOpts) ToListenerCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "listener")
+}
+
+// Create is an operation which provisions a new Listeners based on the
+// configuration defined in the CreateOpts struct. Once the request is
+// validated and progress has started on the provisioning process, a
+// CreateResult will be returned.
+//
+// Users with an admin role can create Listeners on behalf of other tenants by
+// specifying a TenantID attribute different than their own.
+func Create(c *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToListenerCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Post(rootURL(c), b, &r.Body, nil)
+	return
+}
+
+// Get retrieves a particular Listeners based on its unique ID.
+func Get(c *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, id), &r.Body, nil)
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToListenerUpdateMap() (map[string]interface{}, error)
+}
+
+type IpGroupUpdate struct {
+	IpGroupId string `json:"ipgroup_id,omitempty"`
+	Type      string `json:"type,omitempty"`
+}
+
+// UpdateOpts represents options for updating a Listener.
+type UpdateOpts struct {
+	// The administrative state of the Listener. A valid value is true (UP)
+	// or false (DOWN).
+	AdminStateUp *bool `json:"admin_state_up,omitempty"`
+
+	// the ID of the CA certificate used by the listener.
+	CAContainerRef *string `json:"client_ca_tls_container_ref,omitempty"`
+
+	// The ID of the default pool with which the Listener is associated.
+	DefaultPoolID string `json:"default_pool_id,omitempty"`
+
+	// A reference to a container of TLS secrets.
+	DefaultTlsContainerRef *string `json:"default_tls_container_ref,omitempty"`
+
+	// Human-readable description for the Listener.
+	Description string `json:"description,omitempty"`
+
+	// whether to use HTTP2.
+	Http2Enable *bool `json:"http2_enable,omitempty"`
+
+	// Human-readable name for the Listener. Does not have to be unique.
+	Name string `json:"name,omitempty"`
+
+	// A list of references to TLS secrets.
+	SniContainerRefs *[]string `json:"sni_container_refs,omitempty"`
+
+	// Specifies the security policy used by the listener.
+	TlsCiphersPolicy *string `json:"tls_ciphers_policy,omitempty"`
+
+	// Whether enable member retry
+	EnableMemberRetry *bool `json:"enable_member_retry,omitempty"`
+
+	// The keepalive timeout of the Listener.
+	KeepaliveTimeout *int `json:"keepalive_timeout,omitempty"`
+
+	// The client timeout of the Listener.
+	ClientTimeout *int `json:"client_timeout,omitempty"`
+
+	// The member timeout of the Listener.
+	MemberTimeout *int `json:"member_timeout,omitempty"`
+
+	// The ipgroup of the Listener.
+	IpGroup *IpGroupUpdate `json:"ipgroup,omitempty"`
+
+	// The http insert headers of the Listener.
+	InsertHeaders *InsertHeaders `json:"insert_headers,omitempty"`
+
+	// Transparent client ip enable
+	TransparentClientIP *bool `json:"transparent_client_ip_enable,omitempty"`
+
+	// Enhance L7policy enable
+	EnhanceL7policy *bool `json:"enhance_l7policy_enable,omitempty"`
+}
+
+// ToListenerUpdateMap builds a request body from UpdateOpts.
+func (opts UpdateOpts) ToListenerUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "listener")
+}
+
+// Update is an operation which modifies the attributes of the specified
+// Listener.
+func Update(c *golangsdk.ServiceClient, id string, opts UpdateOpts) (r UpdateResult) {
+	b, err := opts.ToListenerUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(resourceURL(c, id), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200, 202},
+	})
+	return
+}
+
+// Delete will permanently delete a particular Listeners based on its unique ID.
+func Delete(c *golangsdk.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, id), nil)
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/listeners/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/listeners/results.go
@@ -1,0 +1,126 @@
+package listeners
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+type LoadBalancerID struct {
+	ID string `json:"id"`
+}
+
+// Listener is the primary load balancing configuration object that specifies
+// the loadbalancer and port on which client traffic is received, as well
+// as other details such as the load balancing method to be use, protocol, etc.
+type Listener struct {
+	// The unique ID for the Listener.
+	ID string `json:"id"`
+
+	// The administrative state of the Listener. A valid value is true (UP) or false (DOWN).
+	AdminStateUp bool `json:"admin_state_up"`
+
+	// the ID of the CA certificate used by the listener.
+	CAContainerRef string `json:"client_ca_tls_container_ref"`
+
+	// The maximum number of connections allowed for the Loadbalancer.
+	// Default is -1, meaning no limit.
+	ConnLimit int `json:"connection_limit"`
+
+	// The UUID of default pool. Must have compatible protocol with listener.
+	DefaultPoolID string `json:"default_pool_id"`
+
+	// A reference to a Barbican container of TLS secrets.
+	DefaultTlsContainerRef string `json:"default_tls_container_ref"`
+
+	// Human-readable description for the Listener.
+	Description string `json:"description"`
+
+	// whether to use HTTP2.
+	Http2Enable bool `json:"http2_enable"`
+
+	// A list of load balancer IDs.
+	Loadbalancers []LoadBalancerID `json:"loadbalancers"`
+
+	// Human-readable name for the Listener. Does not have to be unique.
+	Name string `json:"name"`
+
+	// The protocol to loadbalance. A valid value is TCP, HTTP, or HTTPS.
+	Protocol string `json:"protocol"`
+
+	// The port on which to listen to client traffic that is associated with the
+	// Loadbalancer. A valid value is from 0 to 65535.
+	ProtocolPort int `json:"protocol_port"`
+
+	// The list of references to TLS secrets.
+	SniContainerRefs []string `json:"sni_container_refs"`
+
+	// Specifies the security policy used by the listener.
+	TlsCiphersPolicy string `json:"tls_ciphers_policy"`
+
+	// Whether enable member retry
+	EnableMemberRetry bool `json:"enable_member_retry"`
+
+	// The keepalive timeout of the Listener.
+	KeepaliveTimeout int `json:"keepalive_timeout"`
+
+	// The client timeout of the Listener.
+	ClientTimeout int `json:"client_timeout"`
+
+	// The member timeout of the Listener.
+	MemberTimeout int `json:"member_timeout"`
+
+	// The ipgroup of the Listener.
+	IpGroup IpGroup `json:"ipgroup"`
+
+	// The http insert headers of the Listener.
+	InsertHeaders InsertHeadersInfo `json:"insert_headers"`
+
+	// Transparent client ip enable
+	TransparentClientIP bool `json:"transparent_client_ip_enable"`
+
+	// Enhance L7policy enable
+	EnhanceL7policy bool `json:"enhance_l7policy_enable"`
+}
+
+type InsertHeadersInfo struct {
+	ForwardedELBIP   bool `json:"X-Forwarded-ELB-IP,omitempty"`
+	ForwardedPort    bool `json:"X-Forwarded-Port,omitempty"`
+	ForwardedForPort bool `json:"X-Forwarded-For-Port,omitempty"`
+	ForwardedHost    bool `json:"X-Forwarded-Host" required:"true"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a listener.
+func (r commonResult) Extract() (*Listener, error) {
+	var s struct {
+		Listener *Listener `json:"listener"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Listener, err
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Listener.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Listener.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Listener.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its
+// ExtractErr method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/listeners/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/listeners/urls.go
@@ -1,0 +1,16 @@
+package listeners
+
+import "github.com/chnsz/golangsdk"
+
+const (
+	rootPath     = "elb"
+	resourcePath = "listeners"
+)
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath, resourcePath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(rootPath, resourcePath, id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -119,6 +119,7 @@ github.com/chnsz/golangsdk/openstack/ecs/v1/block_devices
 github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers
 github.com/chnsz/golangsdk/openstack/ecs/v1/flavors
 github.com/chnsz/golangsdk/openstack/ecs/v1/tags
+github.com/chnsz/golangsdk/openstack/elb/v3/listeners
 github.com/chnsz/golangsdk/openstack/identity/v2/tenants
 github.com/chnsz/golangsdk/openstack/identity/v2/tokens
 github.com/chnsz/golangsdk/openstack/identity/v3.0/policies


### PR DESCRIPTION
fixes #609

- use ElbV3Client
- deprecate admin_state_up and tenant_id for listener resource
- support to obtain client IP address with `transparent_client_ip_enable`
- add `idle_timeout`, `request_timeout` and `response_timeout` parameters

the testing result as follows:
```
make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLBV2Listener'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLBV2Listener -timeout 720m
=== RUN   TestAccLBV2Listener_basic
--- PASS: TestAccLBV2Listener_basic (70.15s)
=== RUN   TestAccLBV2Listener_withCert
--- PASS: TestAccLBV2Listener_withCert (51.04s)
=== RUN   TestAccLBV2Listener_v3
--- PASS: TestAccLBV2Listener_v3 (51.59s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 172.804s
```