### PR TITLE
fix(EIP): ignore the parameter if it is empty

### DIFF
--- a/flexibleengine/data_source_flexibleengine_vpc_eip_v1.go
+++ b/flexibleengine/data_source_flexibleengine_vpc_eip_v1.go
@@ -62,9 +62,13 @@ func dataSourceVpcEipRead(_ context.Context, d *schema.ResourceData, meta interf
 		return diag.Errorf("Error creating networking client: %s", err)
 	}
 
-	listOpts := &eips.ListOpts{
-		PortId:   []string{d.Get("port_id").(string)},
-		PublicIp: []string{d.Get("public_ip").(string)},
+	var listOpts eips.ListOpts
+	if portId, ok := d.GetOk("port_id"); ok {
+		listOpts.PortId = []string{portId.(string)}
+	}
+
+	if publicIp, ok := d.GetOk("public_ip"); ok {
+		listOpts.PublicIp = []string{publicIp.(string)}
 	}
 
 	pages, err := eips.List(networkingClient, listOpts).AllPages()


### PR DESCRIPTION


```
make testacc TEST='./flexibleengine' TESTARGS='-run=TestAccVpcV1EipDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run=TestAccVpcV1EipDataSource_basic -timeout 720m
=== RUN   TestAccVpcV1EipDataSource_basic
=== PAUSE TestAccVpcV1EipDataSource_basic
=== CONT  TestAccVpcV1EipDataSource_basic
--- PASS: TestAccVpcV1EipDataSource_basic (54.90s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 54.971s
```