### PR TITLE
enhance: add partitions attribute for dis stream

### DIFF
--- a/docs/resources/dis_stream.md
+++ b/docs/resources/dis_stream.md
@@ -1,0 +1,66 @@
+---
+subcategory: "Data Ingestion Service (DIS)"
+---
+
+# flexibleengine_dis_stream
+
+Manages DIS Stream resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_dis_stream" "stream" {
+  name            = "dis-demo"
+  partition_count = 3
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String, ForceNew) Specifies the name of the DIS stream to be created.
+  Changing this will create a new resource.
+
+* `partition_count` - (Required, Int, ForceNew) Specifies the number of the expect partitions.
+  Changing this will create a new resource.
+
+* `type` - (Optional, String, ForceNew) Specifies the Stream type. The value can be *COMMON* or *ADVANCED*.
+  Defaults to *COMMON*. Changing this will create a new resource.
+
+  + **COMMON stream:**
+    Each partition supports a read speed of up to 2 MB/s and a write speed of up to 1000 records/s and 1 MB/s.
+
+  + **ADVANCED stream:**
+    Each partition supports a read speed of up to 10 MB/s and a write speed of up to 2000 records/s and 5 MB/s.
+
+* `retention_period` - (Optional, Int, ForceNew) Specifies the number of hours for which data from the stream
+  will be retained in DIS. The value ranges from 24 to 168 and defaults to 24. Changing this will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which equals to stream name.
+
+* `status` - Status of stream: `CREATING`,`RUNNING`,`TERMINATING`,`TERMINATED`,`FROZEN`.
+
+* `partitions` - The information of stream partitions. Structure is documented below.
+
+The `partitions` block contains:
+
+* `id` - The ID of the partition.
+
+* `status` - The status of the partition.
+
+* `hash_range` - Possible value range of the hash key used by each partition.
+
+* `sequence_number_range` - Sequence number range of each partition.
+
+## Import
+
+Dis stream can be imported by `name`. For example,
+
+```
+terraform import flexibleengine_dis_stream.example dis-demo
+```

--- a/flexibleengine/resource_flexibleengine_dis_stream_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_dis_stream_v2_test.go
@@ -25,10 +25,18 @@ func TestAccDisStreamV2_basic(t *testing.T) {
 					testAccCheckDisStreamV2Exists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "name", streamName),
 					resource.TestCheckResourceAttr(resourceName, "type", streams.StreamTypeCommon),
-					resource.TestCheckResourceAttr(resourceName, "partition_count", "3"),
 					resource.TestCheckResourceAttr(resourceName, "data_duration", "24"),
-					// resource.TestCheckResourceAttr(resourceName, "data_schema"),
+					resource.TestCheckResourceAttr(resourceName, "partition_count", "3"),
+					resource.TestCheckResourceAttr(resourceName, "partitions.#", "3"),
 				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"type",
+				},
 			},
 		},
 	})


### PR DESCRIPTION
fixes #620

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDisStreamV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDisStreamV2_basic -timeout 720m
=== RUN   TestAccDisStreamV2_basic
=== PAUSE TestAccDisStreamV2_basic
=== CONT  TestAccDisStreamV2_basic
--- PASS: TestAccDisStreamV2_basic (7.87s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 7.885s
```