### PR TITLE
feat: add new resource flexibleengine_mrs_cluster_v2

### DIFF
--- a/docs/resources/mrs_cluster_v2.md
+++ b/docs/resources/mrs_cluster_v2.md
@@ -1,0 +1,563 @@
+---
+subcategory: "MapReduce Service (MRS)"
+---
+
+# flexibleengine_mrs_cluster_v2
+
+Manages a cluster resource within FlexibleEngine MRS.
+
+## Example Usage
+
+### Create an analysis cluster
+
+```hcl
+variable "mrs_az" {}
+variable "cluster_name" {}
+variable "password" {}
+variable "keypair" {}
+variable "vpc_id" {}
+variable "subnet_id" {}
+
+resource "flexibleengine_mrs_cluster_v2" "test" {
+  availability_zone  = var.mrs_az
+  name               = var.cluster_name
+  version            = "MRS 2.0.1"
+  type               = "ANALYSIS"
+  component_list     = ["Hadoop", "Spark", "Hive", "Tez"]
+  manager_admin_pwd  = var.password
+  node_key_pair      = var.keypair
+  vpc_id             = var.vpc_id
+  subnet_id          = var.subnet_id
+
+  master_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 2
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+  analysis_core_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 3
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+```
+
+### Create a stream cluster
+
+```hcl
+variable "mrs_az" {}
+variable "cluster_name" {}
+variable "password" {}
+variable "keypair" {}
+variable "vpc_id" {}
+variable "subnet_id" {}
+
+resource "flexibleengine_mrs_cluster_v2" "test" {
+  availability_zone  = var.mrs_az
+  name               = var.cluster_name
+  type               = "STREAMING"
+  version            = "MRS 3.1.0-LTS.1"
+  manager_admin_pwd  = var.password
+  node_key_pair      = var.keypair
+  vpc_id             = var.vpc_id
+  subnet_id          = var.subnet_id
+  component_list     = ["Ranger", "Kafka", "ZooKeeper"]
+
+  master_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 2
+    root_volume_type  = "SAS"
+    root_volume_size  = 480
+    data_volume_type  = "SAS"
+    data_volume_size  = 600
+    data_volume_count = 1
+  }
+  streaming_core_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 3
+    root_volume_type  = "SAS"
+    root_volume_size  = 480
+    data_volume_type  = "SAS"
+    data_volume_size  = 600
+    data_volume_count = 1
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+```
+
+### Create a hybrid cluster
+
+```hcl
+variable "mrs_az" {}
+variable "cluster_name" {}
+variable "password" {}
+variable "keypair" {}
+variable "vpc_id" {}
+variable "subnet_id" {}
+
+resource "flexibleengine_mrs_cluster_v2" "test" {
+  availability_zone  = var.mrs_az
+  name               = var.cluster_name
+  version            = "MRS 2.0.1"
+  type               = "MIXED"
+  component_list     = ["Hadoop", "Spark", "Hive", "Tez", "Storm"]
+  manager_admin_pwd  = var.password
+  node_key_pair      = var.keypair
+  vpc_id             = var.vpc_id
+  subnet_id          = var.subnet_id
+
+  master_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 2
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+  analysis_core_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 2
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+  streaming_core_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 2
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+  analysis_task_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 1
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+  streaming_task_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 1
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+```
+
+### Create a custom cluster
+
+```hcl
+variable "mrs_az" {}
+variable "cluster_name" {}
+variable "password" {}
+variable "keypair" {}
+variable "vpc_id" {}
+variable "subnet_id" {}
+
+resource "flexibleengine_mrs_cluster_v2" "test" {
+  availability_zone  = var.mrs_az
+  name               = var.cluster_name
+  version            = "MRS 3.1.0-LTS.1"
+  type               = "CUSTOM"
+  safe_mode          = true
+  manager_admin_pwd  = var.password
+  node_key_pair      = var.keypair
+  vpc_id             = var.vpc_id
+  subnet_id          = var.subnet_id
+  template_id        = "mgmt_control_combined_v4"
+  component_list     = ["DBService", "Hadoop", "ZooKeeper", "Ranger"]
+
+  master_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 3
+    root_volume_type  = "SAS"
+    root_volume_size  = 480
+    data_volume_type  = "SAS"
+    data_volume_size  = 600
+    data_volume_count = 1
+    assigned_roles = [
+      "OMSServer:1,2",
+      "SlapdServer:1,2",
+      "KerberosServer:1,2",
+      "KerberosAdmin:1,2",
+      "quorumpeer:1,2,3",
+      "NameNode:2,3",
+      "Zkfc:2,3",
+      "JournalNode:1,2,3",
+      "ResourceManager:2,3",
+      "JobHistoryServer:3",
+      "DBServer:1,3",
+      "HttpFS:1,3",
+      "TimelineServer:3",
+      "RangerAdmin:1,2",
+      "UserSync:2",
+      "TagSync:2",
+      "KerberosClient",
+      "SlapdClient",
+      "meta"
+    ]
+  }
+
+  custom_nodes {
+    group_name        = "node_group_1"
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 4
+    root_volume_type  = "SAS"
+    root_volume_size  = 480
+    data_volume_type  = "SAS"
+    data_volume_size  = 600
+    data_volume_count = 1
+    assigned_roles = [
+      "DataNode",
+      "NodeManager",
+      "KerberosClient",
+      "SlapdClient",
+      "meta"
+    ]
+  }
+}
+
+```
+
+### Create an analysis cluster and bind public IP
+
+```hcl
+variable "mrs_az" {}
+variable "cluster_name" {}
+variable "password" {}
+variable "keypair" {}
+variable "vpc_id" {}
+variable "subnet_id" {}
+variable "public_ip" {}
+
+resource "flexibleengine_mrs_cluster_v2" "test" {
+  availability_zone  = var.mrs_az
+  name               = var.cluster_name
+  version            = "MRS 2.0.1"
+  type               = "ANALYSIS"
+  component_list     = ["Hadoop", "Hive", "Tez"]
+  manager_admin_pwd  = var.password
+  node_key_pair      = var.keypair
+  vpc_id             = var.vpc_id
+  subnet_id          = var.subnet_id
+  public_ip          = var.public_ip
+
+  master_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 2
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+  analysis_core_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 2
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+  analysis_task_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 1
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the MRS cluster resource. If omitted, the
+  provider-level region will be used. Changing this will create a new MRS cluster resource.
+
+* `availability_zone` - (Required, String, ForceNew) Specifies the availability zone in which to create the cluster.
+  Changing this will create a new MRS cluster resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the MRS cluster. The name can contain 2 to 64
+  characters, which may consist of letters, digits, underscores (_) and hyphens (-). Changing this will create a new
+  MRS cluster resource.
+
+* `version` - (Required, String, ForceNew) Specifies the MRS cluster version. Currently, `MRS 1.8.9`,
+  `MRS 2.0.1`, and `MRS 3.1.0-LTS.1` are supported. Changing this will create a new MRS cluster resource.
+
+* `type` - (Optional, String, ForceNew) Specifies the type of the MRS cluster. The valid values are *ANALYSIS*,
+  *STREAMING*, *MIXED* and *CUSTOM* (supported in MRS 3.x only), default to *ANALYSIS*. 
+  Changing this will create a new MRS cluster resource.
+
+* `component_list` - (Required, List, ForceNew) Specifies the list of component names.
+  Changing this will create a new MRS cluster resource. The supported components are as follows:
+
+    <table border="2">
+      <tr>
+          <th>Cluster Version</th>
+          <th>Cluster Type</th>
+          <th>Components</th>
+      </tr>
+      <tr>
+          <td rowspan="4">MRS 3.1.0-LTS.1</td>
+          <td>analysis</td>
+          <td>Hadoop, Spark2x, HBase, Hive, Hue, HetuEngine, Loader, Flink, Oozie, ZooKeeper, Ranger, and Tez</td>
+      </tr>
+      <tr>
+          <td>streaming</td>
+          <td>Kafka, Flume, ZooKeeper, and Ranger</td>
+      </tr>
+      <tr>
+          <td>hybrid</td>
+          <td>Hadoop, Spark2x, HBase, Hive, Hue, HetuEngine, Loader, Flink, Oozie, ZooKeeper, Ranger, Tez, Kafka, and Flume</td>
+      </tr>
+      <tr>
+          <td>custom</td>
+          <td>Hadoop, Spark2x, HBase, Hive, Hue, HetuEngine, Loader, Kafka, Flume, Flink, Oozie, ZooKeeper, Ranger, Tez, and ClickHouse</td>
+      </tr>
+      <tr>
+          <td rowspan="2">MRS 2.0.1</td>
+          <td>analysis</td>
+          <td>Presto, Hadoop, Spark, HBase, Hive, Hue, Loader, and Tez</td>
+      </tr>
+      <tr>
+          <td>streaming</td>
+          <td>Kafka, Storm, and Flume</td>
+      </tr>
+      <tr>
+          <td rowspan="2">MRS 1.8.9</td>
+          <td>analysis</td>
+          <td>Presto, Hadoop, Spark, HBase, Opentsdb, Hive, Hue, Loader, and Flink</td>
+      </tr>
+      <tr>
+          <td>streaming</td>
+          <td>Kafka, KafkaManager, Storm, and Flume</td>
+      </tr>
+    </table>
+
+* `master_nodes` - (Required, List, ForceNew) Specifies a list of the informations about the master nodes in the
+  MRS cluster.
+  The nodes object structure of the `master_nodes` is documented below.
+  Changing this will create a new MRS cluster resource.
+
+* `vpc_id` - (Required, String, ForceNew) Specifies the ID of the VPC which bound to the MRS cluster.
+  Changing this will create a new MRS cluster resource.
+
+* `subnet_id` - (Required, String, ForceNew) Specifies the network ID of a subnet which bound to the MRS cluster.
+  Changing this will create a new MRS cluster resource.
+
+* `manager_admin_pwd` - (Required, String, ForceNew) Specifies the administrator password, which is used to login to
+  the cluster management page. The password can contain 8 to 26 charactors and cannot be the username or the username
+  spelled backwards. The password must contain lowercase letters, uppercase letters, digits, spaces and the special
+  characters: `!?,.:-_{}[]@$^+=/`. Changing this will create a new MRS cluster resource.
+
+* `node_key_pair` - (Required, String, ForceNew) Specifies the name of a key pair, which is used to login to the each
+  nodes(ECSs). Changing this will create a new MRS cluster resource.
+
+* `public_ip` - (Optional, String, ForceNew) Specifies the EIP address which bound to the MRS cluster.
+  The EIP must have been created and must be in the same region as the cluster.
+  Changing this will create a new MRS cluster resource.
+
+* `eip_id` - (Optional, String, ForceNew) Specifies the EIP ID which bound to the MRS cluster.
+  The EIP must have been created and must be in the same region as the cluster.
+  Changing this will create a new MRS cluster resource.
+
+* `log_collection` - (Optional, Bool, ForceNew) Specifies whether logs are collected when cluster installation fails.
+  Default to true. If `log_collection` set true, the OBS buckets will be created and only used to collect logs that
+  record MRS cluster creation failures. Changing this will create a new MRS cluster resource.
+
+* `safe_mode` - (Optional, Bool, ForceNew) Specifies whether the running mode of the MRS cluster is secure,
+  default to true.
+  + true: enable Kerberos authentication.
+  + false: disable Kerberos authentication. Changing this will create a new MRS cluster resource.
+
+* `security_group_ids` - (Optional, List, ForceNew) Specifies an array of one or more security group ID to attach to the
+  MRS cluster. If using the specified security group, the group need to open the specified port (9022) rules.
+
+* `template_id` - (Optional, List, ForceNew) Specifies the template used for node deployment when the cluster type is
+  CUSTOM.
+  + mgmt_control_combined_v2: template for jointly deploying the management and control nodes. The management and
+    control roles are co-deployed on the Master node, and data instances are deployed in the same node group. This
+    deployment mode applies to scenarios where the number of control nodes is less than 100, reducing costs.
+  + mgmt_control_separated_v2: The management and control roles are deployed on different master nodes, and data
+    instances are deployed in the same node group. This deployment mode is applicable to a cluster with 100 to 500 nodes
+    and delivers better performance in high-concurrency load scenarios.
+  + mgmt_control_data_separated_v2: The management role and control role are deployed on different Master nodes,
+    and data instances are deployed in different node groups. This deployment mode is applicable to a cluster with more
+    than 500 nodes. Components can be deployed separately, which can be used for a larger cluster scale.
+
+* `analysis_core_nodes` - (Optional, List) Specifies a list of the informations about the analysis core nodes in the
+  MRS cluster.
+  The nodes object structure of the `analysis_core_nodes` is documented below.
+
+* `streaming_core_nodes` - (Optional, List) Specifies a list of the informations about the streaming core nodes in the
+  MRS cluster.
+  The nodes object structure of the `streaming_core_nodes` is documented below.
+
+* `analysis_task_nodes` - (Optional, List) Specifies a list of the informations about the analysis task nodes in the
+  MRS cluster.
+  The nodes object structure of the `analysis_task_nodes` is documented below.
+
+* `streaming_task_nodes` - (Optional, List) Specifies a list of the informations about the streaming task nodes in the
+  MRS cluster.
+  The nodes object structure of the `streaming_task_nodes` is documented below.
+
+* `custom_nodes` - (Optional, List) Specifies a list of the informations about the custom nodes in the MRS cluster.
+  The nodes object structure of the `custom_nodes` is documented below.
+  Unlike other nodes, it needs to specify group_name.
+
+* `tags` - (Optional, Map, ForceNew) Specifies the key/value pairs to associate with the cluster.
+
+The `nodes` block supports:
+
+* `flavor` - (Required, String, ForceNew) Specifies the instance specifications for each nodes in node group.
+  Changing this will create a new MRS cluster resource.
+
+* `node_number` - (Required, Int) Specifies the number of nodes for the node group.
+  Only the core group and task group updations are allowed. The number of nodes after scaling cannot be
+  less than the number of nodes originally created.
+
+* `root_volume_type` - (Required, String, ForceNew) Specifies the system disk flavor of the nodes. Changing this will
+  create a new MRS cluster resource.
+
+* `root_volume_size` - (Required, Int, ForceNew) Specifies the system disk size of the nodes. Changing this will create
+  a new MRS cluster resource.
+
+* `data_volume_count` - (Required, Int, ForceNew) Specifies the data disk number of the nodes. The number configuration
+  of each node are as follows:
+  + master_nodes: 1.
+  + analysis_core_nodes: minimum is one and the maximum is subject to the configuration of the corresponding flavor.
+  + streaming_core_nodes: minimum is one and the maximum is subject to the configuration of the corresponding flavor.
+  + analysis_task_nodes: minimum is zero and the maximum is subject to the configuration of the corresponding flavor.
+  + streaming_task_nodes: minimum is zero and the maximum is subject to the configuration of the corresponding flavor.
+
+  Changing this will create a new MRS cluster resource.
+  
+* `data_volume_type` - (Optional, String, ForceNew) Specifies the data disk flavor of the nodes.
+  Required if `data_volume_count` is greater than zero. Changing this will create a new MRS cluster resource.
+   The following disk types are supported:
+  + `SATA`: common I/O disk
+  + `SAS`: high I/O disk
+  + `SSD`: ultra-high I/O disk
+
+* `data_volume_size` - (Optional, Int, ForceNew) Specifies the data disk size of the nodes,in GB. The value range is 10
+  to 32768. Required if `data_volume_count` is greater than zero. Changing this will create a new MRS cluster resource.
+
+* `group_name` - (Optional, String, ForceNew) Specifies the name of nodes for the node group.
+  This argument is mandatory when the cluster type is CUSTOM.
+
+* `assigned_roles` - (Optional, List, ForceNew) Specifies the roles deployed in a node group. This argument is mandatory
+  when the cluster type is CUSTOM. Each character string represents a role expression.
+
+  **Role expression definition:**
+
+   + If the role is deployed on all nodes in the node group, set this parameter to role_name, for example: `DataNode`.
+   + If the role is deployed on a specified subscript node in the node group: role_name:index1,index2..., indexN,
+     for example: `DataNode:1,2`. The subscript starts from 1.
+   + Some roles support multi-instance deployment (that is, multiple instances of the same role are deployed on a node):
+      role_name[instance_count], for example: `EsNode[9]`.
+  
+  [Mapping between roles and components](https://docs.prod-cloud-ocb.orange-business.com/api/mrs/mrs_02_0106.html)
+
+  -> `DBService` is a basic component of a cluster. Components such as Hive, Hue, Oozie, Loader, and Redis, and Loader
+   store their metadata in DBService, and provide the metadata backup and restoration functions by using DBService.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The cluster ID in UUID format.
+* `total_node_number` - The total number of nodes deployed in the cluster.
+* `master_node_ip` - The IP address of the master node.
+* `private_ip` - The preferred private IP address of the master node.
+* `status` - The cluster state, which include: running, frozen, abnormal and failed.
+* `create_time` - The cluster creation time, in RFC-3339 format.
+* `update_time` - The cluster update time, in RFC-3339 format.
+* `charging_start_time` - The charging start time which is the start time of billing, in RFC-3339 format.
+* `node` - all the nodes attributes: master_nodes/analysis_core_nodes/streaming_core_nodes/analysis_task_nodes
+/streaming_task_nodes.
+* `host_ips` - The host list of this nodes group in the cluster.
+
+The `components` attributes:
+
+* `id` - Component ID. For example, component_id of Hadoop is MRS 3.1.0-LTS.1_001,
+  MRS 2.0.1_001, and MRS 1.8.9_001.
+* `name` - Component name.
+* `version` - Component version.
+* `description` - Component description.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minute.
+* `update` - Default is 180 minute.
+* `delete` - Default is 40 minute.
+
+## Import
+
+Clusters can be imported by their `id`. For example,
+
+```
+terraform import flexibleengine_mrs_cluster_v2.test b11b407c-e604-4e8d-8bc4-92398320b847
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attrubutes missing from the
+API response, security or some other reason. The missing attributes include:
+`manager_admin_pwd`, `template_id` and `assigned_roles`.
+It is generally recommended running `terraform plan` after importing a cluster.
+You can then decide if changes should be applied to the cluster, or the resource definition
+should be updated to align with the cluster. Also you can ignore changes as below.
+
+```
+resource "flexibleengine_mrs_cluster_v2" "test" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      manager_admin_pwd,
+    ]
+  }
+}
+```

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -267,6 +267,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_lb_l7rule_v2":                       resourceL7RuleV2(),
 			"flexibleengine_mrs_hybrid_cluster_v1":              resourceMRSHybridClusterV1(),
 			"flexibleengine_mrs_cluster_v1":                     resourceMRSClusterV1(),
+			"flexibleengine_mrs_cluster_v2":                     resourceMRSClusterV2(),
 			"flexibleengine_mrs_job_v1":                         resourceMRSJobV1(),
 			"flexibleengine_mrs_job_v2":                         resourceMRSJobV2(),
 			"flexibleengine_mls_instance_v1":                    resourceMlsInstanceV1(),

--- a/flexibleengine/resource_flexibleengine_mrs_cluster_v2.go
+++ b/flexibleengine/resource_flexibleengine_mrs_cluster_v2.go
@@ -1,0 +1,1145 @@
+package flexibleengine
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+	"github.com/chnsz/golangsdk/openstack/mrs/v1/cluster"
+	clusterV2 "github.com/chnsz/golangsdk/openstack/mrs/v2/clusters"
+	"github.com/chnsz/golangsdk/openstack/networking/v1/eips"
+	"github.com/chnsz/golangsdk/openstack/networking/v1/subnets"
+	"github.com/chnsz/golangsdk/openstack/networking/v1/vpcs"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const (
+	typeAnalysis = "ANALYSIS"
+	typeStream   = "STREAMING"
+	typeHybrid   = "MIXED"
+	typeCustom   = "CUSTOM"
+
+	masterGroup        = "master_node_default_group"
+	analysisCoreGroup  = "core_node_analysis_group"
+	streamingCoreGroup = "core_node_streaming_group"
+	analysisTaskGroup  = "task_node_analysis_group"
+	streamingTaskGroup = "task_node_streaming_group"
+	customNodeGroup    = "Core"
+
+	mrsHostDefaultPageNum  = 1
+	mrsHostDefaultPageSize = 100
+)
+
+type stateRefresh struct {
+	Pending      []string
+	Target       []string
+	Timeout      time.Duration
+	Delay        time.Duration
+	PollInterval time.Duration
+}
+
+func resourceMRSClusterV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceMRSClusterV2Create,
+		Read:   resourceMRSClusterV2Read,
+		Update: resourceMRSClusterV2Update,
+		Delete: resourceMRSClusterV2Delete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(1 * time.Hour),
+			Update: schema.DefaultTimeout(3 * time.Hour),
+			Delete: schema.DefaultTimeout(40 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringMatch(
+					regexp.MustCompile("^[A-Za-z][A-Za-z0-9_-]{1,63}$"),
+					"The name consists of 2 to 64 characters, starting with a letter. "+
+						"Only letters, digits, hyphens (-) and underscores (_) are allowed."),
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  typeAnalysis,
+				ValidateFunc: validation.StringInSlice([]string{
+					typeAnalysis, typeStream, typeHybrid, typeCustom,
+				}, false),
+			},
+			"component_list": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"manager_admin_pwd": {
+				Type:      schema.TypeString,
+				Required:  true,
+				Sensitive: true,
+				ForceNew:  true,
+			},
+			"node_key_pair": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"eip_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"public_ip": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"log_collection": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				ForceNew: true,
+			},
+			"safe_mode": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  true,
+			},
+			"security_group_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"template_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"master_nodes": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem:     nodeGroupSchemaResource("master_node_default_group", false, 1, 9),
+			},
+			"analysis_core_nodes": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem:     nodeGroupSchemaResource("core_node_analysis_group", true, 1, 500),
+			},
+			"streaming_core_nodes": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem:     nodeGroupSchemaResource("core_node_streaming_group", true, 1, 500),
+			},
+			"analysis_task_nodes": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem:     nodeGroupSchemaResource("task_node_analysis_group", true, 1, 500),
+			},
+			"streaming_task_nodes": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem:     nodeGroupSchemaResource("task_node_streaming_group", true, 1, 500),
+			},
+			"custom_nodes": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem:     nodeGroupSchemaResource("", false, 1, 500),
+			},
+
+			"tags": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"total_node_number": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"master_node_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"private_ip": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"update_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"charging_start_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"components": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"version": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+
+		CustomizeDiff: func(c context.Context, rd *schema.ResourceDiff, i interface{}) error {
+			nodeGroupNameArray := [6]string{"master_nodes", "analysis_core_nodes", "analysis_task_nodes",
+				"streaming_core_nodes", "streaming_task_nodes", "custom_nodes"}
+
+			for _, nodeGroupName := range nodeGroupNameArray {
+				checkKey := fmt.Sprintf("%s.0.node_number", nodeGroupName)
+				changeKey := fmt.Sprintf("%s.0.host_ips", nodeGroupName)
+				if rd.HasChange(checkKey) {
+					log.Printf("[DEBUG] nodeGroup=%s change,triger host_ips SetNewComputed", nodeGroupName)
+					rd.SetNewComputed(changeKey)
+				}
+			}
+			return nil
+		},
+	}
+}
+
+/*
+   for custom node,the groupName should been empty
+*/
+func nodeGroupSchemaResource(groupName string, nodeScalable bool, minNodeNum, maxNodeNum int) *schema.Resource {
+	nodeResource := schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"flavor": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"root_volume_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"root_volume_size": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"data_volume_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"data_volume_size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+			"data_volume_count": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"host_ips": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"assigned_roles": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if clusterType := d.Get("type").(string); clusterType != typeCustom {
+						return true
+					}
+					return false
+				},
+			},
+		},
+	}
+
+	// when custom type,should support user specified name
+	if groupName == "" {
+		nodeResource.Schema["group_name"] = &schema.Schema{
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		}
+	}
+
+	if nodeScalable {
+		nodeResource.Schema["node_number"] = &schema.Schema{
+			Type:         schema.TypeInt,
+			Required:     true,
+			ValidateFunc: validation.IntBetween(minNodeNum, maxNodeNum),
+		}
+	} else {
+		nodeResource.Schema["node_number"] = &schema.Schema{
+			Type:         schema.TypeInt,
+			Required:     true,
+			ForceNew:     true,
+			ValidateFunc: validation.IntBetween(minNodeNum, maxNodeNum),
+		}
+	}
+
+	return &nodeResource
+}
+
+// The 'component_list' type of the request body is string, before body build, it should be conversation from set to string.
+func buildMrsComponents(d *schema.ResourceData) string {
+	components := d.Get("component_list").(*schema.Set)
+	return buildStringBySet(components)
+}
+
+// The 'security_group_ids' type of the request body is string, before body build, it should be conversation from set to string.
+func buildMrsSecurityGroupIds(d *schema.ResourceData) string {
+	secgroupIds := d.Get("security_group_ids").(*schema.Set)
+	return buildStringBySet(secgroupIds)
+}
+
+// The 'log_collection' type of the request body is int,
+func buildLogCollection(d *schema.ResourceData) *int {
+	if d.Get("log_collection").(bool) {
+		return golangsdk.IntToPointer(1)
+	}
+	return golangsdk.IntToPointer(0)
+}
+
+func buildMrsSafeMode(d *schema.ResourceData) string {
+	isSafe := d.Get("safe_mode").(bool)
+	if isSafe {
+		return "KERBEROS"
+	}
+	return "SIMPLE"
+}
+
+func buildStringBySet(set *schema.Set) string {
+	slice := make([]string, set.Len())
+	for i, v := range set.List() {
+		slice[i] = v.(string)
+	}
+	return strings.Join(slice, ",")
+}
+
+// buildMrsClusterNodeGroups is a method which to build a node group list with all node group arguments.
+func buildMrsClusterNodeGroups(d *schema.ResourceData) []clusterV2.NodeGroupOpts {
+	var (
+		groupOpts      []clusterV2.NodeGroupOpts
+		nodeGroupTypes = map[string]string{
+			"master_nodes":         masterGroup,
+			"analysis_core_nodes":  analysisCoreGroup,
+			"analysis_task_nodes":  analysisTaskGroup,
+			"streaming_core_nodes": streamingCoreGroup,
+			"streaming_task_nodes": streamingTaskGroup,
+			"custom_nodes":         customNodeGroup,
+		}
+	)
+	for k, v := range nodeGroupTypes {
+		if optsRaw, ok := d.GetOk(k); ok {
+			opts := buildNodeGroupOpts(d, optsRaw.([]interface{}), v)
+			groupOpts = append(groupOpts, opts...)
+		}
+	}
+	return groupOpts
+}
+
+func buildNodeGroupOpts(d *schema.ResourceData, optsRaw []interface{}, defaultName string) []clusterV2.NodeGroupOpts {
+	var result []clusterV2.NodeGroupOpts
+	for i := 0; i < len(optsRaw); i++ {
+		var nodeGroup = clusterV2.NodeGroupOpts{}
+		opts := optsRaw[i].(map[string]interface{})
+
+		nodeGroup.GroupName = defaultName
+		customName := opts["group_name"]
+		if customName != nil {
+			nodeGroup.GroupName = customName.(string)
+		}
+
+		nodeGroup.NodeSize = opts["flavor"].(string)
+		nodeGroup.NodeNum = opts["node_number"].(int)
+		nodeGroup.RootVolume = &clusterV2.Volume{
+			Type: opts["root_volume_type"].(string),
+			Size: opts["root_volume_size"].(int),
+		}
+		volumeCount := opts["data_volume_count"].(int)
+		if volumeCount != 0 {
+			nodeGroup.DataVolume = &clusterV2.Volume{
+				Type: opts["data_volume_type"].(string),
+				Size: opts["data_volume_size"].(int),
+			}
+		} else {
+			// According to the API rules, when the data disk is not mounted, the parameters in the structure still
+			// need to be filled in (but not used), fill in the system disk data here.
+			nodeGroup.DataVolume = &clusterV2.Volume{
+				Type: opts["root_volume_type"].(string),
+				Size: opts["root_volume_size"].(int),
+			}
+		}
+		nodeGroup.DataVolumeCount = golangsdk.IntToPointer(volumeCount)
+		// This parameter is mandatory when the cluster type is CUSTOM. Specifies the roles deployed in a node group.
+		if clusterType := d.Get("type").(string); clusterType == typeCustom {
+			for _, v := range opts["assigned_roles"].([]interface{}) {
+				nodeGroup.AssignedRoles = append(nodeGroup.AssignedRoles, v.(string))
+			}
+		}
+
+		result = append(result, nodeGroup)
+	}
+	return result
+}
+
+func clusterV2StateRefreshFunc(client *golangsdk.ServiceClient, clusterID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		clusterGet, err := cluster.Get(client, clusterID).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return clusterGet, "DELETED", nil
+			}
+			return nil, "", err
+		}
+		return clusterGet, clusterGet.Clusterstate, nil
+	}
+}
+
+func waitForMrsClusterStateCompleted(client *golangsdk.ServiceClient, id string, refresh stateRefresh) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:      refresh.Pending,
+		Target:       refresh.Target,
+		Refresh:      clusterV2StateRefreshFunc(client, id),
+		Timeout:      refresh.Timeout,
+		Delay:        refresh.Delay,
+		PollInterval: refresh.PollInterval,
+	}
+	_, err := stateConf.WaitForState()
+	if err != nil {
+		//the system will recyle the cluster when creating failed
+		return err
+	}
+	return nil
+}
+
+// addTagsToMrsCluster method is inherited from MRS V1 resources.
+func addTagsToMrsCluster(d *schema.ResourceData, config *Config) error {
+	client, err := config.MrsV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine MRS V1 client: %s", err)
+	}
+
+	tagRaw := d.Get("tags").(map[string]interface{})
+	if len(tagRaw) > 0 {
+		taglist := expandResourceTags(tagRaw)
+		if tagErr := tags.Create(client, "clusters", d.Id(), taglist).ExtractErr(); tagErr != nil {
+			return fmt.Errorf("Error setting tags of MRS cluster %s: %s", d.Id(), tagErr)
+		}
+	}
+	return nil
+}
+
+func resourceMRSClusterV2Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	region := GetRegion(d, config)
+	mrsV1Client, err := config.MrsV1Client(region)
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine MRS V1 client: %s", err)
+	}
+	mrsV2Client, err := config.MrsV2Client(region)
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine MRS V2 client: %s", err)
+	}
+
+	networkingClient, err := config.NetworkingV1Client(region)
+	if err != nil {
+		return fmt.Errorf("Error creating networking client: %s", err)
+	}
+
+	vpcId := d.Get("vpc_id").(string)
+	vpcResp, err := getVpcById(networkingClient, vpcId)
+	if err != nil {
+		return fmt.Errorf("Unable to find the vpc (%s): %s", vpcId, err)
+	}
+	subnetId := d.Get("subnet_id").(string)
+	subnetResp, err := getVpcSubnetById(networkingClient, subnetId)
+	if err != nil {
+		return fmt.Errorf("Unable to find the subnet (%s): %s", subnetId, err)
+	}
+
+	eipId, publicIp, err := queryEipInfo(networkingClient, d.Get("eip_id").(string), d.Get("public_ip").(string))
+	if err != nil {
+		return fmt.Errorf("Unable to find the eip_id=%s,public_ip=%s: %s", d.Get("eip_id").(string),
+			d.Get("public_ip").(string), err)
+	}
+
+	clusterName := d.Get("name").(string)
+	createOpts := &clusterV2.CreateOpts{
+		Region:               region,
+		AvailabilityZone:     d.Get("availability_zone").(string),
+		ClusterVersion:       d.Get("version").(string),
+		ClusterName:          clusterName,
+		ClusterType:          d.Get("type").(string),
+		ManagerAdminPassword: d.Get("manager_admin_pwd").(string),
+		NodeKeypair:          d.Get("node_key_pair").(string),
+		LoginMode:            "KEYPAIR",
+		VpcName:              vpcResp.Name,
+		SubnetId:             subnetId,
+		SubnetName:           subnetResp.Name,
+		EipId:                eipId,
+		EipAddress:           publicIp,
+		Components:           buildMrsComponents(d),
+		LogCollection:        buildLogCollection(d),
+		NodeGroups:           buildMrsClusterNodeGroups(d),
+		SafeMode:             buildMrsSafeMode(d),
+		SecurityGroupsIds:    buildMrsSecurityGroupIds(d),
+		TemplateId:           d.Get("template_id").(string),
+	}
+
+	resp, err := clusterV2.Create(mrsV2Client, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating Cluster: %s", err)
+	}
+	d.SetId(resp.ID)
+
+	refresh := stateRefresh{
+		Pending:      []string{"starting"},
+		Target:       []string{"running"},
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        480 * time.Second,
+		PollInterval: 15 * time.Second,
+	}
+	// check the cluster state and wait for it become running.
+	if err = waitForMrsClusterStateCompleted(mrsV1Client, d.Id(), refresh); err != nil {
+		d.SetId("")
+		return fmt.Errorf("Error waiting for MapReduce cluster (%s) to become ready: %s", clusterName, err)
+	}
+
+	// After MapReduce cluster state become running, add some tags to the cluster.
+	if err = addTagsToMrsCluster(d, config); err != nil {
+		return fmt.Errorf("Error tagging for MapReduce cluster (%s): %s", d.Id(), err)
+	}
+
+	return resourceMRSClusterV2Read(d, meta)
+}
+
+func setMrsClsuterType(d *schema.ResourceData, resp *cluster.Cluster) error {
+	// The returned ClusterType is an 'Int' type, with a value of 0 to 2,
+	// which respectively represent:'ANALYSIS','STREAMING' ,'MIXED' and 'CUSTOM'.
+	clusterType := []string{"ANALYSIS", "STREAMING", "MIXED", "CUSTOM"}
+	if resp.ClusterType >= len(clusterType) || resp.ClusterType < 0 {
+		return fmt.Errorf("The cluster type of the response is '%d', not in the map", resp.ClusterType)
+	}
+	return d.Set("type", clusterType[resp.ClusterType])
+}
+
+func setMrsClsuterSafeMode(d *schema.ResourceData, resp *cluster.Cluster) error {
+	result := true
+	if resp.Safemode == 0 {
+		result = false
+	}
+	return d.Set("safe_mode", result)
+}
+
+func setMRSClusterLogCollection(d *schema.ResourceData, resp *cluster.Cluster) error {
+	result := true
+	if resp.LogCollection == 0 {
+		result = false
+	}
+	return d.Set("log_collection", result)
+}
+
+func setMrsClsuterSecurityGroupIds(d *schema.ResourceData, resp *cluster.Cluster) error {
+	secGroupsIds := strings.Split(resp.Securitygroupsid, ",")
+	return d.Set("security_group_ids", secGroupsIds)
+}
+
+func setMrsClsuterTotalNodeNumber(d *schema.ResourceData, resp *cluster.Cluster) error {
+	totalNodes, err := strconv.Atoi(resp.Totalnodenum)
+	if err != nil {
+		return err
+	}
+	return d.Set("total_node_number", totalNodes)
+}
+
+func setMrsClsuterCreateTimestamp(d *schema.ResourceData, resp *cluster.Cluster) error {
+	createTime, err := strconv.ParseInt(resp.Createat, 10, 64)
+	if err != nil {
+		return err
+	}
+	return d.Set("create_time", utils.FormatTimeStampRFC3339(createTime))
+}
+
+func setMrsClsuterUpdateTimestamp(d *schema.ResourceData, resp *cluster.Cluster) error {
+	updateTime, err := strconv.ParseInt(resp.Updateat, 10, 64)
+	if err != nil {
+		return err
+	}
+	return d.Set("update_time", utils.FormatTimeStampRFC3339(updateTime))
+}
+
+func setMrsClsuterChargingTimestamp(d *schema.ResourceData, resp *cluster.Cluster) error {
+	chargingStartTime, err := strconv.ParseInt(resp.Chargingstarttime, 10, 64)
+	if err != nil {
+		return err
+	}
+	return d.Set("charging_start_time", utils.FormatTimeStampRFC3339(chargingStartTime))
+}
+
+func setMrsClsuterComponentList(d *schema.ResourceData, resp *cluster.Cluster) error {
+	result := make([]interface{}, len(resp.Componentlist))
+	for i, attachment := range resp.Componentlist {
+		result[i] = attachment.Componentname
+	}
+	return d.Set("component_list", result)
+}
+
+func setMrsClsuterComponents(d *schema.ResourceData, resp *cluster.Cluster) error {
+	components := make([]map[string]interface{}, len(resp.Componentlist))
+	for i, attachment := range resp.Componentlist {
+		components[i] = map[string]interface{}{
+			"id":          attachment.Componentid,
+			"name":        attachment.Componentname,
+			"version":     attachment.Componentversion,
+			"description": attachment.Componentdesc,
+		}
+		log.Printf("[DEBUG] components: %v", components)
+	}
+
+	return d.Set("components", components)
+}
+
+func setMrsClusterNodeGroups(d *schema.ResourceData, mrsV1Client *golangsdk.ServiceClient,
+	resp *cluster.Cluster) error {
+	var groupMapDecl = map[string]string{
+		masterGroup:        "master_nodes",
+		analysisCoreGroup:  "analysis_core_nodes",
+		streamingCoreGroup: "streaming_core_nodes",
+		analysisTaskGroup:  "analysis_task_nodes",
+		streamingTaskGroup: "streaming_task_nodes",
+	}
+
+	clustHostMap, err := queryMrsClusterHosts(d, mrsV1Client)
+	if err != nil {
+		return err
+	}
+	var values = make(map[string][]map[string]interface{})
+
+	for _, node := range resp.NodeGroups {
+		value, ok := groupMapDecl[node.GroupName]
+		isCustomNode := false
+		if !ok {
+			value = "custom_nodes"
+			isCustomNode = true
+		}
+
+		groupMap := map[string]interface{}{
+			"node_number":      node.NodeNum,
+			"flavor":           node.NodeSize,
+			"root_volume_type": node.RootVolumeType,
+			"root_volume_size": node.RootVolumeSize,
+		}
+		hostIps := parseHostIps(node.GroupName, isCustomNode, clustHostMap)
+		if len(hostIps) == 0 {
+			log.Printf("[WARN]One nodeGroup lost host_ips information by some internal error,nodeGroup= %+v", node)
+		}
+		groupMap["host_ips"] = hostIps
+
+		if isCustomNode {
+			groupMap["group_name"] = node.GroupName
+		}
+
+		groupMap["assigned_roles"] = node.AssignedRoles
+		if node.DataVolumeCount != 0 {
+			groupMap["data_volume_type"] = node.DataVolumeType
+			groupMap["data_volume_size"] = node.DataVolumeSize
+			groupMap["data_volume_count"] = node.DataVolumeCount
+		}
+		log.Printf("[DEBUG] node group '%s' is : %+v", value, groupMap)
+		values[value] = append(values[value], groupMap)
+	}
+
+	for k, v := range values {
+		// lintignore:R001
+		if err := d.Set(k, v); err != nil {
+			return fmt.Errorf("set nodeGroup %s error", k)
+		}
+	}
+
+	return nil
+}
+
+func parseHostIps(groupName string, isCustomNode bool, clustHostMap map[string][]string) []string {
+	var rt []string
+	if !isCustomNode {
+		if hostIps, ok := clustHostMap[groupName]; ok {
+			rt = append(rt, hostIps...)
+		}
+	} else {
+		key := fmt.Sprintf("%s-%s", customNodeGroup, groupName)
+		if hostIps, ok := clustHostMap[key]; ok {
+			rt = append(rt, hostIps...)
+		}
+	}
+
+	return rt
+}
+
+func setClsuterTags(d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	resourceTags, err := tags.Get(client, "clusters", d.Id()).Extract()
+	if err != nil {
+		return fmt.Errorf("Error Fetching tags of MapReduce cluster form server: %s", err)
+	}
+	tagmap := tagsToMap(resourceTags.Tags)
+	return d.Set("tags", tagmap)
+}
+
+func getMrsClusterFromServer(d *schema.ResourceData, client *golangsdk.ServiceClient) (*cluster.Cluster, error) {
+	resp, err := cluster.Get(client, d.Id()).Extract()
+	if err != nil {
+		return nil, CheckDeleted(d, err, "MapReduce cluster is not exist")
+	}
+	if resp.Clusterstate == "terminated" {
+		d.SetId("")
+		return resp, fmt.Errorf("Retrieved Cluster %s, but it was terminated, abort it", d.Id())
+	}
+	return resp, nil
+}
+
+func resourceMRSClusterV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	client, err := config.MrsV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine MRS client: %s", err)
+	}
+
+	resp, err := getMrsClusterFromServer(d, client)
+	if err != nil {
+		return fmt.Errorf("Error getting MapReduce form server: %s", err)
+	}
+
+	log.Printf("[DEBUG] Retrieved Cluster %s: %#v", d.Id(), resp)
+	d.SetId(resp.Clusterid)
+	mErr := multierror.Append(
+		d.Set("region", resp.Datacenter),
+		d.Set("availability_zone", resp.AvailabilityZone),
+		d.Set("name", resp.Clustername),
+		d.Set("version", resp.Clusterversion),
+		d.Set("node_key_pair", resp.Nodepubliccertname),
+		d.Set("vpc_id", resp.Vpcid),
+		d.Set("subnet_id", resp.Subnetid),
+		d.Set("master_node_ip", resp.Masternodeip),
+		d.Set("private_ip", resp.Privateipfirst),
+		d.Set("status", resp.Clusterstate),
+		d.Set("public_ip", resp.EipAddress),
+		d.Set("eip_id", resp.EipId),
+		setMrsClsuterType(d, resp),
+		setMrsClsuterComponentList(d, resp),
+		setMrsClsuterComponents(d, resp),
+		setMrsClsuterSafeMode(d, resp),
+		setMRSClusterLogCollection(d, resp),
+		setMrsClsuterSecurityGroupIds(d, resp),
+		setMrsClsuterTotalNodeNumber(d, resp),
+		setMrsClsuterCreateTimestamp(d, resp),
+		setMrsClsuterUpdateTimestamp(d, resp),
+		setMrsClsuterChargingTimestamp(d, resp),
+		setMrsClsuterCreateTimestamp(d, resp),
+		setMrsClusterNodeGroups(d, client, resp),
+		setClsuterTags(d, client),
+	)
+	if err := mErr.ErrorOrNil(); err != nil {
+		return fmt.Errorf("Error setting vault fields: %s", err)
+	}
+
+	return nil
+}
+
+// resizeMRSClusterCoreNodes is a method which used to resize core node for each cluster type.
+// The resizeCount is a number of the group size changing, nagetive means scale in group.
+func resizeMRSClusterCoreNodes(client *golangsdk.ServiceClient, id, groupType string, resizeCount int) error {
+	var isScaleOut = "scale_out"
+	if resizeCount < 0 {
+		isScaleOut = "scale_in"
+		resizeCount = -resizeCount
+	}
+	opts := cluster.UpdateOpts{
+		Parameters: cluster.ResizeParameters{
+			ScaleType: isScaleOut,
+			NodeGroup: &groupType,
+			NodeId:    "node_orderadd",
+			Instances: strconv.Itoa(resizeCount),
+		},
+	}
+	_, err := cluster.Update(client, id, opts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error resizing core node")
+	}
+	refresh := stateRefresh{
+		Pending:      []string{"scaling-out", "scaling-in"},
+		Target:       []string{"running"},
+		Delay:        2 * time.Minute,
+		Timeout:      1 * time.Hour,
+		PollInterval: 15 * time.Second,
+	}
+	if err = waitForMrsClusterStateCompleted(client, id, refresh); err != nil {
+		return fmt.Errorf("Error waiting for Mrs cluster resize to be complated: %s", err)
+	}
+	return nil
+}
+
+// resizeMRSClusterTaskNodes is a method which use to scale out/in the (analysis/streaming) nodes.
+func resizeMRSClusterTaskNodes(client *golangsdk.ServiceClient, id, groupType string, oldList, newList []interface{},
+	resizeCount int) error {
+	var isScaleOut = "scale_out"
+	newRaw := newList[0].(map[string]interface{})
+
+	if resizeCount < 0 {
+		isScaleOut = "scale_in"
+		resizeCount = -resizeCount
+	}
+	params := cluster.ResizeParameters{
+		ScaleType: isScaleOut,
+		NodeGroup: &groupType,
+		NodeId:    "node_orderadd", // Fixed value of resize request
+		Instances: strconv.Itoa(resizeCount),
+	}
+	if len(oldList) == 0 {
+		params.TaskNodeInfo = &cluster.TaskNodeInfo{
+			NodeSize:        newRaw["flavor"].(string),
+			DataVolumeType:  newRaw["data_volume_type"].(string),
+			DataVolumeSize:  newRaw["data_volume_size"].(int),
+			DataVolumeCount: newRaw["data_volume_count"].(int),
+		}
+	}
+	opts := cluster.UpdateOpts{
+		Parameters: params,
+	}
+	_, err := cluster.Update(client, id, opts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error resizing task node")
+	}
+	refresh := stateRefresh{
+		Pending:      []string{"scaling-out", "scaling-in"},
+		Target:       []string{"running"},
+		Delay:        2 * time.Minute,
+		Timeout:      1 * time.Hour,
+		PollInterval: 15 * time.Second,
+	}
+	if err = waitForMrsClusterStateCompleted(client, id, refresh); err != nil {
+		return fmt.Errorf("Error waiting for Mrs cluster resize to be complated: %s", err)
+	}
+	return nil
+}
+
+// the getNodeResizeNumber is a method which use to calculate the number of the group resize option.
+func getNodeResizeNumber(oldList, newList []interface{}) int {
+	newNode := newList[0].(map[string]interface{})
+	newSize := newNode["node_number"].(int)
+	if len(oldList) == 0 {
+		return newSize
+	}
+	oldNode := oldList[0].(map[string]interface{})
+	oldSize := oldNode["node_number"].(int)
+	// Distinguish scale out and scale in by positive and negative
+	return newSize - oldSize
+}
+
+// calculate the number of the custom group resize option. Dont support add new nodeGroup
+func parseCustomNodeResize(oldList, newList []interface{}) map[string]int {
+	var rst = make(map[string]int)
+
+	for newIndex := 0; newIndex < len(oldList); newIndex++ {
+		newNode := newList[newIndex].(map[string]interface{})
+
+		groupName := newNode["group_name"].(string)
+		newSize := newNode["node_number"].(int)
+
+		oldNode := oldList[newIndex].(map[string]interface{})
+		oldSize := oldNode["node_number"].(int)
+
+		// Distinguish scale out and scale in by positive and negative
+		rst[groupName] = newSize - oldSize
+	}
+	return rst
+}
+
+func updateMRSClusterNodes(d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	clusterType := d.Get("type").(string)
+	if clusterType == typeAnalysis || clusterType == typeHybrid {
+		if d.HasChange("analysis_core_nodes") {
+			oldRaws, newRaws := d.GetChange("analysis_core_nodes")
+			num := getNodeResizeNumber(oldRaws.([]interface{}), newRaws.([]interface{}))
+			err := resizeMRSClusterCoreNodes(client, d.Id(), analysisCoreGroup, num)
+			if err != nil {
+				return err
+			}
+		}
+		if d.HasChange("analysis_task_nodes") {
+			oldRaws, newRaws := d.GetChange("analysis_task_nodes")
+			num := getNodeResizeNumber(oldRaws.([]interface{}), newRaws.([]interface{}))
+			err := resizeMRSClusterTaskNodes(client, d.Id(), analysisTaskGroup,
+				oldRaws.([]interface{}), newRaws.([]interface{}), num)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	if clusterType == typeStream || clusterType == typeHybrid {
+		if d.HasChange("streaming_core_nodes") {
+			oldRaws, newRaws := d.GetChange("streaming_core_nodes")
+			num := getNodeResizeNumber(oldRaws.([]interface{}), newRaws.([]interface{}))
+			err := resizeMRSClusterCoreNodes(client, d.Id(), streamingCoreGroup, num)
+			if err != nil {
+				return err
+			}
+		}
+		if d.HasChange("streaming_task_nodes") {
+			oldRaws, newRaws := d.GetChange("streaming_task_nodes")
+			num := getNodeResizeNumber(oldRaws.([]interface{}), newRaws.([]interface{}))
+			err := resizeMRSClusterTaskNodes(client, d.Id(), streamingTaskGroup,
+				oldRaws.([]interface{}), newRaws.([]interface{}), num)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if clusterType == typeCustom {
+		if d.HasChange("custom_nodes") {
+			oldRaws, newRaws := d.GetChange("custom_nodes")
+			scaleMap := parseCustomNodeResize(oldRaws.([]interface{}), newRaws.([]interface{}))
+			for k, num := range scaleMap {
+				err := resizeMRSClusterCoreNodes(client, d.Id(), k, num)
+				if err != nil {
+					return err
+				}
+			}
+
+		}
+	}
+
+	return nil
+}
+
+func resourceMRSClusterV2Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	client, err := config.MrsV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine MRS client: %s", err)
+	}
+
+	if d.HasChange("tags") {
+		tagErr := UpdateResourceTags(client, d, "clusters", d.Id())
+		if tagErr != nil {
+			return fmt.Errorf("Error updating tags of MRS cluster:%s, err:%s", d.Id(), tagErr)
+		}
+	}
+
+	// lintignore:R019
+	if d.HasChanges("analysis_core_nodes", "streaming_core_nodes", "analysis_task_nodes",
+		"streaming_task_nodes", "custom_nodes") {
+		err = updateMRSClusterNodes(d, client)
+		if err != nil {
+			return err
+		}
+	}
+
+	return resourceMRSClusterV2Read(d, meta)
+}
+
+func resourceMRSClusterV2Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	client, err := config.MrsV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine MRS client: %s", err)
+	}
+
+	err = cluster.Delete(client, d.Id()).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("Error deleting FlexibleEngine Cluster: %s", err)
+	}
+	refresh := stateRefresh{
+		Pending:      []string{"running", "terminating"},
+		Target:       []string{"terminated", "DELETED"},
+		Delay:        45 * time.Second,
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		PollInterval: 10 * time.Second,
+	}
+	if err = waitForMrsClusterStateCompleted(client, d.Id(), refresh); err != nil {
+		d.SetId("")
+		return fmt.Errorf("Error waiting for Mrs cluster (%s) to be terminated: %s", d.Id(), err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+/*
+	When the host type is core, the map key format: {type}-{groupName},
+	parse from the host name : {clustId}_{groupName}xxxx[-000x]
+*/
+func queryMrsClusterHosts(d *schema.ResourceData, mrsV1Client *golangsdk.ServiceClient) (map[string][]string, error) {
+
+	clusterID := d.Id()
+
+	hostOpts := cluster.HostOpts{
+		CurrentPage: mrsHostDefaultPageNum,
+		PageSize:    mrsHostDefaultPageSize,
+	}
+
+	resp, err := cluster.ListHosts(mrsV1Client, clusterID, hostOpts)
+	if err != nil {
+		return nil, fmt.Errorf("query mapreduce cluster host failed: %s", err)
+	}
+	log.Printf("[DEBUG] Get mapreduce cluster host list response: %#v", resp)
+	hostsMap := make(map[string][]string)
+	if len(resp.Hosts) > 0 {
+		for _, item := range resp.Hosts {
+			switch hostType := item.Type; hostType {
+			case "Master":
+				hostsMap[masterGroup] = append(hostsMap[masterGroup], item.Ip)
+			case "Streaming_Core":
+				hostsMap[streamingCoreGroup] = append(hostsMap[streamingCoreGroup], item.Ip)
+			case "Streaming_Task":
+				hostsMap[streamingTaskGroup] = append(hostsMap[streamingTaskGroup], item.Ip)
+			case "Analysis_Core":
+				hostsMap[analysisCoreGroup] = append(hostsMap[analysisCoreGroup], item.Ip)
+			case "Analysis_Task":
+				hostsMap[analysisTaskGroup] = append(hostsMap[analysisTaskGroup], item.Ip)
+			default:
+				reg := regexp.MustCompile(fmt.Sprintf(`%s_(\w*)\w{4}(-\d{4})?`, clusterID))
+				allSubMatchStr := reg.FindAllStringSubmatch(item.Name, -1)
+				if len(allSubMatchStr) > 0 {
+					key := fmt.Sprintf("%s-%s", hostType, allSubMatchStr[0][1])
+					hostsMap[key] = append(hostsMap[key], item.Ip)
+				} else {
+					return nil, fmt.Errorf("parse host info failed. host=%v", item)
+				}
+
+			}
+		}
+	}
+
+	return hostsMap, nil
+}
+
+// getVpcById is a method to obtain vpc informations from special region through vpc ID.
+func getVpcById(client *golangsdk.ServiceClient, vpcId string) (*vpcs.Vpc, error) {
+	return vpcs.Get(client, vpcId).Extract()
+}
+
+// getVpcSubnetById is a method to obtain subnet informations from special region through subnet ID.
+func getVpcSubnetById(client *golangsdk.ServiceClient, subentId string) (*subnets.Subnet, error) {
+	return subnets.Get(client, subentId).Extract()
+}
+
+func queryEipInfo(client *golangsdk.ServiceClient, eipId, PublicIp string) (string, string, error) {
+	if eipId == "" && PublicIp == "" {
+		return "", "", nil
+	}
+
+	var listOpts eips.ListOpts
+	if eipId != "" {
+		listOpts.Id = []string{eipId}
+	}
+	if PublicIp != "" {
+		listOpts.PublicIp = []string{PublicIp}
+	}
+
+	pages, err := eips.List(client, listOpts).AllPages()
+	if err != nil {
+		return "", "", err
+	}
+
+	allEips, err := eips.ExtractPublicIPs(pages)
+	if err != nil {
+		return "", "", fmt.Errorf("Unable to retrieve eips: %s ", err)
+	}
+
+	if len(allEips) < 1 {
+		return "", "", fmt.Errorf("Unable to retrieve eips")
+	}
+
+	return allEips[0].ID, allEips[0].PublicAddress, nil
+}

--- a/flexibleengine/resource_flexibleengine_mrs_cluster_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_mrs_cluster_v2_test.go
@@ -1,0 +1,785 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/mrs/v1/cluster"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+type GroupNodeNum struct {
+	AnalysisCoreNum int
+	StreamCoreNum   int
+	AnalysisTaskNum int
+	StreamTaskNum   int
+}
+
+func TestAccMrsMapReduceCluster_basic(t *testing.T) {
+	var clusterGet cluster.Cluster
+	resourceName := "flexibleengine_mrs_cluster_v2.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	password := fmt.Sprintf("TF%s%s%d", acctest.RandString(10), acctest.RandStringFromCharSet(1, "-_"),
+		acctest.RandIntRange(0, 99))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMRSV2ClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMrsMapReduceClusterConfig_basic(rName, password),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMRSV2ClusterExists(resourceName, &clusterGet),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "STREAMING"),
+					resource.TestCheckResourceAttr(resourceName, "safe_mode", "true"),
+					resource.TestCheckResourceAttr(resourceName, "status", "running"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+				),
+			},
+			{
+				Config: testAccMrsMapReduceClusterConfig_update(rName, password),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "status", "running"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo1", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "update_value"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"manager_admin_pwd",
+				},
+			},
+		},
+	})
+}
+
+func TestAccMrsMapReduceCluster_analysis(t *testing.T) {
+	var clusterGet cluster.Cluster
+	resourceName := "flexibleengine_mrs_cluster_v2.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	password := fmt.Sprintf("TF%s%s%d", acctest.RandString(10), acctest.RandStringFromCharSet(1, "-_"),
+		acctest.RandIntRange(0, 99))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMRSV2ClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMrsMapReduceClusterConfig_analysis(rName, password, buildGroupNodeNumbers(3, 0, 1, 0)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMRSV2ClusterExists(resourceName, &clusterGet),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "ANALYSIS"),
+					resource.TestCheckResourceAttr(resourceName, "safe_mode", "true"),
+					resource.TestCheckResourceAttr(resourceName, "status", "running"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_core_nodes.0.node_number", "3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_task_nodes.0.node_number", "1"),
+				),
+			},
+			{
+				Config: testAccMrsMapReduceClusterConfig_analysis(rName, password, buildGroupNodeNumbers(4, 0, 2, 0)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "status", "running"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_core_nodes.0.node_number", "4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_task_nodes.0.node_number", "2"),
+				),
+			},
+			{
+				Config: testAccMrsMapReduceClusterConfig_analysis(rName, password, buildGroupNodeNumbers(3, 0, 1, 0)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "status", "running"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_core_nodes.0.node_number", "3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_task_nodes.0.node_number", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"manager_admin_pwd",
+				},
+			},
+		},
+	})
+}
+
+func TestAccMrsMapReduceCluster_stream(t *testing.T) {
+	var clusterGet cluster.Cluster
+	resourceName := "flexibleengine_mrs_cluster_v2.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	password := fmt.Sprintf("TF%s%s%d", acctest.RandString(10), acctest.RandStringFromCharSet(1, "-_"),
+		acctest.RandIntRange(0, 99))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMRSV2ClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMrsMapReduceClusterConfig_stream(rName, password, buildGroupNodeNumbers(0, 3, 0, 0)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMRSV2ClusterExists(resourceName, &clusterGet),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "STREAMING"),
+					resource.TestCheckResourceAttr(resourceName, "safe_mode", "true"),
+					resource.TestCheckResourceAttr(resourceName, "status", "running"),
+					resource.TestCheckResourceAttr(resourceName, "streaming_core_nodes.0.node_number", "3"),
+				),
+			},
+			{
+				Config: testAccMrsMapReduceClusterConfig_stream(rName, password, buildGroupNodeNumbers(0, 4, 0, 0)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "status", "running"),
+					resource.TestCheckResourceAttr(resourceName, "streaming_core_nodes.0.node_number", "4"),
+				),
+			},
+			{
+				Config: testAccMrsMapReduceClusterConfig_stream(rName, password, buildGroupNodeNumbers(0, 3, 0, 0)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "status", "running"),
+					resource.TestCheckResourceAttr(resourceName, "streaming_core_nodes.0.node_number", "3"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"manager_admin_pwd",
+				},
+			},
+		},
+	})
+}
+
+func TestAccMrsMapReduceCluster_hybrid(t *testing.T) {
+	var clusterGet cluster.Cluster
+	resourceName := "flexibleengine_mrs_cluster_v2.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	password := fmt.Sprintf("TF%s%s%d", acctest.RandString(10), acctest.RandStringFromCharSet(1, "-_"),
+		acctest.RandIntRange(0, 99))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMRSV2ClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMrsMapReduceClusterConfig_hybrid(rName, password, buildGroupNodeNumbers(3, 3, 1, 1)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMRSV2ClusterExists(resourceName, &clusterGet),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "MIXED"),
+					resource.TestCheckResourceAttr(resourceName, "safe_mode", "true"),
+					resource.TestCheckResourceAttr(resourceName, "status", "running"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_core_nodes.0.node_number", "3"),
+					resource.TestCheckResourceAttr(resourceName, "streaming_core_nodes.0.node_number", "3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_task_nodes.0.node_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "streaming_task_nodes.0.node_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_core_nodes.0.host_ips.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "streaming_core_nodes.0.host_ips.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_task_nodes.0.host_ips.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "streaming_task_nodes.0.host_ips.#", "1"),
+				),
+			},
+			{
+				Config: testAccMrsMapReduceClusterConfig_hybrid(rName, password, buildGroupNodeNumbers(4, 4, 2, 2)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "status", "running"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_core_nodes.0.node_number", "4"),
+					resource.TestCheckResourceAttr(resourceName, "streaming_core_nodes.0.node_number", "4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_task_nodes.0.node_number", "2"),
+					resource.TestCheckResourceAttr(resourceName, "streaming_task_nodes.0.node_number", "2"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_core_nodes.0.host_ips.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "streaming_core_nodes.0.host_ips.#", "4"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_task_nodes.0.host_ips.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "streaming_task_nodes.0.host_ips.#", "2"),
+				),
+			},
+			{
+				Config: testAccMrsMapReduceClusterConfig_hybrid(rName, password, buildGroupNodeNumbers(3, 3, 1, 1)),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "status", "running"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_core_nodes.0.node_number", "3"),
+					resource.TestCheckResourceAttr(resourceName, "streaming_core_nodes.0.node_number", "3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_task_nodes.0.node_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "streaming_task_nodes.0.node_number", "1"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_core_nodes.0.host_ips.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "streaming_core_nodes.0.host_ips.#", "3"),
+					resource.TestCheckResourceAttr(resourceName, "analysis_task_nodes.0.host_ips.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "streaming_task_nodes.0.host_ips.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"manager_admin_pwd",
+				},
+			},
+		},
+	})
+}
+
+func TestAccMrsMapReduceCluster_custom(t *testing.T) {
+	var clusterGet cluster.Cluster
+	resourceName := "flexibleengine_mrs_cluster_v2.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	password := fmt.Sprintf("TF%s%s%d", acctest.RandString(10), acctest.RandStringFromCharSet(1, "-_"),
+		acctest.RandIntRange(0, 99))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMRSV2ClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMrsMapReduceClusterConfig_custom(rName, password, 3),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMRSV2ClusterExists(resourceName, &clusterGet),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "CUSTOM"),
+					resource.TestCheckResourceAttr(resourceName, "status", "running"),
+					resource.TestCheckResourceAttr(resourceName, "custom_nodes.0.node_number", "3"),
+					resource.TestCheckResourceAttr(resourceName, "custom_nodes.0.host_ips.#", "3"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"manager_admin_pwd",
+					"template_id",
+				},
+			},
+		},
+	})
+}
+
+func TestAccMrsMapReduceCluster_publicIp(t *testing.T) {
+	var clusterGet cluster.Cluster
+	resourceName := "flexibleengine_mrs_cluster_v2.test"
+	eipResourceName := "flexibleengine_vpc_eip_v1.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	bName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	password := fmt.Sprintf("TF%s%s%d", acctest.RandString(10), acctest.RandStringFromCharSet(1, "-_"),
+		acctest.RandIntRange(0, 99))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMRSV2ClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMrsMapReduceClusterConfig_publicIp(rName, password, bName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckMRSV2ClusterExists(resourceName, &clusterGet),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "STREAMING"),
+					resource.TestCheckResourceAttr(resourceName, "safe_mode", "true"),
+					resource.TestCheckResourceAttr(resourceName, "status", "running"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttrPair(resourceName, "eip_id", eipResourceName, "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "public_ip", eipResourceName, "address"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"manager_admin_pwd",
+				},
+			},
+		},
+	})
+}
+
+func buildGroupNodeNumbers(analysisCoreNum, streamCoreNum, analysisTaskNum, streamTaskNum int) GroupNodeNum {
+	return GroupNodeNum{
+		AnalysisCoreNum: analysisCoreNum,
+		StreamCoreNum:   streamCoreNum,
+		AnalysisTaskNum: analysisTaskNum,
+		StreamTaskNum:   streamTaskNum,
+	}
+}
+
+func testAccCheckMRSV2ClusterDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	client, err := config.MrsV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine MRS client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_mrs_cluster_v2" {
+			continue
+		}
+
+		clusterGet, err := cluster.Get(client, rs.Primary.ID).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return nil
+			}
+			return fmt.Errorf("MRS cluster (%s) is still exists", rs.Primary.ID)
+		}
+		if clusterGet.Clusterstate == "terminated" {
+			return nil
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckMRSV2ClusterExists(n string, clusterGet *cluster.Cluster) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Resource %s not found", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No MRS cluster ID")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		mrsClient, err := config.MrsV1Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating FlexibleEngine MRS client: %s ", err)
+		}
+
+		found, err := cluster.Get(mrsClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+		*clusterGet = *found
+		return nil
+	}
+}
+
+func testAccMrsMapReduceClusterConfig_base(rName string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_compute_availability_zones_v2" "test" {}
+
+resource "flexibleengine_vpc_v1" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test" {
+  name       = "%s"
+  cidr       = "192.168.0.0/24"
+  vpc_id     = flexibleengine_vpc_v1.test.id
+  gateway_ip = "192.168.0.1"
+}
+
+resource "flexibleengine_compute_keypair_v2" "test" {
+  name = "%s"
+}`, rName, rName, rName)
+}
+
+// The task node has not contain data disks.
+func testAccMrsMapReduceClusterConfig_basic(rName, pwd string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_mrs_cluster_v2" "test" {
+  availability_zone  = data.flexibleengine_compute_availability_zones_v2.test.names[0]
+  name               = "%s"
+  type               = "STREAMING"
+  version            = "MRS 2.0.1"
+  manager_admin_pwd  = "%s"
+  node_key_pair      = flexibleengine_compute_keypair_v2.test.name
+  subnet_id          = flexibleengine_vpc_subnet_v1.test.id
+  vpc_id             = flexibleengine_vpc_v1.test.id
+  component_list     = ["Storm", "Kafka"]
+
+  master_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 2
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+  streaming_core_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 2
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+  streaming_task_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 1
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_count = 0
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}`, testAccMrsMapReduceClusterConfig_base(rName), rName, pwd)
+}
+
+func testAccMrsMapReduceClusterConfig_update(rName, pwd string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_mrs_cluster_v2" "test" {
+  availability_zone  = data.flexibleengine_compute_availability_zones_v2.test.names[0]
+  name               = "%s"
+  type               = "STREAMING"
+  version            = "MRS 2.0.1"
+  manager_admin_pwd  = "%s"
+  node_key_pair      = flexibleengine_compute_keypair_v2.test.name
+  subnet_id          = flexibleengine_vpc_subnet_v1.test.id
+  vpc_id             = flexibleengine_vpc_v1.test.id
+  component_list     = ["Storm", "Kafka"]
+
+  master_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 2
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+  streaming_core_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 2
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+  streaming_task_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 1
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_count = 0
+  }
+
+  tags = {
+    foo1 = "bar"
+    key  = "update_value"
+  }
+}`, testAccMrsMapReduceClusterConfig_base(rName), rName, pwd)
+}
+
+func testAccMrsMapReduceClusterConfig_analysis(rName, pwd string, nodeNums GroupNodeNum) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_mrs_cluster_v2" "test" {
+  availability_zone  = data.flexibleengine_compute_availability_zones_v2.test.names[0]
+  name               = "%s"
+  type               = "ANALYSIS"
+  version            = "MRS 3.1.0-LTS.1"
+  manager_admin_pwd  = "%s"
+  node_key_pair      = flexibleengine_compute_keypair_v2.test.name
+  subnet_id          = flexibleengine_vpc_subnet_v1.test.id
+  vpc_id             = flexibleengine_vpc_v1.test.id
+  component_list     = ["Hadoop", "Hive", "Tez"]
+
+  master_nodes {
+    flavor            = "s3.4xlarge.4.linux.mrs"
+    node_number       = 2
+    root_volume_type  = "SAS"
+    root_volume_size  = 480
+    data_volume_type  = "SAS"
+    data_volume_size  = 600
+    data_volume_count = 1
+  }
+  analysis_core_nodes {
+    flavor            = "s3.4xlarge.4.linux.mrs"
+    node_number       = %d
+    root_volume_type  = "SAS"
+    root_volume_size  = 480
+    data_volume_type  = "SAS"
+    data_volume_size  = 600
+    data_volume_count = 1
+  }
+  analysis_task_nodes {
+    flavor            = "s3.4xlarge.4.linux.mrs"
+    node_number       = %d
+    root_volume_type  = "SAS"
+    root_volume_size  = 480
+    data_volume_type  = "SAS"
+    data_volume_size  = 600
+    data_volume_count = 1
+  }
+}`, testAccMrsMapReduceClusterConfig_base(rName), rName, pwd,
+		nodeNums.AnalysisCoreNum, nodeNums.AnalysisTaskNum)
+}
+
+func testAccMrsMapReduceClusterConfig_stream(rName, pwd string, nodeNums GroupNodeNum) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_mrs_cluster_v2" "test" {
+  availability_zone  = data.flexibleengine_compute_availability_zones_v2.test.names[0]
+  name               = "%s"
+  type               = "STREAMING"
+  version            = "MRS 3.1.0-LTS.1"
+  manager_admin_pwd  = "%s"
+  node_key_pair      = flexibleengine_compute_keypair_v2.test.name
+  subnet_id          = flexibleengine_vpc_subnet_v1.test.id
+  vpc_id             = flexibleengine_vpc_v1.test.id
+  component_list     = ["Ranger", "Kafka", "ZooKeeper"]
+
+  master_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 2
+    root_volume_type  = "SAS"
+    root_volume_size  = 480
+    data_volume_type  = "SAS"
+    data_volume_size  = 600
+    data_volume_count = 1
+  }
+  streaming_core_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = %d
+    root_volume_type  = "SAS"
+    root_volume_size  = 480
+    data_volume_type  = "SAS"
+    data_volume_size  = 600
+    data_volume_count = 1
+  }
+}`, testAccMrsMapReduceClusterConfig_base(rName), rName, pwd, nodeNums.StreamCoreNum)
+}
+
+func testAccMrsMapReduceClusterConfig_hybrid(rName, pwd string, nodeNums GroupNodeNum) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_mrs_cluster_v2" "test" {
+  availability_zone  = data.flexibleengine_compute_availability_zones_v2.test.names[0]
+  name               = "%s"
+  type               = "MIXED"
+  version            = "MRS 2.0.1"
+  safe_mode          = true
+  manager_admin_pwd  = "%s"
+  node_key_pair      = flexibleengine_compute_keypair_v2.test.name
+  subnet_id          = flexibleengine_vpc_subnet_v1.test.id
+  vpc_id             = flexibleengine_vpc_v1.test.id
+  component_list     = ["Hadoop", "Spark", "Hive", "Tez", "Storm"]
+
+  master_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 2
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+  analysis_core_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = %d
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+  streaming_core_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = %d
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+  analysis_task_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = %d
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+  streaming_task_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = %d
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+}`, testAccMrsMapReduceClusterConfig_base(rName), rName, pwd,
+		nodeNums.AnalysisCoreNum, nodeNums.StreamCoreNum, nodeNums.AnalysisTaskNum, nodeNums.StreamTaskNum)
+}
+
+func testAccMrsMapReduceClusterConfig_custom(rName, pwd string, nodeNum1 int) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_mrs_cluster_v2" "test" {
+  availability_zone  = data.flexibleengine_compute_availability_zones_v2.test.names[0]
+  name               = "%s"
+  type               = "CUSTOM"
+  version            = "MRS 3.1.0-LTS.1"
+  safe_mode          = true
+  manager_admin_pwd  = "%s"
+  node_key_pair      = flexibleengine_compute_keypair_v2.test.name
+  subnet_id          = flexibleengine_vpc_subnet_v1.test.id
+  vpc_id             = flexibleengine_vpc_v1.test.id
+  template_id        = "mgmt_control_combined_v4"
+  component_list     = ["DBService", "Hadoop", "ZooKeeper", "Ranger", "ClickHouse"]
+
+master_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 3
+    root_volume_type  = "SAS"
+    root_volume_size  = 480
+    data_volume_type  = "SAS"
+    data_volume_size  = 600
+    data_volume_count = 1
+    assigned_roles = [
+      "OMSServer:1,2",
+      "SlapdServer:1,2",
+      "KerberosServer:1,2",
+      "KerberosAdmin:1,2",
+      "quorumpeer:1,2,3",
+      "NameNode:2,3",
+      "Zkfc:2,3",
+      "JournalNode:1,2,3",
+      "ResourceManager:2,3",
+      "JobHistoryServer:3",
+      "DBServer:1,3",
+      "HttpFS:1,3",
+      "TimelineServer:3",
+      "RangerAdmin:1,2",
+      "UserSync:2",
+      "TagSync:2",
+      "KerberosClient",
+      "SlapdClient",
+      "meta",
+      "ClickHouseBalancer:1,2"
+    ]
+  }
+
+  custom_nodes {
+    group_name        = "node_group_1"
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = %d
+    root_volume_type  = "SAS"
+    root_volume_size  = 480
+    data_volume_type  = "SAS"
+    data_volume_size  = 600
+    data_volume_count = 1
+    assigned_roles = [
+      "DataNode",
+      "NodeManager",
+      "KerberosClient",
+      "SlapdClient",
+      "meta"
+    ]
+  }
+
+  custom_nodes {
+    group_name        = "ClickHouse"
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 2
+    root_volume_type  = "SAS"
+    root_volume_size  = 480
+    data_volume_type  = "SAS"
+    data_volume_size  = 600
+    data_volume_count = 1
+    assigned_roles = [
+      "ClickHouseServer",
+      "meta",
+      "KerberosClient",
+      "SlapdClient"
+    ]
+  }
+  
+}`, testAccMrsMapReduceClusterConfig_base(rName), rName, pwd, nodeNum1)
+}
+
+func testAccMrsMapReduceClusterConfig_publicIp(rName, pwd, bName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpc_eip_v1" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+	name        = "%s"
+    share_type  = "PER"
+    size        = 5
+    charge_mode = "traffic"
+  }
+}
+
+resource "flexibleengine_mrs_cluster_v2" "test" {
+  availability_zone  = data.flexibleengine_compute_availability_zones_v2.test.names[0]
+  name               = "%s"
+  type               = "STREAMING"
+  version            = "MRS 2.0.1"
+  manager_admin_pwd  = "%s"
+  node_key_pair      = flexibleengine_compute_keypair_v2.test.name
+  subnet_id          = flexibleengine_vpc_subnet_v1.test.id
+  vpc_id             = flexibleengine_vpc_v1.test.id
+  public_ip          = flexibleengine_vpc_eip_v1.test.address
+  component_list     = ["Storm"]
+
+  master_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 2
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+  streaming_core_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 2
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_type  = "SAS"
+    data_volume_size  = 480
+    data_volume_count = 1
+  }
+  streaming_task_nodes {
+    flavor            = "c6.4xlarge.4.linux.mrs"
+    node_number       = 1
+    root_volume_type  = "SAS"
+    root_volume_size  = 300
+    data_volume_count = 0
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}`, testAccMrsMapReduceClusterConfig_base(rName), bName, rName, pwd)
+}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
-	github.com/huaweicloud/terraform-provider-huaweicloud v1.31.0
+	github.com/huaweicloud/terraform-provider-huaweicloud v1.31.1
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -71,7 +71,6 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20211129061956-055d0ed2e3f8/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chnsz/golangsdk v0.0.0-20211210025418-bfef50238f46 h1:43hIUYGkH3u7KBDcRQs2k2748R8xKRGlkie9T7/RJy0=
 github.com/chnsz/golangsdk v0.0.0-20211210025418-bfef50238f46/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -212,8 +211,8 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.31.0 h1:ojdPzQunq4l86dADA4s3/I8gsArfAH1HDl6eJ8RCeSI=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.31.0/go.mod h1:38XygHPvTdGcklj9f3oKXOw8Q+Q1eqSCf4y3cz9jzJo=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.31.1 h1:E6gy6iJHE2K+nvNBznbv7tB6DmHNJ2eRxQqoYOL5gpc=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.31.1/go.mod h1:vzrbD6uGArTipACBzzOzL+bkgO9ux8SoPLnHLzyJmJI=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
@@ -236,6 +235,7 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
+github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4 h1:cTxwSmnaqLoo+4tLukHoB9iqHOu3LmLhRmgUxZo6Vp4=
 github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.11.2 h1:MiK62aErc3gIiVEtyzKfeOHgW7atJb5g/KNX5m3c2nQ=

--- a/vendor/github.com/chnsz/golangsdk/openstack/mrs/v2/clusters/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/mrs/v2/clusters/requests.go
@@ -1,0 +1,396 @@
+package clusters
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+)
+
+// CreateOpts is a structure representing information of the cluster creation.
+type CreateOpts struct {
+	// Region of the cluster.
+	Region string `json:"region" required:"true"`
+	// Availability zone name.
+	AvailabilityZone string `json:"availability_zone" required:"true"`
+	// Cluster name, which can contain 2 to 64 characters.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	ClusterName string `json:"cluster_name" required:"true"`
+	// Cluster type. The options are as follows:
+	//   ANALYSIS: analysis cluster
+	//   STREAMING: streaming cluster
+	//   MIXED: hybrid cluster
+	//   CUSTOM: customized cluster, which is supported only by MRS 3.x.
+	ClusterType string `json:"cluster_type" required:"true"`
+	// Cluster version.
+	// Possible values are as follows:
+	//   MRS 1.8.10
+	//   MRS 1.9.2
+	//   MRS 2.1.0
+	//   MRS 3.0.2
+	ClusterVersion string `json:"cluster_version" required:"true"`
+	// Name of the VPC where the subnet locates
+	// Perform the following operations to obtain the VPC name from the VPC management console:
+	// Log in to the management console.
+	// Click Virtual Private Cloud and select Virtual Private Cloud from the left list.
+	// On the Virtual Private Cloud page, obtain the VPC name from the list.
+	VpcName string `json:"vpc_name" required:"true"`
+	// List of component names, which are separated by commas (,). The options are as follows:
+	// MRS 3.0.5
+	//   ANALYSIS: Hadoop,Spark2x,HBase,Hive,Hue,Loader,Flink,Oozie,ZooKeeper,Ranger,Tez,Impala,Presto,Kudu,Alluxio
+	//   STREAMING: Kafka,Storm,Flume,ZooKeeper,Ranger
+	//   MIXED: Hadoop,Spark2x,HBase,Hive,Hue,Loader,Flink,Oozie,ZooKeeper,Ranger,Tez,Impala,Presto,Kudu,Alluxio,
+	//     Kafka,Storm,Flume
+	//   CUSTOM: Hadoop,Spark2x,HBase,Hive,Hue,Loader,Kafka,Storm,Flume,Flink,Oozie,ZooKeeper,Ranger,Tez,Impala,
+	//     Presto,ClickHouse，Kudu,Alluxio
+	// MRS 1.9.2
+	//   ANALYSIS: Presto,Hadoop,Spark,HBase,Opentsdb,Hive,Hue,Loader,Tez,Flink,Alluxio,Ranger
+	//   STREAMING: Kafka,KafkaManager,Storm,Flume
+	Components string `json:"components" required:"true"`
+	// Node login mode.
+	// PASSWORD: password-based login. If this value is selected, node_root_password cannot be left blank.
+	// KEYPAIR: specifies the key pair used for login. If this value is selected, node_keypair_name cannot be left blank.
+	LoginMode string `json:"login_mode" required:"true"`
+	// Password of the MRS Manager administrator.
+	// The password can contain 8 to 26 charactors.
+	// The password must contain lowercase letters, uppercase letters, digits, spaces
+	// and the special characters: !?,.:-_{}[]@$^+=/.
+	// the password cannot be the username or the username spelled backwards.
+	ManagerAdminPassword string `json:"manager_admin_password" required:"true"`
+	// Information about the node groups in the cluster. For details about the parameters, see Table 5.
+	NodeGroups []NodeGroupOpts `json:"node_groups" required:"true"`
+	// Running mode of an MRS cluster
+	// SIMPLE: normal cluster. In a normal cluster, Kerberos authentication is disabled, and users can use all functions provided by the cluster.
+	// KERBEROS: security cluster. In a security cluster, Kerberos authentication is enabled, and common users cannot use the file management and job management functions of an MRS cluster or view cluster resource usage and the job records of Hadoop and Spark. To use more cluster functions, the users must contact the Manager administrator to assign more permissions.
+	SafeMode string `json:"safe_mode" required:"true"`
+	// Jobs can be submitted when a cluster is created. Currently, only one job can be created. For details about job parameters, see Table 9.
+	AddJobs []JobOpts `json:"add_jobs,omitempty"`
+	// Whether to create the default security group of the MR S security group, the default is false.
+	// If true, no matter what 'security_groups_id' is set, the cluster will create a default security group.
+	AutoCreateSecGroup string `json:"auto_create_default_security_group,omitempty"`
+	// Bootstrap action script information. For more parameter description, see Table 8.
+	// MRS 1.7.2 or later supports this parameter.
+	BootstrapScripts []ScriptOpts `json:"bootstrap_scripts,omitempty"`
+	// Charging type information.
+	ChargeInfo *ChargeInfo `json:"charge_info,omitempty"`
+	// Indicates the enterprise project ID.
+	// When creating a cluster, associate the enterprise project ID with the cluster.
+	// The default value is 0, indicating the default enterprise project.
+	// To obtain the enterprise project ID, see the id value in the enterprise_project field data structure table in section Querying the Enterprise Project List of the Enterprise Management API Reference.
+	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
+	// An EIP bound to an MRS cluster can be used to access MRS Manager. The EIP must have been created and must be in the same region as the cluster.
+	EipAddress string `json:"eip_address,omitempty"`
+	// ID of the bound EIP. This parameter is mandatory when eip_address is configured. To obtain the EIP ID, log in to the VPC console, choose Network > Elastic IP and Bandwidth > Elastic IP, click the EIP to be bound, and obtain the ID in the Basic Information area.
+	EipId string `json:"eip_id,omitempty"`
+	// Indicate whether it is a dedicated cloud resource, the default is false.
+	IsDecProject *bool `json:"is_dec_project,omitempty"`
+	// Specifies whether to collect logs when cluster creation fails:
+	//   0: Do not collect.
+	//   1: Collect.
+	// The default value is 1, indicating that OBS buckets will be created and only used to collect logs that record MRS cluster creation failures.
+	LogCollection *int `json:"log_collection,omitempty"`
+	// Name of the agency bound to a cluster node by default. The value is fixed to MRS_ECS_DEFAULT_AGENCY.
+	// An agency allows ECS or BMS to manage MRS resources. You can configure an agency of the ECS type to automatically obtain the AK/SK to access OBS.
+	// The MRS_ECS_DEFAULT_AGENCY agency has the OBS OperateAccess permission of OBS and the CES FullAccess (for users who have enabled fine-grained policies), CES Administrator, and KMS Administrator permissions in the region where the cluster is located.
+	MrsEcsDefaultAgency string `json:"mrs_ecs_default_agency,omitempty"`
+	// Password of user root for logging in to a cluster node.
+	// The password can contain 8 to 26 charactors.
+	// The password must contain lowercase letters, uppercase letters, digits, spaces
+	// and the special characters: !?,.:-_{}[]@$^+=/.
+	// the password cannot be the username or the username spelled backwards.
+	NodeRootPassword string `json:"node_root_password,omitempty"`
+	// Name of a key pair You can use a key pair to log in to the Master node in the cluster.
+	NodeKeypair string `json:"node_keypair_name,omitempty"`
+	// Security group ID of the cluster
+	// If this parameter is left blank, MRS automatically creates a security group, whose name starts with mrs_{cluster_name}.
+	// If this parameter is not left blank, a fixed security group is used to create a cluster. The transferred ID must be the security group ID owned by the current tenant. The security group must include an inbound rule in which all protocols and all ports are allowed and the source is the IP address of the specified node on the management plane.
+	SecurityGroupsIds string `json:"security_groups_id,omitempty"`
+	// Subnet ID.
+	SubnetId string `json:"subnet_id,omitempty"`
+	// Subnet name.
+	// Required if SubnetID is empty.
+	SubnetName string `json:"subnet_name,omitempty"`
+	// Specifies the template used for node deployment when the cluster type is CUSTOM.
+	// mgmt_control_combined_v2: template for jointly deploying the management and control nodes. The management and control roles are co-deployed on the Master node, and data instances are deployed in the same node group. This deployment mode applies to scenarios where the number of control nodes is less than 100, reducing costs.
+	// mgmt_control_separated_v2: The management and control roles are deployed on different master nodes, and data instances are deployed in the same node group. This deployment mode is applicable to a cluster with 100 to 500 nodes and delivers better performance in high-concurrency load scenarios.
+	// mgmt_control_data_separated_v2: The management role and control role are deployed on different Master nodes, and data instances are deployed in different node groups. This deployment mode is applicable to a cluster with more than 500 nodes. Components can be deployed separately, which can be used for a larger cluster scale.
+	TemplateId string `json:"template_id,omitempty"`
+	// Cluster tag For more parameter description, see Table 4.
+	// A maximum of 10 tags can be added to a cluster.
+	Tags []tags.ResourceTag `json:"tags,omitempty"`
+}
+
+// ChargeInfo is a structure representing billing information.
+type ChargeInfo struct {
+	// Billing mode.
+	// The valid values are as follows:
+	//   postPaid: indicates the pay-per-use billing mode.
+	ChargeMode string `json:"charge_mode" required:"true"`
+}
+
+// NodeGroupOpts is a structure representing node group.
+type NodeGroupOpts struct {
+	// Instance specifications of a node.
+	NodeSize string `json:"node_size" required:"true"`
+	// Specifies the node group name.
+	// The rules for configuring node groups are as follows:
+	//     master_node_default_group: Master node group, which must be included in all cluster types.
+	//     core_node_analysis_group: analysis Core node group, which must be contained in the analysis cluster and
+	//         hybrid cluster.
+	//     core_node_streaming_group: indicates the streaming Core node group, which must be included in both streaming
+	//         and hybrid clusters.
+	//     task_node_analysis_group: Analysis Task node group.
+	//         This node group can be selected for analysis clusters and hybrid clusters as required.
+	//     task_node_streaming_group: streaming Task node group.
+	//         This node group can be selected for streaming clusters and hybrid clusters as required.
+	//     node_group{x}: node group of the customized cluster. A maximum of nine node groups can be added.
+	//         The value can contain a maximum of 64 characters, including letters, digits and underscores (_).
+	GroupName string `json:"group_name" required:"true"`
+	// Number of nodes.
+	NodeNum int `json:"node_num" required:"true"`
+	// Specifies the system disk information of the node.
+	RootVolume *Volume `json:"root_volume,omitempty"`
+	// Data disk information.
+	DataVolume *Volume `json:"data_volume,omitempty"`
+	// Number of data disks of a node. The value range is 0 to 10.
+	DataVolumeCount *int `json:"data_volume_count,omitempty"`
+	// Billing type of the node group.
+	ChargeInfo *ChargeInfo `json:"charge_info,omitempty"`
+	// Autoscaling rule corresponding to the node group.
+	AsPolicy *AsPolicy `json:"auto_scaling_policy,omitempty"`
+	// This parameter is mandatory when the cluster type is CUSTOM. Specifies the roles deployed in a node group.
+	// This parameter is a character string array. Each character string represents a role expression.
+	// Role expression definition:
+	//     If the role is deployed on all nodes in the node group, set this parameter to <role name>, e.g. DataNode.
+	//     If the role is deployed on a specified subscript node in the node group:
+	//         <role name>:<index1>,<index2>..., <indexN>, e.g. NameNode:1,2.
+	//     Some roles support multi-instance deployment (that is, multiple instances of the same role are deployed on a
+	//         node): <role name>[<instance count>], for example, EsNode[9].
+	AssignedRoles []string `json:"assigned_roles,omitempty"`
+}
+
+// Volume is a structure representing node volume configurations.
+type Volume struct {
+	// Disk Type. The following disk types are supported:
+	//     SATA: common I/O disk
+	//     SAS: high I/O disk
+	//     SSD: ultra-high I/O disk
+	Type string `json:"type" required:"true"`
+	// Specifies the data disk size, in GB. The value range is 10 to 32768.
+	Size int `json:"size" required:"true"`
+}
+
+// AsPolicy is a structure representing auto-scaling policy for task nodes.
+type AsPolicy struct {
+	// Whether to enable the auto scaling rule.
+	Enabled string `json:"auto_scaling_enable" required:"true"`
+	// Minimum number of nodes left in the node group. The value range is 0 to 500.
+	MinCapacity int `json:"min_capacity" required:"true"`
+	// Maximum number of nodes in the node group. The value range is 0 to 500.
+	MaxCapacity int `json:"max_capacity" required:"true"`
+	// List of the resource plan.
+	ResourcesPlans []ResourcesPlan `json:"resources_plans,omitempty"`
+	// List of custom scaling automation scripts.
+	Rules []Rule `json:"rules,omitempty"`
+	// List of auto scaling rules.
+	ExecScripts []ScaleScript `json:"exec_scripts,omitempty"`
+}
+
+// ResourcesPlan is a structure representing resource plan of the policy.
+type ResourcesPlan struct {
+	// Cycle type of a resource plan.
+	PeriodType string `json:"period_type" required:"true"`
+	// Start time of a resource plan.
+	// The value is in the format of hour:minute, indicating that the time ranges from 0:00 to 23:59.
+	StartTime string `json:"start_time" required:"true"`
+	// End time of a resource plan. The value is in the same format as that of start_time.
+	// The interval between end_time and start_time must be greater than or equal to 30 minutes.
+	EndTime string `json:"end_time" required:"true"`
+	// Minimum number of the preserved nodes in a node group in a resource plan. The value range is 0 to 500.
+	MinCapacity int `json:"min_capacity" required:"true"`
+	// Maximum number of the preserved nodes in a node group in a resource plan. The value range is 0 to 500.
+	MaxCapacity int `json:"max_capacity" required:"true"`
+}
+
+// Rule is a structure representing configuration of the auto-scaling rule.
+type Rule struct {
+	// Auto scaling rule adjustment type. The options are scale_out and scale_in.
+	AdjustmentType string `json:"adjustment_type" required:"true"`
+	// Cluster cooling time after an auto scaling rule is triggered, when no auto scaling operation is performed.
+	// The unit is minute.
+	CoolDownMinutes int `json:"cool_down_minutes" required:"true"`
+	// Unique name of an auto scaling rule. A cluster name can contain only 1 to 64 characters.
+	// Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	Name string `json:"name" required:"true"`
+	// Number of nodes that can be adjusted once. The value range is 1 to 100.
+	ScalingAdjustment int `json:"scaling_adjustment" required:"true"`
+	// Condition for triggering a rule.
+	Trigger Trigger `json:"trigger" required:"true"`
+	// Description about an auto scaling rule. It contains a maximum of 1,024 characters.
+	Description *string `json:"description,omitempty"`
+}
+
+// Trigger is a structure representing the condition for the triggering a rule.
+type Trigger struct {
+	// Number of consecutive five-minute periods, during which a metric threshold is reached.
+	// The value range is 1 to 288.
+	EvaluationPeriods int `json:"evaluation_periods" required:"true"`
+	// Metric name.
+	MetricName string `json:"metric_name" required:"true"`
+	// Metric threshold to trigger a rule.
+	MetricValue string `json:"metric_value" required:"true"`
+	// Metric judgment logic operator. The options are LT, GT, LTOE and GTOE.
+	ComparisonOperator string `json:"comparison_operator,omitempty"`
+}
+
+// ScriptOpts is a structure representing the bootstrap action script information.
+type ScriptOpts struct {
+	// Whether to continue executing subsequent scripts and creating a cluster after the bootstrap action script fails to be executed.
+	// continue: Continue to execute subsequent scripts.
+	// errorout: Stop the action.
+	// The default value is errorout, indicating that the action is stopped.
+	// NOTE:
+	// You are advised to set this parameter to continue in the commissioning phase so that the cluster can continue to be installed and started no matter whether the bootstrap action is successful.
+	FailAction string `json:"fail_action" required:"true"`
+	// Name of a bootstrap action script. It must be unique in a cluster.
+	// The value can contain only digits, letters, spaces, hyphens (-), and underscores (_) and must not start with a space.
+	// The value can contain 1 to 64 characters.
+	Name string `json:"name" required:"true"`
+	// Type of a node where the bootstrap action script is executed. The value can be Master, Core, or Task.
+	Nodes []string `json:"nodes" required:"true"`
+	// Bootstrap action script parameters.
+	Parameters string `json:"parameters,omitempty"`
+	// Path of a bootstrap action script. Set this parameter to an OBS bucket path or a local VM path.
+	// OBS bucket path: Enter a script path manually. For example, enter the path of the public sample script provided by MRS. Example: s3a://bootstrap/presto/presto-install.sh. If dualroles is installed, the parameter of the presto-install.sh script is dualroles. If worker is installed, the parameter of the presto-install.sh script is worker. Based on the Presto usage habit, you are advised to install dualroles on the active Master nodes and worker on the Core nodes.
+	// Local VM path: Enter a script path. The script path must start with a slash (/) and end with .sh.
+	URI string `json:"uri" required:"true"`
+	// Whether the bootstrap action script runs only on active Master nodes.
+	// The default value is false, indicating that the bootstrap action script can run on all Master nodes.
+	ActiveMaster *bool `json:"active_master,omitempty"`
+	// Time when the bootstrap action script is executed. Currently, the following two options are available: Before component start and After component start
+	// The default value is false, indicating that the bootstrap action script is executed after the component is started.
+	BeforeComponentStart *bool `json:"before_component_start,omitempty"`
+}
+
+// JobOpts is a structure representing the job which to execution.
+type JobOpts struct {
+	// SQL program path. This parameter is needed by Spark Script and Hive Script jobs only, and must meet the following requirements:
+	// Contains a maximum of 1,023 characters, excluding special characters such as ;|&><'$. The address cannot be empty or full of spaces.
+	// Files can be stored in HDFS or OBS. The path varies depending on the file system.
+	// OBS: The path must start with s3a://. Files or programs encrypted by KMS are not supported.
+	// HDFS: The path starts with a slash (/).
+	// Ends with .sql. sql is case-insensitive.
+	HiveScriptPath string `json:"hive_script_path" required:"true"`
+	// Job name. It contains 1 to 64 characters. Only letters, digits, hyphens (-), and underscores (_) are allowed.
+	// NOTE:
+	// Identical job names are allowed but not recommended.
+	JobName string `json:"job_name" required:"true"`
+	// Job type code
+	//   1: MapReduce
+	//   2: Spark
+	//   3: Hive Script
+	//   4: HiveQL (not supported currently)
+	//   5: DistCp, importing and exporting data (not supported currently)
+	//   6: Spark Script
+	//   7: Spark SQL, submitting Spark SQL statements (not supported currently).
+	// NOTE:
+	// Spark and Hive jobs can be added to only clusters that include Spark and Hive components.
+	JobType int `json:"job_type" required:"true"`
+	// true: Submit a job during cluster creation.
+	// false: Submit a job after the cluster is created.
+	// Set this parameter to true in this example.
+	SubmitJobOnceClusterRun bool `json:"submit_job_once_cluster_run" required:"true"`
+	// Key parameter for program execution. The parameter is specified by the function of the user's program. MRS is only responsible for loading the parameter.
+	// The parameter contains a maximum of 2,047 characters, excluding special characters such as ;|&>'<$, and can be left blank.
+	Arguments string `json:"arguments,omitempty"`
+	// Data import and export
+	// import
+	// export
+	FileAction string `json:"file_action,omitempty"`
+	// HiveQL statement
+	Hql string `json:"hql,omitempty"`
+	// Address for inputting data
+	// Files can be stored in HDFS or OBS. The path varies depending on the file system.
+	//   OBS: The path must start with s3a://. Files or programs encrypted by KMS are not supported.
+	//   HDFS: The path starts with a slash (/).
+	// The parameter contains a maximum of 1,023 characters, excluding special characters such as ;|&>'<$, and can be left blank.
+	Input string `json:"input,omitempty"`
+	// Path of the JAR or SQL file for program execution. The parameter must meet the following requirements:
+	// Contains a maximum of 1,023 characters, excluding special characters such as ;|&><'$. The parameter value cannot be empty or full of spaces.
+	// Files can be stored in HDFS or OBS. The path varies depending on the file system.
+	//   OBS: The path must start with s3a://. Files or programs encrypted by KMS are not supported.
+	//   HDFS: The path starts with a slash (/).
+	// Spark Script must end with .sql while MapReduce and Spark Jar must end with .jar. sql and jar are case-insensitive.
+	JarPath string `json:"jar_path,omitempty"`
+	// Path for storing job logs that record job running status.
+	// Files can be stored in HDFS or OBS. The path varies depending on the file system.
+	//   OBS: The path must start with s3a://.
+	//   HDFS: The path starts with a slash (/).
+	// The parameter contains a maximum of 1,023 characters, excluding special characters such as ;|&>'<$, and can be left blank.
+	JobLog string `json:"job_log,omitempty"`
+	// Address for outputting data
+	// Files can be stored in HDFS or OBS. The path varies depending on the file system.
+	//   OBS: The path must start with s3a://.
+	//   HDFS: The path starts with a slash (/).
+	// If the specified path does not exist, the system will automatically create it.
+	// The parameter contains a maximum of 1,023 characters, excluding special characters such as ;|&>'<$, and can be left blank.
+	Output string `json:"output,omitempty"`
+	// Whether to delete the cluster after the job execution is complete.
+	ShutdownCluster bool `json:"shutdown_cluster,omitempty"`
+}
+
+// ScaleScript is a structure representing the auto-scaling rules.
+type ScaleScript struct {
+	// Unique name of a custom automation script. The value can contain 1 to 64 characters.
+	// The value can contain digits, letters, spaces, hyphens (-), and underscores (_) and must not start with a space.
+	Name string `json:"name" required:"true"`
+	// Path of a custom automation script. Set this parameter to an OBS bucket path or a local VM path.
+	//     OBS bucket path: Enter a script path manually. for example, s3a://XXX/scale.sh.
+	//     Local VM path: Enter a script path. The script path must start with a slash (/) and end with .sh.
+	URI string `json:"uri" required:"true"`
+	// Type of a node where the custom automation script is executed. The node type can be Master, Core, or Task.
+	Nodes []string `json:"nodes" required:"true"`
+	// Time when a script is executed. The following four options are supported:
+	//     before_scale_out: before scale-out
+	//     before_scale_in: before scale-in
+	//     after_scale_out: after scale-out
+	//     after_scale_in: after scale-in
+	ActionStage string `json:"action_stage" required:"true"`
+	// Whether to continue to execute subsequent scripts and create a cluster after the custom automation script fails
+	// to be executed.
+	//     continue: Continue to execute subsequent scripts.
+	//     errorout: Stop the action.
+	FailAction string `json:"fail_action" required:"true"`
+	// Parameters of a custom automation script. Multiple parameters are separated by space.
+	// The following predefined system parameters can be transferred:
+	//     ${mrs_scale_node_num}: Number of the nodes to be added or removed.
+	//     ${mrs_scale_type}: Scaling type. The value can be scale_out or scale_in.
+	//     ${mrs_scale_node_hostnames}: Host names of the nodes to be added or removed.
+	//     ${mrs_scale_node_ips}: IP addresses of the nodes to be added or removed.
+	//     ${mrs_scale_rule_name}: Name of the rule that triggers auto scaling.
+	// Other user-defined parameters are used in the same way as those of common shell scripts.
+	Parameters string `json:"parameters,omitempty"`
+	// Whether the custom automation script runs only on the active Master node.
+	ActiveMaster bool `json:"active_master,omitempty"`
+}
+
+// CreateOptsBuilder is an interface which to support request body build of the cluster creation.
+type CreateOptsBuilder interface {
+	ToClusterCreateMap() (map[string]interface{}, error)
+}
+
+// ToClusterCreateMap is a method which to build a request body by the CreateOpts.
+func (opts CreateOpts) ToClusterCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create is a method to create a new mapreduce cluster.
+func Create(client *golangsdk.ServiceClient, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToClusterCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
+	_, r.Err = client.Post(rootURL(client), b, &r.Body, reqOpt)
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/mrs/v2/clusters/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/mrs/v2/clusters/results.go
@@ -1,0 +1,22 @@
+package clusters
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// Cluster is a struct that represents the result of Create methods.
+type Cluster struct {
+	ID string `json:"cluster_id"`
+}
+
+// CreateResult represents a result of the Create method.
+type CreateResult struct {
+	golangsdk.Result
+}
+
+// Extract is a method which to extract a cluster response.
+func (r CreateResult) Extract() (*Cluster, error) {
+	var s Cluster
+	err := r.ExtractInto(&s)
+	return &s, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/mrs/v2/clusters/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/mrs/v2/clusters/urls.go
@@ -1,0 +1,7 @@
+package clusters
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("clusters")
+}

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config/config.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config/config.go
@@ -19,6 +19,7 @@ import (
 	"github.com/chnsz/golangsdk/openstack/obs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/pathorcontents"
 )
 
@@ -437,8 +438,8 @@ func (c *Config) NewServiceClient(srv, region string) (*golangsdk.ServiceClient,
 }
 
 func (c *Config) newServiceClientByName(client *golangsdk.ProviderClient, catalog ServiceCatalog, region string) (*golangsdk.ServiceClient, error) {
-	if catalog.Name == "" || catalog.Version == "" {
-		return nil, fmt.Errorf("must specify the service name and api version")
+	if catalog.Name == "" {
+		return nil, fmt.Errorf("must specify the service name")
 	}
 
 	// Custom Resource-level region only supports AK/SK authentication.
@@ -474,7 +475,10 @@ func (c *Config) newServiceClientByName(client *golangsdk.ProviderClient, catalo
 		sc.Endpoint = fmt.Sprintf("https://%s.%s.%s/", catalog.Name, region, c.Cloud)
 	}
 
-	sc.ResourceBase = sc.Endpoint + catalog.Version + "/"
+	sc.ResourceBase = sc.Endpoint
+	if catalog.Version != "" {
+		sc.ResourceBase = sc.ResourceBase + catalog.Version + "/"
+	}
 	if !catalog.WithOutProjectID {
 		sc.ResourceBase = sc.ResourceBase + projectID + "/"
 	}
@@ -628,6 +632,10 @@ func (c *Config) IAMV3Client(region string) (*golangsdk.ServiceClient, error) {
 
 func (c *Config) IdentityV3Client(region string) (*golangsdk.ServiceClient, error) {
 	return c.NewServiceClient("identity", region)
+}
+
+func (c *Config) IAMNoVersionClient(region string) (*golangsdk.ServiceClient, error) {
+	return c.NewServiceClient("iam_no_version", region)
 }
 
 func (c *Config) CdnV1Client(region string) (*golangsdk.ServiceClient, error) {

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config/endpoints.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config/endpoints.go
@@ -22,6 +22,13 @@ var allServiceCatalog = map[string]ServiceCatalog{
 		Admin:            true,
 		WithOutProjectID: true,
 	},
+	"iam_no_version": {
+		Name:             "iam",
+		Version:          "",
+		Scope:            "global",
+		Admin:            true,
+		WithOutProjectID: true,
+	},
 	// iam is used for huaweicloud IAM APIs
 	"iam": {
 		Name:             "iam",

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config/logger.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config/logger.go
@@ -16,6 +16,9 @@ import (
 	"github.com/unknwon/com"
 )
 
+// MAXFieldLength is the maximum string length of single field when logging
+const MAXFieldLength int = 256
+
 var maxTimeout = 10 * time.Minute
 
 // LogRoundTripper satisfies the http.RoundTripper interface and is used to
@@ -131,7 +134,7 @@ func (lrt *LogRoundTripper) logResponse(original io.ReadCloser, contentType stri
 		if err != nil {
 			return nil, err
 		}
-		debugInfo := lrt.formatJSON(bs.Bytes(), false)
+		debugInfo := lrt.formatJSON(bs.Bytes(), true)
 		if debugInfo != "" {
 			log.Printf("[DEBUG] API Response Body: %s", debugInfo)
 		}
@@ -211,6 +214,8 @@ func maskSecurityFields(data map[string]interface{}) bool {
 		case string:
 			if isSecurityFields(k) {
 				data[k] = "***"
+			} else if len(val.(string)) > MAXFieldLength {
+				data[k] = "** large string **"
 			}
 		case map[string]interface{}:
 			subData := val.(map[string]interface{})
@@ -231,7 +236,8 @@ func isSecurityFields(field string) bool {
 
 	// "adminPass" is apply to the ecs/bms instance request JSON body
 	// "adminPwd" is apply to the css cluster request JSON body
-	securityFields := []string{"adminPass", "adminPwd"}
+	// 'encrypted_user_data' is apply to the function request JSON body of FunctionGraph
+	securityFields := []string{"adminPass", "adminPwd", "encrypted_user_data"}
 	for _, key := range securityFields {
 		if key == field {
 			return true

--- a/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/encoding.go
+++ b/vendor/github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/encoding.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/hex"
+)
+
+// HashAndHexEncode is one of the implementations of SchemaStateFunc.
+// The function gets the hash of v then returns the hexadecimal encoding string.
+// If the type of v is not string, just returns an empty string.
+func HashAndHexEncode(v interface{}) string {
+	switch v.(type) {
+	case string:
+		hash := sha1.Sum([]byte(v.(string)))
+		return hex.EncodeToString(hash[:])
+	default:
+		return ""
+	}
+}
+
+// DecodeHashAndHexEncode is one of the implementations of SchemaStateFunc.
+// The function tries to decode v if it is in base64 format, then gets the hash of
+// decode string and returns the hexadecimal encoding string.
+// If the type of v is not string, just returns an empty string.
+func DecodeHashAndHexEncode(v interface{}) string {
+	switch v.(type) {
+	case string:
+		return installScriptHashSum(v.(string))
+	default:
+		return ""
+	}
+}
+
+func installScriptHashSum(script string) string {
+	// Check whether the script is not Base64 encoded.
+	// Always calculate hash of base64 decoded value since we
+	// check against double-encoding when setting it
+	v, base64DecodeError := base64.StdEncoding.DecodeString(script)
+	if base64DecodeError != nil {
+		v = []byte(script)
+	}
+
+	hash := sha1.Sum(v)
+	return hex.EncodeToString(hash[:])
+}
+
+// TryBase64EncodeToString will encode the script with base64.
+// If the script is already base64 encoded, returns it directly.
+func TryBase64EncodeToString(script string) string {
+	if _, err := base64.StdEncoding.DecodeString(script); err != nil {
+		return base64.StdEncoding.EncodeToString([]byte(script))
+	}
+	return script
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -307,7 +307,7 @@ github.com/hashicorp/terraform-plugin-sdk/v2/plugin
 github.com/hashicorp/terraform-plugin-sdk/v2/terraform
 # github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d
 github.com/hashicorp/yamux
-# github.com/huaweicloud/terraform-provider-huaweicloud v1.31.0
+# github.com/huaweicloud/terraform-provider-huaweicloud v1.31.1
 ## explicit
 github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config
 github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/hashcode

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -141,6 +141,7 @@ github.com/chnsz/golangsdk/openstack/lts/v2/logtopics
 github.com/chnsz/golangsdk/openstack/mls/v1/instances
 github.com/chnsz/golangsdk/openstack/mrs/v1/cluster
 github.com/chnsz/golangsdk/openstack/mrs/v1/job
+github.com/chnsz/golangsdk/openstack/mrs/v2/clusters
 github.com/chnsz/golangsdk/openstack/mrs/v2/jobs
 github.com/chnsz/golangsdk/openstack/networking/v1/bandwidths
 github.com/chnsz/golangsdk/openstack/networking/v1/eips


### PR DESCRIPTION
refer to #659 

the testing results are as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccMrsMapReduceCluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccMrsMapReduceCluster_basic -timeout 720m
=== RUN   TestAccMrsMapReduceCluster_basic
=== PAUSE TestAccMrsMapReduceCluster_basic
=== CONT  TestAccMrsMapReduceCluster_basic
--- PASS: TestAccMrsMapReduceCluster_basic (1232.38s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 1232.397s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccMrsMapReduceCluster_analysis'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccMrsMapReduceCluster_analysis -timeout 720m
=== RUN   TestAccMrsMapReduceCluster_analysis
=== PAUSE TestAccMrsMapReduceCluster_analysis
=== CONT  TestAccMrsMapReduceCluster_analysis

--- PASS: TestAccMrsMapReduceCluster_analysis (3585.45s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 3585.468s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccMrsMapReduceCluster_stream'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccMrsMapReduceCluster_stream -timeout 720m
=== RUN   TestAccMrsMapReduceCluster_stream
=== PAUSE TestAccMrsMapReduceCluster_stream
=== CONT  TestAccMrsMapReduceCluster_stream
--- PASS: TestAccMrsMapReduceCluster_stream (2081.95s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 2081.964s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccMrsMapReduceCluster_custom'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccMrsMapReduceCluster_custom -timeout 720m
=== RUN   TestAccMrsMapReduceCluster_custom
=== PAUSE TestAccMrsMapReduceCluster_custom
=== CONT  TestAccMrsMapReduceCluster_custom
--- PASS: TestAccMrsMapReduceCluster_custom (1763.75s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 1763.769s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccMrsMapReduceCluster_publicIp'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccMrsMapReduceCluster_publicIp -timeout 720m
=== RUN   TestAccMrsMapReduceCluster_publicIp
=== PAUSE TestAccMrsMapReduceCluster_publicIp
=== CONT  TestAccMrsMapReduceCluster_publicIp

--- PASS: TestAccMrsMapReduceCluster_publicIp (922.70s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 922.719s
```