### PR TITLE
fix: update endpoint of dnsV2Client

### DIFF
--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -425,11 +425,14 @@ func (c *Config) bmsClient(region string) (*golangsdk.ServiceClient, error) {
 	})
 }
 
-func (c *Config) dnsV2Client(region string) (*golangsdk.ServiceClient, error) {
-	return huaweisdk.NewDNSV2(c.HwClient, golangsdk.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: c.getHwEndpointType(),
-	})
+// dnsV2Client is a global client for DNS service, the endpoint is https://dns.{cloud}/v2/
+func (c *Config) dnsV2Client(_ string) (*golangsdk.ServiceClient, error) {
+	sc := new(golangsdk.ServiceClient)
+	sc.ProviderClient = c.HwClient
+	sc.Endpoint = fmt.Sprintf("https://dns.%s", defaultCloud)
+	sc.ResourceBase = fmt.Sprintf("%s/v2/", sc.Endpoint)
+
+	return sc, nil
 }
 
 func (c *Config) identityV3Client(region string) (*golangsdk.ServiceClient, error) {

--- a/flexibleengine/data_source_flexibleengine_dns_zone_v2_test.go
+++ b/flexibleengine/data_source_flexibleengine_dns_zone_v2_test.go
@@ -11,24 +11,22 @@ import (
 
 var zoneName = fmt.Sprintf("acpttest%s.com.", acctest.RandString(5))
 
-func TestAccFlexibleEngineDNSZoneV2DataSource_basic(t *testing.T) {
+func TestAccDNSZoneV2DataSource_basic(t *testing.T) {
+	resourceName := "data.flexibleengine_dns_zone_v2.z1"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFlexibleEngineDNSZoneV2DataSource_zone,
+				Config: testAccDNSZoneV2DataSource_zone,
 			},
 			{
-				Config: testAccFlexibleEngineDNSZoneV2DataSource_basic,
+				Config: testAccDNSZoneV2DataSource_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDNSZoneV2DataSourceID("data.flexibleengine_dns_zone_v2.z1"),
-					resource.TestCheckResourceAttr(
-						"data.flexibleengine_dns_zone_v2.z1", "name", zoneName),
-					resource.TestCheckResourceAttr(
-						"data.flexibleengine_dns_zone_v2.z1", "zone_type", "public"),
-					resource.TestCheckResourceAttr(
-						"data.flexibleengine_dns_zone_v2.z1", "ttl", "7200"),
+					testAccCheckDNSZoneV2DataSourceID(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", zoneName),
+					resource.TestCheckResourceAttr(resourceName, "zone_type", "public"),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "7200"),
 				),
 			},
 		},
@@ -50,18 +48,19 @@ func testAccCheckDNSZoneV2DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccFlexibleEngineDNSZoneV2DataSource_zone = fmt.Sprintf(`
+var testAccDNSZoneV2DataSource_zone = fmt.Sprintf(`
 resource "flexibleengine_dns_zone_v2" "z1" {
-  name = "%s"
+  name        = "%s"
   description = "dns data source test"
-  email = "terraform-dns-zone-v2-test-name@example.com"
-  zone_type = "public"
-  ttl = 7200
+  email       = "terraform-dns-zone-v2-test-name@example.com"
+  zone_type   = "public"
+  ttl         = 7200
 }`, zoneName)
 
-var testAccFlexibleEngineDNSZoneV2DataSource_basic = fmt.Sprintf(`
+var testAccDNSZoneV2DataSource_basic = fmt.Sprintf(`
 %s
+
 data "flexibleengine_dns_zone_v2" "z1" {
-	name = "${flexibleengine_dns_zone_v2.z1.name}"
+  name = flexibleengine_dns_zone_v2.z1.name
 }
-`, testAccFlexibleEngineDNSZoneV2DataSource_zone)
+`, testAccDNSZoneV2DataSource_zone)


### PR DESCRIPTION
fixes #664

dnsV2Client is a global client for DNS service, the endpoint is https://dns.{cloud}/v2/

testing result:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDNSV2'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDNSV2 -timeout 720m
=== RUN   TestAccDNSV2PtrRecord_basic
=== PAUSE TestAccDNSV2PtrRecord_basic
=== RUN   TestAccDNSV2RecordSet_basic
=== PAUSE TestAccDNSV2RecordSet_basic
=== RUN   TestAccDNSV2RecordSet_readTTL
=== PAUSE TestAccDNSV2RecordSet_readTTL
=== RUN   TestAccDNSV2RecordSet_private
=== PAUSE TestAccDNSV2RecordSet_private
=== RUN   TestAccDNSV2Zone_basic
=== PAUSE TestAccDNSV2Zone_basic
=== RUN   TestAccDNSV2Zone_private
=== PAUSE TestAccDNSV2Zone_private
=== RUN   TestAccDNSV2Zone_readTTL
=== PAUSE TestAccDNSV2Zone_readTTL
=== CONT  TestAccDNSV2PtrRecord_basic
=== CONT  TestAccDNSV2Zone_basic
=== CONT  TestAccDNSV2Zone_readTTL
=== CONT  TestAccDNSV2Zone_private
--- PASS: TestAccDNSV2Zone_readTTL (16.55s)
=== CONT  TestAccDNSV2RecordSet_readTTL
--- PASS: TestAccDNSV2Zone_basic (28.33s)
=== CONT  TestAccDNSV2RecordSet_private
--- PASS: TestAccDNSV2Zone_private (34.37s)
=== CONT  TestAccDNSV2RecordSet_basic
--- PASS: TestAccDNSV2PtrRecord_basic (45.57s)
--- PASS: TestAccDNSV2RecordSet_readTTL (30.86s)
--- PASS: TestAccDNSV2RecordSet_private (48.93s)
--- PASS: TestAccDNSV2RecordSet_basic (56.74s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 91.129s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDNSZoneV2DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDNSZoneV2DataSource_basic -timeout 720m
=== RUN   TestAccDNSZoneV2DataSource_basic
--- PASS: TestAccDNSZoneV2DataSource_basic (20.22s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 20.237s
```
