### PR TITLE
feat: add support to identity provider resources

### DIFF
--- a/docs/resources/identity_provider.md
+++ b/docs/resources/identity_provider.md
@@ -1,0 +1,154 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+---
+
+# flexibleengine_identity_provider
+
+Manages the identity providers within FlexibleEngine IAM service.
+
+-> **NOTE:** You can create up to 10 identity providers.
+
+## Example Usage
+
+### Create a SAML protocol provider
+
+```hcl
+resource "flexibleengine_identity_provider" "provider_1" {
+  name     = "saml_idp_demo"
+  protocol = "saml"
+}
+```
+
+### Create a OpenID Connect protocol provider
+
+```hcl
+resource "flexibleengine_identity_provider" "provider_2" {
+  name     = "oidc_idp_demo"
+  protocol = "oidc"
+  
+  openid_connect_config {
+    access_type            = "program_console"
+    provider_url           = "https://accounts.example.com"
+    client_id              = "your_client_id"
+    authorization_endpoint = "https://accounts.example.com/o/oauth2/v2/auth"
+    scopes                 = ["openid"]
+    signing_key            = jsonencode(
+    {
+      keys = [
+        {
+          alg = "RS256"
+          e   = "AQAB"
+          kid = "..."
+          kty = "RSA"
+          n   = "..."
+          use = "sig"
+        },
+      ]
+    }
+    )
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String, ForceNew) Specifies the name of the identity provider to be registered.
+  The maximum length is 64 characters. Only letters, digits, underscores (_), and hyphens (-) are allowed.
+  The name is unique, it is recommended to include domain name information.
+  Changing this creates a new resource.
+
+* `protocol` - (Required, String, ForceNew) Specifies the protocol of the identity provider.
+  Valid values are *saml* and *oidc*.
+  Changing this creates a new resource.
+
+* `enabled` - (Optional, Bool) Specifies the status for the identity provider. Defaults to true.
+
+* `description` - (Optional, String) Specifies the description of the identity provider.
+
+* `metadata` - (Optional, String) Specifies the metadata of the IDP(Identity Provider) server.
+  To obtain the metadata file of your enterprise IDP, contact the enterprise administrator.
+  This field is used to import a metadata file to IAM to implement federated identity authentication.
+  This field is required only if the protocol is set to *saml*.
+  The maximum length is 30,000 characters and it stores in the state with SHA1 algorithm.
+
+  -> **NOTE:**
+    The metadata file specifies API addresses and certificate information in compliance with the SAML 2.0 standard.
+    It is usually stored in a file. In the TF script, you can import the metafile through the **file** function,
+    for example:
+    <br/>`metadata = file("/usr/local/data/files/metadata.txt")`
+
+* `openid_connect_config` - (Optional, List) Specifies the description of the identity provider.
+  This field is required only if the protocol is set to *oidc*.
+
+The `openid_connect_config` block supports:
+
+* `access_type` - (Required, String) Specifies the access type of the identity provider.
+  Available options are:
+  + `program`: programmatic access only.
+  + `program_console`: programmatic access and management console access.
+
+* `provider_url` - (Required, String) Specifies the URL of the identity provider.
+  This field corresponds to the iss field in the ID token.
+
+* `client_id` - (Required, String) Specifies the ID of a client registered with the OpenID Connect identity provider.
+
+* `signing_key` - (Required, String) Public key used to sign the ID token of the OpenID Connect identity provider.
+  This field is required only if the protocol is set to *oidc*.
+
+* `authorization_endpoint` - (Optional, String) Specifies the authorization endpoint of the OpenID Connect identity
+  provider. This field is required only if the access type is set to `program_console`.
+
+* `scopes` - (Optional, List) Specifies the scopes of authorization requests. It is an array of one or more scopes.
+  Valid values are *openid*, *email*, *profile* and other values defined by you.
+  This field is required only if the access type is set to `program_console`.
+
+* `response_type` - (Optional, String) Response type. Valid values is *id_token*, default value is *id_token*.
+  This field is required only if the access type is set to `program_console`.
+
+* `response_mode` - (Optional, String) Response mode.
+  Valid values is *form_post* and *fragment*, default value is *form_post*.
+  This field is required only if the access type is set to `program_console`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which equals to the name.
+
+* `login_link` - The login link of the identity provider.
+
+* `sso_type` - The single sign-on type of the identity provider.
+
+* `conversion_rules` - The identity conversion rules of the identity provider.
+  The [object](#conversion_rules) structure is documented below
+
+<a name="conversion_rules"></a>
+The `conversion_rules` block supports:
+
+* `local` - The federated user information on the cloud platform.
+
+* `remote` - The description of the identity provider.
+
+The `local` block supports:
+
+* `username` - The name of a federated user on the cloud platform.
+
+* `group` - The user group to which the federated user belongs on the cloud platform.
+
+The `remote` block supports:
+
+* `attribute` - The attribute in the IDP assertion.
+
+* `condition` - The condition of conversion rule.
+
+* `value` - The rule is matched only if the specified strings appear in the attribute type.
+
+## Import
+
+Identity provider can be imported using the `name`, e.g.
+
+```
+$ terraform import flexibleengine_identity_provider.provider_1 example_com_provider_saml
+```

--- a/docs/resources/identity_provider_conversion.md
+++ b/docs/resources/identity_provider_conversion.md
@@ -1,0 +1,91 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+---
+
+# flexibleengine_identity_provider_conversion
+
+Manage the conversion rules of identity provider within FlexibleEngine IAM service.
+
+## Example Usage
+
+```hcl
+variable provider_id {}
+
+resource "flexibleengine_identity_provider_conversion" "conversion" {
+  provider_id = var.provider_id
+
+  conversion_rules {
+    local {
+      username = "Tom"
+    }
+    remote {
+      attribute = "Tom"
+    }
+  }
+
+  conversion_rules {
+    local {
+      username = "FederationUser"
+    }
+    remote {
+      attribute = "username"
+      condition = "any_one_of"
+      value     = ["Tom", "Jerry"]
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `provider_id` - (Required, String) The ID or name of the identity provider used to manage the conversion rules.
+
+* `conversion_rules` - (Required, List) Specifies the identity conversion rules of the identity provider.
+  You can use identity conversion rules to map the identities of existing users to FlexibleEngine and manage their access
+  to cloud resources.
+  The [object](#conversion_rules) structure is documented below.
+
+<a name="conversion_rules"></a>
+The `conversion_rules` block supports:
+
+* `local` - (Required, List) Specifies the federated user information on the cloud platform.
+
+* `remote` - (Required, List) Specifies Federated user information in the IDP system.
+
+  -> **NOTE:** 
+    If the protocol of identity provider is SAML, this field is an expression consisting of assertion
+    attributes and operators.<br/>
+    If the protocol of identity provider is OIDC, the value of this field is determined by the ID token.
+
+The `local` block supports:
+
+* `username` - (Required, String) Specifies the name of a federated user on the cloud platform.
+
+* `group` - (Optional, String) Specifies the user group to which the federated user belongs on the cloud platform.
+
+The `remote` block supports:
+
+* `attribute` - (Required, String) Specifies the attribute in the IDP assertion.
+
+* `condition` - (Optional, String) Specifies the condition of conversion rule.
+  Available options are:
+  + `any_one_of`: The rule is matched only if the specified strings appear in the attribute type.
+  + `not_any_of`: The rule is matched only if the specified strings do not appear in the attribute type.
+
+* `value` - (Optional, List) Specifies the rule is matched only if the specified strings appear in the attribute type.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of conversion rules.
+
+## Import
+
+Identity provider conversion rules are imported using the `provider_id`, e.g.
+
+```
+$ terraform import flexibleengine_identity_provider_conversion.conversion example_com_provider_oidc
+```

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -290,6 +290,8 @@ func Provider() *schema.Provider {
 			"flexibleengine_identity_role_v3":                   resourceIdentityRoleV3(),
 			"flexibleengine_identity_role_assignment_v3":        resourceIdentityRoleAssignmentV3(),
 			"flexibleengine_identity_user_v3":                   resourceIdentityUserV3(),
+			"flexibleengine_identity_provider":                  resourceIdentityProvider(),
+			"flexibleengine_identity_provider_conversion":       resourceIAMProviderConversion(),
 			"flexibleengine_lts_group":                          resourceLTSGroupV2(),
 			"flexibleengine_lts_topic":                          resourceLTSTopicV2(),
 			"flexibleengine_s3_bucket":                          resourceS3Bucket(),

--- a/flexibleengine/resource_flexibleengine_identity_provider.go
+++ b/flexibleengine/resource_flexibleengine_identity_provider.go
@@ -1,0 +1,539 @@
+package flexibleengine
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/identity/federatedauth/mappings"
+	"github.com/chnsz/golangsdk/openstack/identity/federatedauth/metadatas"
+	"github.com/chnsz/golangsdk/openstack/identity/federatedauth/oidcconfig"
+	"github.com/chnsz/golangsdk/openstack/identity/federatedauth/protocols"
+	"github.com/chnsz/golangsdk/openstack/identity/federatedauth/providers"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+const (
+	protocolSAML = "saml"
+	protocolOIDC = "oidc"
+
+	scopeSpilt = " "
+)
+
+func resourceIdentityProvider() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIdentityProviderCreate,
+		ReadContext:   resourceIdentityProviderRead,
+		UpdateContext: resourceIdentityProviderUpdate,
+		DeleteContext: resourceIdentityProviderDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[\w-]{1,64}$`),
+					"The maximum length is 64 characters. "+
+						"Only letters, digits, underscores (_), and hyphens (-) are allowed"),
+			},
+			"protocol": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{protocolSAML, protocolOIDC}, false),
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"metadata": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				StateFunc: utils.HashAndHexEncode,
+			},
+			"openid_connect_config": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"access_type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validation.StringInSlice([]string{"program", "program_console"}, false),
+						},
+						"provider_url": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"client_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"signing_key": {
+							Type:     schema.TypeString,
+							Required: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								equal, _ := utils.CompareJsonTemplateAreEquivalent(old, new)
+								return equal
+							},
+						},
+						"authorization_endpoint": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"scopes": {
+							Type:     schema.TypeList,
+							Optional: true,
+							MaxItems: 10,
+							Computed: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+						"response_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "id_token",
+						},
+						"response_mode": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "form_post",
+							ValidateFunc: validation.StringInSlice([]string{"fragment", "form_post"}, false),
+						},
+					},
+				},
+			},
+			"conversion_rules": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"local": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"username": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"group": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+								},
+							},
+						},
+						"remote": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"attribute": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"condition": {
+										Type:     schema.TypeString,
+										Computed: true,
+									},
+									"value": {
+										Type:     schema.TypeList,
+										Computed: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"sso_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"login_link": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceIdentityProviderCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*Config)
+	client, err := conf.IAMNoVersionClient(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("Error creating FlexibleEngine IAM without version client: %s", err)
+	}
+
+	if conf.DomainID == "" {
+		return diag.Errorf("the domain_id must be specified in the provider configuration")
+	}
+
+	// Create a SAML protocol provider.
+	opts := providers.CreateProviderOpts{
+		Enabled:     d.Get("enabled").(bool),
+		Description: d.Get("description").(string),
+	}
+	name := d.Get("name").(string)
+	log.Printf("[DEBUG] Create identity options %s : %#v", name, opts)
+	provider, err := providers.Create(client, name, opts)
+	if err != nil {
+		return diag.Errorf("Failed to create identity provider: %s", err)
+	}
+
+	d.SetId(provider.ID)
+
+	// Create protocol and default mapping
+	protocol := d.Get("protocol").(string)
+	err = createProtocol(d, client)
+	if err != nil {
+		return diag.Errorf("error in creating provider protocol: %s", err)
+	}
+
+	// Import metadata, metadata only worked on saml protocol providers
+	if protocol == protocolSAML {
+		err = importMetadata(d, client, conf.DomainID)
+		if err != nil {
+			return diag.Errorf("error importing matedata into identity provider: %s", err)
+		}
+	} else if ac, ok := d.GetOk("openid_connect_config"); ok {
+		// Create access config for oidc provider.
+		accessConfigArr := ac.([]interface{})
+		accessConfig := accessConfigArr[0].(map[string]interface{})
+
+		accessType := accessConfig["access_type"].(string)
+		createAccessTypeOpts := oidcconfig.CreateOpts{
+			AccessMode: accessType,
+			IdpURL:     accessConfig["provider_url"].(string),
+			ClientID:   accessConfig["client_id"].(string),
+			SigningKey: accessConfig["signing_key"].(string),
+		}
+
+		if accessType == "program_console" {
+			scopes := utils.ExpandToStringList(accessConfig["scopes"].([]interface{}))
+			createAccessTypeOpts.Scope = strings.Join(scopes, scopeSpilt)
+			createAccessTypeOpts.AuthorizationEndpoint = accessConfig["authorization_endpoint"].(string)
+			createAccessTypeOpts.ResponseType = accessConfig["response_type"].(string)
+			createAccessTypeOpts.ResponseMode = accessConfig["response_mode"].(string)
+		}
+		log.Printf("[DEBUG] Create access type of provider: %#v", opts)
+
+		_, err = oidcconfig.Create(client, provider.ID, createAccessTypeOpts)
+		if err != nil {
+			return diag.Errorf("Error creating the provider access config: %s", err)
+		}
+	}
+
+	return resourceIdentityProviderRead(ctx, d, meta)
+}
+
+// importMetadata import metadata to provider, overwrite if it exists.
+func importMetadata(d *schema.ResourceData, client *golangsdk.ServiceClient, domainID string) error {
+	metadata := d.Get("metadata").(string)
+	if metadata == "" {
+		return nil
+	}
+
+	providerID := d.Get("name").(string)
+	opts := metadatas.ImportOpts{
+		DomainID: domainID,
+		Metadata: metadata,
+	}
+	if _, err := metadatas.Import(client, providerID, protocolSAML, opts); err != nil {
+		return fmt.Errorf("failed to import metadata: %s", err)
+	}
+	return nil
+}
+
+// createProtocol create protocol and default mapping
+func createProtocol(d *schema.ResourceData, client *golangsdk.ServiceClient) error {
+	providerID := d.Get("name").(string)
+
+	// Create default mapping
+	defaultConversionRules := getDefaultConversionOpts()
+	conversionRuleID := "mapping_" + providerID
+	_, err := mappings.Create(client, conversionRuleID, *defaultConversionRules)
+	if err != nil {
+		return fmt.Errorf("error in creating default conversion rule: %s", err)
+	}
+
+	// Create protocol
+	protocolName := d.Get("protocol").(string)
+	_, err = protocols.Create(client, providerID, protocolName, conversionRuleID)
+	if err != nil {
+		// If fails to create protocols, then delete the mapping.
+		mErr := multierror.Append(
+			nil,
+			err,
+			mappings.Delete(client, conversionRuleID),
+		)
+		log.Printf("[ERROR] Error creating protocol, and the mapping that has been created. Error: %s", mErr)
+		return fmt.Errorf("error creating identity provider protocol: %s", mErr.Error())
+	}
+	return nil
+}
+
+func getDefaultConversionOpts() *mappings.MappingOption {
+	localRules := []mappings.LocalRule{
+		{
+			User: mappings.LocalRuleVal{
+				Name: "FederationUser",
+			},
+		},
+	}
+	remoteRules := []mappings.RemoteRule{
+		{
+			Type: "__NAMEID__",
+		},
+	}
+
+	opts := mappings.MappingOption{
+		Rules: []mappings.MappingRule{
+			{
+				Local:  localRules,
+				Remote: remoteRules,
+			},
+		},
+	}
+	return &opts
+}
+
+func resourceIdentityProviderRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*Config)
+	client, err := conf.IAMNoVersionClient(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("Error creating FlexibleEngine IAM client without version number: %s", err)
+	}
+
+	provider, err := providers.Get(client, d.Id())
+	if err != nil {
+		return CheckDeletedDiag(d, err, "error obtaining identity provider")
+	}
+
+	// Query the protocol name from cloud
+	protocol := queryProtocolName(d, client)
+	url := generateLoginLink(conf, provider.ID, protocol)
+
+	mErr := multierror.Append(err,
+		d.Set("name", provider.ID),
+		d.Set("protocol", protocol),
+		d.Set("sso_type", provider.SsoType),
+		d.Set("enabled", provider.Enabled),
+		d.Set("login_link", url),
+		d.Set("description", provider.Description),
+	)
+
+	// Query and set conversion rules
+	conversionRuleID := "mapping_" + d.Id()
+	conversions, err := mappings.Get(client, conversionRuleID)
+	if err == nil {
+		conversionRules := buildConversionRulesAttr(conversions)
+		err = d.Set("conversion_rules", conversionRules)
+		mErr = multierror.Append(mErr, err)
+	}
+
+	// Query and set metadata of the protocol SAML provider
+	if protocol == protocolSAML {
+		r, err := metadatas.Get(client, d.Id(), protocolSAML)
+		if err == nil {
+			err = d.Set("metadata", utils.HashAndHexEncode(r.Data))
+			mErr = multierror.Append(mErr, err)
+		}
+	}
+
+	// Query and set access type of the protocol OIDC provider
+	if protocol == protocolOIDC {
+		accessType, err := oidcconfig.Get(client, d.Id())
+		if err == nil {
+			scopes := strings.Split(accessType.Scope, scopeSpilt)
+			accessTypeConfig := []interface{}{
+				map[string]interface{}{
+					"access_type":            accessType.AccessMode,
+					"provider_url":           accessType.IdpURL,
+					"client_id":              accessType.ClientID,
+					"signing_key":            accessType.SigningKey,
+					"scopes":                 scopes,
+					"response_mode":          accessType.ResponseMode,
+					"authorization_endpoint": accessType.AuthorizationEndpoint,
+					"response_type":          accessType.ResponseType,
+				},
+			}
+
+			err = d.Set("openid_connect_config", accessTypeConfig)
+			mErr = multierror.Append(mErr, err)
+		}
+	}
+
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error setting identity provider attributes: %s", err)
+	}
+	return nil
+}
+
+func buildConversionRulesAttr(conversions *mappings.IdentityMapping) []interface{} {
+	conversionRules := make([]interface{}, 0, len(conversions.Rules))
+	for _, v := range conversions.Rules {
+		localRules := make([]map[string]interface{}, 0, len(v.Local))
+		for _, localRule := range v.Local {
+			username := localRule.User.Name
+			r := map[string]interface{}{
+				"username": username,
+			}
+			if localRule.Group != nil {
+				r["group"] = localRule.Group.Name
+			}
+			localRules = append(localRules, r)
+		}
+
+		remoteRules := make([]map[string]interface{}, 0, len(v.Remote))
+		for _, remoteRule := range v.Remote {
+			r := map[string]interface{}{
+				"attribute": remoteRule.Type,
+			}
+			if len(remoteRule.NotAnyOf) > 0 {
+				r["condition"] = "not_any_of"
+				r["value"] = remoteRule.NotAnyOf
+			} else if len(remoteRule.AnyOneOf) > 0 {
+				r["condition"] = "any_one_of"
+				r["value"] = remoteRule.AnyOneOf
+			}
+			remoteRules = append(remoteRules, r)
+		}
+
+		rule := map[string]interface{}{
+			"local":  localRules,
+			"remote": remoteRules,
+		}
+		conversionRules = append(conversionRules, rule)
+	}
+	return conversionRules
+}
+
+// generateLoginLink generate login link base on config.domainID.
+func generateLoginLink(conf *Config, id, protocol string) string {
+	url := fmt.Sprintf("https://auth.%s/authui/federation/websso?domain_id=%s&idp=%s&protocol=%s",
+		conf.Cloud, conf.DomainID, id, protocol)
+	return url
+}
+
+func queryProtocolName(d *schema.ResourceData, client *golangsdk.ServiceClient) string {
+	arr, err := protocols.List(client, d.Id())
+	if err != nil {
+		return ""
+	}
+
+	// The SAML protocol provider may not have protocol data,
+	// so the default value is set to SAML.
+	protocolName := protocolSAML
+	if len(arr) > 0 {
+		protocolName = arr[0].ID
+	}
+	return protocolName
+}
+
+func resourceIdentityProviderUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*Config)
+	client, err := conf.IAMNoVersionClient(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("Error creating FlexibleEngine IAM client without version number: %s", err)
+	}
+
+	mErr := &multierror.Error{}
+	if d.HasChanges("enabled", "description") {
+		status := d.Get("enabled").(bool)
+		description := d.Get("description").(string)
+		opts := providers.UpdateOpts{
+			Enabled:     &status,
+			Description: &description,
+		}
+		log.Printf("[DEBUG] Update identity options %s : %#v", d.Id(), opts)
+
+		_, err = providers.Update(client, d.Id(), opts)
+		if err != nil {
+			e := fmt.Errorf("Failed to update identity provider: %s", err)
+			mErr = multierror.Append(mErr, e)
+		}
+	}
+
+	if d.HasChange("metadata") {
+		err = importMetadata(d, client, conf.DomainID)
+		if err != nil {
+			mErr = multierror.Append(mErr, err)
+		}
+	}
+
+	if d.HasChange("openid_connect_config") && d.Get("protocol") == protocolOIDC {
+		err = updateAccessConfig(client, d)
+		if err != nil {
+			mErr = multierror.Append(mErr, err)
+		}
+	}
+
+	if err = mErr.ErrorOrNil(); err != nil {
+		return diag.Errorf("error in updating provider: %s", err)
+	}
+
+	return resourceIdentityProviderRead(ctx, d, meta)
+}
+
+func updateAccessConfig(client *golangsdk.ServiceClient, d *schema.ResourceData) error {
+	accessConfigArr := d.Get("openid_connect_config").([]interface{})
+	if len(accessConfigArr) == 0 {
+		return fmt.Errorf("the openid_connect_config is required for the OIDC provider")
+	}
+	accessConfig := accessConfigArr[0].(map[string]interface{})
+
+	accessType := accessConfig["access_type"].(string)
+	opts := oidcconfig.UpdateOpenIDConnectConfigOpts{
+		AccessMode: accessType,
+		IdpURL:     accessConfig["provider_url"].(string),
+		ClientID:   accessConfig["client_id"].(string),
+		SigningKey: accessConfig["signing_key"].(string),
+	}
+
+	if accessType == "program_console" {
+		scopes := utils.ExpandToStringList(accessConfig["scopes"].([]interface{}))
+		opts.Scope = strings.Join(scopes, scopeSpilt)
+		opts.AuthorizationEndpoint = accessConfig["authorization_endpoint"].(string)
+		opts.ResponseType = accessConfig["response_type"].(string)
+		opts.ResponseMode = accessConfig["response_mode"].(string)
+	}
+	log.Printf("[DEBUG] Update access type of provider: %#v", opts)
+	providerID := d.Id()
+	_, err := oidcconfig.Update(client, providerID, opts)
+	return err
+}
+
+func resourceIdentityProviderDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*Config)
+	client, err := conf.IAMNoVersionClient(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("Error creating FlexibleEngine IAM client without version number: %s", err)
+	}
+
+	err = providers.Delete(client, d.Id())
+	if err != nil {
+		return CheckDeletedDiag(d, err, "Error deleting FlexibleEngine identity provider")
+	}
+	d.SetId("")
+	return nil
+}

--- a/flexibleengine/resource_flexibleengine_identity_provider_conversion.go
+++ b/flexibleengine/resource_flexibleengine_identity_provider_conversion.go
@@ -1,0 +1,259 @@
+package flexibleengine
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/identity/federatedauth/mappings"
+	"github.com/chnsz/golangsdk/openstack/identity/federatedauth/providers"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+const MappingIDPrefix = "mapping_"
+
+func resourceIAMProviderConversion() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceIAMProviderConversionCreate,
+		ReadContext:   resourceIAMProviderConversionRead,
+		UpdateContext: resourceIAMProviderConversionUpdate,
+		DeleteContext: resourceIAMProviderConversionDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"provider_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"conversion_rules": {
+				Type:     schema.TypeList,
+				Required: true,
+				MaxItems: 10,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"local": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"username": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"group": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"remote": {
+							Type:     schema.TypeList,
+							Required: true,
+							MaxItems: 10,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"attribute": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"condition": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice([]string{"any_one_of", "not_any_of"}, false),
+									},
+									"value": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceIAMProviderConversionCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*Config)
+	client, err := conf.IAMNoVersionClient(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("Error creating FlexibleEngine IAM without version client: %s", err)
+	}
+
+	providerID := d.Get("provider_id").(string)
+	conversionID := MappingIDPrefix + providerID
+
+	// Check if the mappingID exists, update if it exists, otherwise create it.
+	r, err := mappings.List(client).AllPages()
+	if err != nil {
+		if _, ok := err.(golangsdk.ErrDefault404); !ok {
+			return diag.Errorf("error in querying or extract conversions: %s", err)
+		}
+	}
+
+	conversions, err := mappings.ExtractMappings(r)
+	if err != nil {
+		return diag.Errorf("error in extracting provider conversions: %s", err)
+	}
+
+	filterData, err := utils.FilterSliceWithField(conversions, map[string]interface{}{
+		"ID": conversionID,
+	})
+	if err != nil {
+		return diag.Errorf("error in filtering conversions: %s", err)
+	}
+
+	conversionRules := d.Get("conversion_rules").([]interface{})
+	mappingOpts := buildConversionRules(conversionRules)
+
+	// Create the mapping if it does not exist, otherwise update it.
+	if len(filterData) == 0 {
+		_, err = mappings.Create(client, conversionID, mappingOpts)
+	} else {
+		_, err = mappings.Update(client, conversionID, mappingOpts)
+	}
+	if err != nil {
+		return diag.Errorf("error in creating/updating mapping: %s", err)
+	}
+	d.SetId(conversionID)
+
+	return resourceIAMProviderConversionRead(ctx, d, meta)
+}
+
+func buildConversionRules(conversionRules []interface{}) mappings.MappingOption {
+	rules := make([]mappings.MappingRule, 0, len(conversionRules))
+
+	for _, cr := range conversionRules {
+		convRule := cr.(map[string]interface{})
+
+		// build local rules
+		local := convRule["local"].([]interface{})
+		localRules := make([]mappings.LocalRule, 0, len(local))
+		for _, v := range local {
+			lRule := v.(map[string]interface{})
+			r := mappings.LocalRule{
+				User: mappings.LocalRuleVal{
+					Name: lRule["username"].(string),
+				},
+			}
+			group, ok := lRule["group"]
+			if ok && len(group.(string)) > 0 {
+				r.Group = &mappings.LocalRuleVal{
+					Name: group.(string),
+				}
+			}
+			localRules = append(localRules, r)
+		}
+		// build remote rule
+		remote := convRule["remote"].([]interface{})
+		remoteRules := make([]mappings.RemoteRule, 0, len(remote))
+		for _, v := range remote {
+			rRule := v.(map[string]interface{})
+			r := mappings.RemoteRule{
+				Type: rRule["attribute"].(string),
+			}
+			if condition, ok := rRule["condition"]; ok {
+				values := utils.ExpandToStringList(rRule["value"].([]interface{}))
+				if condition.(string) == "any_one_of" {
+					r.AnyOneOf = values
+				} else if condition.(string) == "not_any_of" {
+					r.NotAnyOf = values
+				}
+			}
+			remoteRules = append(remoteRules, r)
+		}
+
+		rule := mappings.MappingRule{
+			Local:  localRules,
+			Remote: remoteRules,
+		}
+		rules = append(rules, rule)
+	}
+	opts := mappings.MappingOption{
+		Rules: rules,
+	}
+	return opts
+}
+
+func resourceIAMProviderConversionRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*Config)
+	client, err := conf.IAMNoVersionClient(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("Error creating FlexibleEngine IAM client without version number: %s", err)
+	}
+
+	conversionID := d.Id()
+	conversions, err := mappings.Get(client, conversionID)
+	if err != nil {
+		return CheckDeletedDiag(d, err, "error in querying conversion rules")
+	}
+
+	conversionRules := buildConversionRulesAttr(conversions)
+	providerID := strings.Replace(conversionID, MappingIDPrefix, "", -1)
+	mErr := multierror.Append(
+		d.Set("provider_id", providerID),
+		d.Set("conversion_rules", conversionRules),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("Error setting identity provider conversion rules: %s", mErr)
+	}
+	return nil
+}
+
+func resourceIAMProviderConversionUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*Config)
+	client, err := conf.IAMNoVersionClient(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("Error creating FlexibleEngine IAM client without version number: %s", err)
+	}
+
+	conversionRules := d.Get("conversion_rules").([]interface{})
+	conversionRuleOpts := buildConversionRules(conversionRules)
+	conversionID := d.Id()
+	_, err = mappings.Update(client, conversionID, conversionRuleOpts)
+	if err != nil {
+		return diag.Errorf("Failed to update the provider conversion rules: %s", err)
+	}
+
+	return resourceIAMProviderConversionRead(ctx, d, meta)
+}
+
+func resourceIAMProviderConversionDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	conf := meta.(*Config)
+	client, err := conf.IAMNoVersionClient(conf.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("Error creating FlexibleEngine IAM client without version number: %s", err)
+	}
+
+	providerID := d.Get("provider_id").(string)
+	_, err = providers.Get(client, providerID)
+	if err != nil && errors.As(err, &golangsdk.ErrDefault404{}) {
+		d.SetId("")
+		return nil
+	}
+
+	conversionID := d.Id()
+	opts := getDefaultConversionOpts()
+	_, err = mappings.Update(client, conversionID, *opts)
+	if err != nil {
+		return diag.Errorf("Error resetting provider conversion rules to default value" +
+			"(the conversion rules can not be deleted, it can be reset to default value).")
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/flexibleengine/resource_flexibleengine_identity_provider_conversion_test.go
+++ b/flexibleengine/resource_flexibleengine_identity_provider_conversion_test.go
@@ -1,0 +1,165 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/identity/federatedauth/mappings"
+)
+
+func TestAccIdentityProviderConversion_basic(t *testing.T) {
+	var mappingRules mappings.IdentityMapping
+	var name = fmt.Sprintf("idp-ACCPTTEST-%s", acctest.RandString(5))
+	resourceName := "flexibleengine_identity_provider_conversion.conversion"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckIdentityProviderConversionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityProviderConversion_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityProviderConversionExists(resourceName, &mappingRules),
+					resource.TestCheckResourceAttr(resourceName, "conversion_rules.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "conversion_rules.0.local.0.username", "Tom"),
+				),
+			},
+			{
+				Config: testAccIdentityProviderConversion_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "conversion_rules.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "conversion_rules.0.local.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "conversion_rules.0.local.0.username", "Tom"),
+					resource.TestCheckResourceAttr(resourceName, "conversion_rules.1.remote.0.value.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckIdentityProviderConversionDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	identityClient, err := config.IAMNoVersionClient(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_identity_provider_conversion" {
+			continue
+		}
+
+		_, err := mappings.Get(identityClient, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("Identity Provider Conversion still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckIdentityProviderConversionExists(n string, rules *mappings.IdentityMapping) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		identityClient, err := config.IAMNoVersionClient(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
+		}
+
+		found, err := mappings.Get(identityClient, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("Identity Provider Conversion not found")
+		}
+
+		*rules = *found
+
+		return nil
+	}
+}
+
+func testAccIdentityProviderConversion_conf(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_identity_provider" "provider_1" {
+  name     = "%s"
+  protocol = "oidc"
+}
+
+resource "flexibleengine_identity_provider_conversion" "conversion" {
+  provider_id = flexibleengine_identity_provider.provider_1.id
+
+  conversion_rules {
+    local {
+      username = "Tom"
+    }
+    remote {
+      attribute = "Tom"
+    }
+  }
+}
+`, name)
+}
+
+func testAccIdentityProviderConversion_update(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_identity_provider" "provider_1" {
+  name     = "%s"
+  protocol = "oidc"
+}
+
+resource "flexibleengine_identity_provider_conversion" "conversion" {
+  provider_id = flexibleengine_identity_provider.provider_1.id
+
+  conversion_rules {
+    local {
+      username = "Tom"
+    }
+    local {
+      username = "federateduser"
+    }
+    remote {
+      attribute = "Tom"
+    }
+    remote {
+      attribute = "federatedgroup"
+    }
+  }
+
+  conversion_rules {
+    local {
+      username = "Jams"
+    }
+    remote {
+      attribute = "username"
+      condition = "any_one_of"
+      value     = ["Tom", "Jerry"]
+    }
+  }
+}
+`, name)
+}

--- a/flexibleengine/resource_flexibleengine_identity_provider_test.go
+++ b/flexibleengine/resource_flexibleengine_identity_provider_test.go
@@ -1,0 +1,224 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/identity/federatedauth/providers"
+)
+
+func TestAccIdentityProvider_basic(t *testing.T) {
+	var provider providers.Provider
+	var name = fmt.Sprintf("idp-ACCPTTEST-%s", acctest.RandString(5))
+	resourceName := "flexibleengine_identity_provider.provider_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckIdentityProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityProvider_saml(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityProviderExists(resourceName, &provider),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "saml"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+				),
+			},
+			{
+				Config: testAccIdentityProvider_saml_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "saml"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccIdentityProvider_oidc(t *testing.T) {
+	var provider providers.Provider
+	var name = fmt.Sprintf("idp-ACCPTTEST-%s", acctest.RandString(5))
+	resourceName := "flexibleengine_identity_provider.provider_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckIdentityProviderDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityProvider_oidc(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIdentityProviderExists(resourceName, &provider),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "oidc"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.0.access_type", "program_console"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.0.client_id", "client_id_example"),
+				),
+			},
+			{
+				Config: testAccIdentityProvider_oidc_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "oidc"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.0.access_type", "program"),
+					resource.TestCheckResourceAttr(resourceName, "openid_connect_config.0.client_id", "client_id_demo"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIdentityProviderDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	identityClient, err := config.IAMNoVersionClient(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_identity_provider" {
+			continue
+		}
+
+		_, err := providers.Get(identityClient, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("Identity Provider still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckIdentityProviderExists(n string, idp *providers.Provider) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		identityClient, err := config.IAMNoVersionClient(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
+		}
+
+		found, err := providers.Get(identityClient, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("Identity Provider not found")
+		}
+
+		*idp = *found
+
+		return nil
+	}
+}
+
+func testAccIdentityProvider_saml(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_identity_provider" "provider_1" {
+  name     = "%s"
+  protocol = "saml"
+}
+`, name)
+}
+
+func testAccIdentityProvider_saml_update(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_identity_provider" "provider_1" {
+  name     = "%s"
+  protocol = "saml"
+  enabled  = false
+}
+`, name)
+}
+
+func testAccIdentityProvider_oidc(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_identity_provider" "provider_1" {
+  name        = "%s"
+  protocol    = "oidc"
+  description = "unit test"
+
+  openid_connect_config {
+    access_type            = "program_console"
+    provider_url           = "https://accounts.example.com"
+    client_id              = "client_id_example"
+    authorization_endpoint = "https://accounts.example.com/o/oauth2/v2/auth"
+    scopes                 = ["openid"]
+    signing_key            = jsonencode(
+    {
+      keys = [
+        {
+          alg = "RS256"
+          e   = "AQAB"
+          kid = "d05ef20c4512645vv1..."
+          kty = "RSA"
+          n   = "cws_cnjiwsbvweolwn_-vnl..."
+          use = "sig"
+        },
+      ]
+    }
+    )
+  }
+}
+`, name)
+}
+
+func testAccIdentityProvider_oidc_update(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_identity_provider" "provider_1" {
+  name        = "%s"
+  protocol    = "oidc"
+  enabled     = false
+  description = "acceptance test"
+
+  openid_connect_config {
+    access_type  = "program"
+    provider_url = "https://accounts.example.com"
+    client_id    = "client_id_demo"
+    signing_key  = jsonencode(
+    {
+      keys = [
+        {
+          alg = "RS256"
+          e   = "AQAB"
+          kid = "d05ef20c4512645vv1..."
+          kty = "RSA"
+          n   = "cws_cnjiwsbvweolwn_-vnl..."
+          use = "sig"
+        },
+      ]
+    }
+    )
+  }
+}
+`, name)
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/mappings/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/mappings/requests.go
@@ -1,0 +1,101 @@
+package mappings
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+var RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+type MappingOption struct {
+	Rules []MappingRule `json:"rules" required:"true"`
+}
+
+type MappingRule struct {
+	Local  []LocalRule  `json:"local" required:"true"`
+	Remote []RemoteRule `json:"remote" required:"true"`
+}
+
+type LocalRule struct {
+	User  LocalRuleVal  `json:"user" required:"true"`
+	Group *LocalRuleVal `json:"group,omitempty"`
+}
+
+type LocalRuleVal struct {
+	Name string `json:"name"`
+}
+
+type RemoteRule struct {
+	Type     string   `json:"type" required:"true"`
+	AnyOneOf []string `json:"any_one_of,omitempty"`
+	NotAnyOf []string `json:"not_any_of,omitempty"`
+}
+
+type responseBody struct {
+	Mapping IdentityMapping `json:"mapping"`
+}
+
+func Create(c *golangsdk.ServiceClient, id string, opts MappingOption) (*IdentityMapping, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "mapping")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Put(resourceURL(c, id), b, &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+
+	if err == nil {
+		var r responseBody
+		rst.ExtractInto(&r)
+		return &r.Mapping, nil
+	}
+	return nil, err
+}
+
+func Get(c *golangsdk.ServiceClient, id string) (*IdentityMapping, error) {
+	var rst golangsdk.Result
+	_, err := c.Get(resourceURL(c, id), &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r responseBody
+		rst.ExtractInto(&r)
+		return &r.Mapping, nil
+	}
+	return nil, err
+}
+
+func List(client *golangsdk.ServiceClient) pagination.Pager {
+	return pagination.NewPager(client, listURL(client), func(r pagination.PageResult) pagination.Page {
+		return IdentityMappingPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+func Update(c *golangsdk.ServiceClient, id string, opts MappingOption) (*IdentityMapping, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "mapping")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Patch(resourceURL(c, id), b, &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r responseBody
+		rst.ExtractInto(&r)
+		return &r.Mapping, nil
+	}
+	return nil, err
+}
+
+func Delete(c *golangsdk.ServiceClient, id string) error {
+	_, err := c.Delete(resourceURL(c, id), &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	return err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/mappings/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/mappings/results.go
@@ -1,0 +1,54 @@
+package mappings
+
+import (
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+type IdentityMapping struct {
+	ID    string        `json:"id"`
+	Rules []MappingRule `json:"rules"`
+	Links LinksSelf     `json:"links"`
+}
+
+type LinksSelf struct {
+	Self string `json:"self"`
+}
+
+type Links struct {
+	Next     string `json:"next"`
+	Self     string `json:"self"`
+	Previous string `json:"previous"`
+}
+
+type IdentityMappingPage struct {
+	pagination.LinkedPageBase
+}
+
+func (r IdentityMappingPage) IsEmpty() (bool, error) {
+	mappings, err := ExtractMappings(r)
+	return len(mappings) == 0, err
+}
+
+func (r IdentityMappingPage) NextPageURL() (string, error) {
+	var s struct {
+		Links Links `json:"links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	url := s.Links.Next
+	if url == "" {
+		return "", nil
+	}
+	return url, nil
+}
+
+func ExtractMappings(r pagination.Page) ([]IdentityMapping, error) {
+	var s struct {
+		Links    Links             `json:"links"`
+		Mappings []IdentityMapping `json:"mappings"`
+	}
+	err := (r.(IdentityMappingPage)).ExtractInto(&s)
+	return s.Mappings, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/mappings/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/mappings/urls.go
@@ -1,0 +1,11 @@
+package mappings
+
+import "github.com/chnsz/golangsdk"
+
+func resourceURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL("v3", "OS-FEDERATION", "mappings", id)
+}
+
+func listURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("v3", "OS-FEDERATION", "mappings")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/metadatas/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/metadatas/requests.go
@@ -1,0 +1,45 @@
+package metadatas
+
+import "github.com/chnsz/golangsdk"
+
+var RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+type ImportOpts struct {
+	DomainID string `json:"domain_id" required:"true"`
+	Metadata string `json:"metadata" required:"true"`
+	// It is not a required field, but this argument must be present in the parameter.
+	XAccountType string `json:"xaccount_type"`
+}
+
+func Import(c *golangsdk.ServiceClient, idpID string, protocolID string, opts ImportOpts) (*MetadataResult, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Post(resourceURL(c, idpID, protocolID), b, &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r MetadataResult
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+func Get(c *golangsdk.ServiceClient, idpID string, protocolID string) (*Metadata, error) {
+	var rst golangsdk.Result
+	_, err := c.Get(resourceURL(c, idpID, protocolID), &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r Metadata
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/metadatas/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/metadatas/results.go
@@ -1,0 +1,16 @@
+package metadatas
+
+type MetadataResult struct {
+	Message string `json:"message"`
+}
+
+type Metadata struct {
+	ID           string `json:"id"`
+	IdpID        string `json:"idp_id"`
+	EntityID     string `json:"entity_id"`
+	ProtocolID   string `json:"protocol_id"`
+	DomainID     string `json:"domain_id"`
+	XAccountType string `json:"xaccount_type"`
+	UpdateTime   string `json:"update_time"`
+	Data         string `json:"data"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/metadatas/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/metadatas/urls.go
@@ -1,0 +1,7 @@
+package metadatas
+
+import "github.com/chnsz/golangsdk"
+
+func resourceURL(c *golangsdk.ServiceClient, idpID string, protocolID string) string {
+	return c.ServiceURL("v3-ext", "OS-FEDERATION", "identity_providers", idpID, "protocols", protocolID, "metadata")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/oidcconfig/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/oidcconfig/requests.go
@@ -1,0 +1,83 @@
+package oidcconfig
+
+import "github.com/chnsz/golangsdk"
+
+var RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+type CreateOpts struct {
+	AccessMode            string `json:"access_mode" required:"true"`
+	IdpURL                string `json:"idp_url" required:"true"`
+	ClientID              string `json:"client_id" required:"true"`
+	SigningKey            string `json:"signing_key" required:"true"`
+	AuthorizationEndpoint string `json:"authorization_endpoint,omitempty"`
+	Scope                 string `json:"scope,omitempty"`
+	ResponseType          string `json:"response_type,omitempty"`
+	ResponseMode          string `json:"response_mode,omitempty"`
+}
+
+type responseBody struct {
+	Config OpenIDConnectConfig `json:"openid_connect_config"`
+}
+
+func Create(c *golangsdk.ServiceClient, idpID string, opts CreateOpts) (*OpenIDConnectConfig, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "openid_connect_config")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Post(resourceURL(c, idpID), b, &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r responseBody
+		rst.ExtractInto(&r)
+		return &r.Config, nil
+	}
+	return nil, err
+}
+
+func Get(c *golangsdk.ServiceClient, idpID string) (*OpenIDConnectConfig, error) {
+	var rst golangsdk.Result
+	_, err := c.Get(resourceURL(c, idpID), &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+
+	if err == nil {
+		var r responseBody
+		rst.ExtractInto(&r)
+		return &r.Config, nil
+	}
+	return nil, err
+}
+
+type UpdateOpenIDConnectConfigOpts struct {
+	AccessMode            string `json:"access_mode" required:"true"`
+	IdpURL                string `json:"idp_url" required:"true"`
+	ClientID              string `json:"client_id" required:"true"`
+	SigningKey            string `json:"signing_key" required:"true"`
+	AuthorizationEndpoint string `json:"authorization_endpoint,omitempty"`
+	Scope                 string `json:"scope,omitempty"`
+	ResponseType          string `json:"response_type,omitempty"`
+	ResponseMode          string `json:"response_mode,omitempty"`
+}
+
+func Update(c *golangsdk.ServiceClient, idpID string, opts UpdateOpenIDConnectConfigOpts) (*OpenIDConnectConfig, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "openid_connect_config")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Put(resourceURL(c, idpID), b, &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r responseBody
+		rst.ExtractInto(&r)
+		return &r.Config, nil
+	}
+	return nil, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/oidcconfig/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/oidcconfig/results.go
@@ -1,0 +1,12 @@
+package oidcconfig
+
+type OpenIDConnectConfig struct {
+	AccessMode            string `json:"access_mode"`
+	IdpURL                string `json:"idp_url"`
+	ClientID              string `json:"client_id"`
+	AuthorizationEndpoint string `json:"authorization_endpoint"`
+	Scope                 string `json:"scope"`
+	ResponseType          string `json:"response_type"`
+	ResponseMode          string `json:"response_mode"`
+	SigningKey            string `json:"signing_key"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/oidcconfig/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/oidcconfig/urls.go
@@ -1,0 +1,7 @@
+package oidcconfig
+
+import "github.com/chnsz/golangsdk"
+
+func resourceURL(c *golangsdk.ServiceClient, idpID string) string {
+	return c.ServiceURL("v3.0", "OS-FEDERATION", "identity-providers", idpID, "openid-connect-config")
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/protocols/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/protocols/requests.go
@@ -1,0 +1,93 @@
+package protocols
+
+import "github.com/chnsz/golangsdk"
+
+var RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+type ProtocolOption struct {
+	MappingID string `json:"mapping_id,omitempty"`
+}
+
+func Create(c *golangsdk.ServiceClient, idpID, protocolID string, mappingID string) (*IdentityProtocol, error) {
+	opts := ProtocolOption{MappingID: mappingID}
+	b, err := golangsdk.BuildRequestBody(opts, "protocol")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Put(resourceURL(c, idpID, protocolID), b, &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r struct {
+			Protocol IdentityProtocol `json:"protocol"`
+		}
+		rst.ExtractInto(&r)
+		return &r.Protocol, nil
+	}
+	return nil, err
+}
+
+func Get(c *golangsdk.ServiceClient, idpID string, protocolID string) (*IdentityProtocol, error) {
+	var rst golangsdk.Result
+	_, err := c.Get(resourceURL(c, idpID, protocolID), &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+
+	if err == nil {
+		var r struct {
+			Protocol IdentityProtocol `json:"protocol"`
+		}
+		rst.ExtractInto(&r)
+		return &r.Protocol, nil
+	}
+	return nil, err
+}
+
+func List(c *golangsdk.ServiceClient, idpID string) ([]IdentityProtocol, error) {
+	var rst golangsdk.Result
+	_, err := c.Get(root(c, idpID), &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+
+	if err == nil {
+		var r struct {
+			Protocols []IdentityProtocol `json:"protocols"`
+		}
+		rst.ExtractInto(&r)
+		return r.Protocols, nil
+	}
+	return nil, err
+}
+
+func Update(c *golangsdk.ServiceClient, idpID string, id string, mappingID string) (*IdentityProtocol, error) {
+	opts := ProtocolOption{MappingID: mappingID}
+	b, err := golangsdk.BuildRequestBody(opts, "protocol")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Patch(resourceURL(c, idpID, id), b, &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r struct {
+			Protocol IdentityProtocol `json:"protocol"`
+		}
+		rst.ExtractInto(&r)
+		return &r.Protocol, nil
+	}
+	return nil, err
+}
+
+func Delete(c *golangsdk.ServiceClient, idpID string, protocolID string) *golangsdk.ErrResult {
+	var r golangsdk.ErrResult
+	_, r.Err = c.Delete(resourceURL(c, idpID, protocolID), &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	return &r
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/protocols/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/protocols/results.go
@@ -1,0 +1,12 @@
+package protocols
+
+type IdentityProtocol struct {
+	ID        string        `json:"id"`
+	MappingID string        `json:"mapping_id"`
+	Links     ProtocolLinks `json:"links"`
+}
+
+type ProtocolLinks struct {
+	IdentityProvider string `json:"identity_provider"`
+	Self             string `json:"self"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/protocols/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/protocols/urls.go
@@ -1,0 +1,11 @@
+package protocols
+
+import "github.com/chnsz/golangsdk"
+
+func root(c *golangsdk.ServiceClient, idpID string) string {
+	return c.ServiceURL("v3", "OS-FEDERATION", "identity_providers", idpID, "protocols")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, idpID string, protocolID string) string {
+	return c.ServiceURL("v3", "OS-FEDERATION", "identity_providers", idpID, "protocols", protocolID)
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/providers/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/providers/requests.go
@@ -1,0 +1,80 @@
+package providers
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+var RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+type CreateProviderOpts struct {
+	SsoType     string `json:"sso_type,omitempty"`
+	Description string `json:"description,omitempty"`
+	Enabled     bool   `json:"enabled,omitempty"`
+}
+
+type responseBody struct {
+	IdentityProvider Provider `json:"identity_provider"`
+}
+
+func Create(c *golangsdk.ServiceClient, id string, opts CreateProviderOpts) (*Provider, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "identity_provider")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Put(resourceURL(c, id), b, &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r responseBody
+		rst.ExtractInto(&r)
+		return &r.IdentityProvider, nil
+	}
+	return nil, err
+}
+
+func Get(c *golangsdk.ServiceClient, id string) (*Provider, error) {
+	var rst golangsdk.Result
+	_, err := c.Get(resourceURL(c, id), &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r responseBody
+		rst.ExtractInto(&r)
+		return &r.IdentityProvider, nil
+	}
+	return nil, err
+}
+
+type UpdateOpts struct {
+	Description *string `json:"description,omitempty"`
+	Enabled     *bool   `json:"enabled,omitempty"`
+}
+
+func Update(c *golangsdk.ServiceClient, id string, opts UpdateOpts) (*Provider, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "identity_provider")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Patch(resourceURL(c, id), b, &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r responseBody
+		rst.ExtractInto(&r)
+		return &r.IdentityProvider, nil
+	}
+	return nil, err
+}
+
+func Delete(c *golangsdk.ServiceClient, regionID string) error {
+	_, err := c.Delete(resourceURL(c, regionID), &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	return err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/providers/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/providers/results.go
@@ -1,0 +1,22 @@
+package providers
+
+type ProviderLinks struct {
+	Self      string `json:"self"`
+	Protocols string `json:"protocols"`
+	Next      string `json:"next"`
+	Previous  string `json:"previous"`
+}
+
+type Provider struct {
+	SsoType     string        `json:"sso_type"`
+	ID          string        `json:"id"`
+	Description string        `json:"description"`
+	Enabled     bool          `json:"enabled"`
+	RemoteIDs   []string      `json:"remote_ids"`
+	Links       ProviderLinks `json:"links"`
+}
+
+type ProviderList struct {
+	Links             ProviderLinks `json:"links"`
+	IdentityProviders []Provider    `json:"identity_providers"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/providers/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/identity/federatedauth/providers/urls.go
@@ -1,0 +1,7 @@
+package providers
+
+import "github.com/chnsz/golangsdk"
+
+func resourceURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL("v3", "OS-FEDERATION", "identity_providers", id)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -121,6 +121,11 @@ github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers
 github.com/chnsz/golangsdk/openstack/ecs/v1/flavors
 github.com/chnsz/golangsdk/openstack/ecs/v1/tags
 github.com/chnsz/golangsdk/openstack/elb/v3/listeners
+github.com/chnsz/golangsdk/openstack/identity/federatedauth/mappings
+github.com/chnsz/golangsdk/openstack/identity/federatedauth/metadatas
+github.com/chnsz/golangsdk/openstack/identity/federatedauth/oidcconfig
+github.com/chnsz/golangsdk/openstack/identity/federatedauth/protocols
+github.com/chnsz/golangsdk/openstack/identity/federatedauth/providers
 github.com/chnsz/golangsdk/openstack/identity/v2/tenants
 github.com/chnsz/golangsdk/openstack/identity/v2/tokens
 github.com/chnsz/golangsdk/openstack/identity/v3.0/policies


### PR DESCRIPTION
fixes #553 

the testing result as follows:

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccIdentityProvider_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccIdentityProvider_basic -timeout 720m
=== RUN   TestAccIdentityProvider_basic
=== PAUSE TestAccIdentityProvider_basic
=== CONT  TestAccIdentityProvider_basic
--- PASS: TestAccIdentityProvider_basic (12.47s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 12.487s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccIdentityProviderConversion_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccIdentityProviderConversion_basic -timeout 720m
=== RUN   TestAccIdentityProviderConversion_basic
=== PAUSE TestAccIdentityProviderConversion_basic
=== CONT  TestAccIdentityProviderConversion_basic
--- PASS: TestAccIdentityProviderConversion_basic (14.62s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 14.631s
```