### PR TITLE
feat(DMS/maintain windows): add a data source to query DMS maintain windows

### DIFF
--- a/docs/data-sources/dms_maintainwindow.md
+++ b/docs/data-sources/dms_maintainwindow.md
@@ -1,0 +1,35 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+# flexibleengine_dms_maintainwindow
+
+Use this data source to get the ID of an available FlexibleEngine dms maintainwindow. This is an alternative
+to `flexibleengine_dms_maintainwindow_v1`
+
+## Example Usage
+
+```hcl
+data "flexibleengine_dms_maintainwindow" "maintainwindow1" {
+  seq = 1
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the dms maintainwindows. If omitted, the provider-level
+  region will be used.
+
+* `seq` - (Required, Int) Indicates the sequential number of a maintenance time window.
+
+* `begin` - (Optional, String) Indicates the time at which a maintenance time window starts.
+
+* `end` - (Required, String) Indicates the time at which a maintenance time window ends.
+
+* `default` - (Required, Bool) Indicates whether a maintenance time window is set to the default time segment.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a data source ID in UUID format.

--- a/flexibleengine/data_source_flexibleengine_dms_maintainwindow.go
+++ b/flexibleengine/data_source_flexibleengine_dms_maintainwindow.go
@@ -1,0 +1,102 @@
+package flexibleengine
+
+import (
+	"context"
+	"log"
+	"strconv"
+
+	"github.com/chnsz/golangsdk/openstack/dms/v1/maintainwindows"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func DataSourceDmsMaintainWindow() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDmsMaintainWindowRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"seq": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"begin": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"end": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"default": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDmsMaintainWindowRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	region := GetRegion(d, config)
+
+	dmsV1Client, err := config.DmsV1Client(region)
+	if err != nil {
+		return diag.Errorf("Error creating FlexibleEngine DMS client V1: %s", err)
+	}
+
+	maintainWindows, err := maintainwindows.Get(dmsV1Client).Extract()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if len(maintainWindows.MaintainWindows) < 1 {
+		return diag.Errorf("Your query returned no results. Please change your filters and try again.")
+	}
+	filter := make(map[string]interface{})
+	if v, ok := d.GetOk("seq"); ok {
+		filter["ID"] = v.(int)
+	}
+	if v, ok := d.GetOk("begin"); ok {
+		filter["Begin"] = v.(string)
+	}
+	if v, ok := d.GetOk("end"); ok {
+		filter["End"] = v.(string)
+	}
+	if v, ok := d.GetOk("default"); ok {
+		filter["Default"] = v.(bool)
+	}
+
+	data, err := utils.FilterSliceWithZeroField(maintainWindows.MaintainWindows, filter)
+	if err != nil {
+		return diag.Errorf("Error filtering DMS maintain window data, %s", err)
+	}
+	if len(data) < 1 {
+		return diag.Errorf("Your query returned no results. Please change your filters and try again.")
+	}
+
+	mw := data[0].(maintainwindows.MaintainWindow)
+	log.Printf("[DEBUG] DMS MaintainWindow : %#v", mw)
+
+	d.SetId(strconv.Itoa(mw.ID))
+	mErr := multierror.Append(
+		d.Set("seq", mw.ID),
+		d.Set("begin", mw.Begin),
+		d.Set("end", mw.End),
+		d.Set("default", mw.Default),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("error setting DMS maintain window attributes: %s", mErr)
+	}
+
+	return nil
+}

--- a/flexibleengine/data_source_flexibleengine_dms_maintainwindow_test.go
+++ b/flexibleengine/data_source_flexibleengine_dms_maintainwindow_test.go
@@ -1,0 +1,34 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDmsMaintainWindowDataSource_basic(t *testing.T) {
+	dataSourceName := "data.flexibleengine_dms_maintainwindow.maintainwindow1"
+	dc := initDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDmsMaintainWindowDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "seq", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "begin", "22:00:00"),
+				),
+			},
+		},
+	})
+}
+
+var testAccDmsMaintainWindowDataSource_basic = fmt.Sprintf(`
+data "flexibleengine_dms_maintainwindow" "maintainwindow1" {
+  seq = 1
+}
+`)

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -231,6 +231,8 @@ func Provider() *schema.Provider {
 			"flexibleengine_vpcep_public_services":              dataSourceVPCEPPublicServices(),
 			"flexibleengine_vpcep_endpoints":                    dataSourceVPCEPEndpoints(),
 
+			"flexibleengine_dms_maintainwindow": DataSourceDmsMaintainWindow(),
+
 			// Deprecated data source
 			"flexibleengine_dcs_az_v1":      dataSourceDcsAZV1(),
 			"flexibleengine_dds_flavor_v3":  dataSourceDDSFlavorV3(),

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/aws/aws-sdk-go v1.25.3
-	github.com/chnsz/golangsdk v0.0.0-20211210025418-bfef50238f46
+	github.com/chnsz/golangsdk v0.0.0-20211222074358-97d483ca6411
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,9 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20211210025418-bfef50238f46 h1:43hIUYGkH3u7KBDcRQs2k2748R8xKRGlkie9T7/RJy0=
 github.com/chnsz/golangsdk v0.0.0-20211210025418-bfef50238f46/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20211222074358-97d483ca6411 h1:7IhpCtZ9S8aKDA8o7W7xveJCk/mgr+iliesXTAcHyC8=
+github.com/chnsz/golangsdk v0.0.0-20211222074358-97d483ca6411/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -235,7 +236,6 @@ github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
-github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4 h1:cTxwSmnaqLoo+4tLukHoB9iqHOu3LmLhRmgUxZo6Vp4=
 github.com/keybase/go-crypto v0.0.0-20200123153347-de78d2cb44f4/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.11.2 h1:MiK62aErc3gIiVEtyzKfeOHgW7atJb5g/KNX5m3c2nQ=

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/maintainwindows/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/maintainwindows/requests.go
@@ -1,0 +1,11 @@
+package maintainwindows
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// Get maintain windows
+func Get(client *golangsdk.ServiceClient) (r GetResult) {
+	_, r.Err = client.Get(getURL(client), &r.Body, nil)
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/maintainwindows/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/maintainwindows/results.go
@@ -1,0 +1,30 @@
+package maintainwindows
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// GetResponse response
+type GetResponse struct {
+	MaintainWindows []MaintainWindow `json:"maintain_windows"`
+}
+
+// MaintainWindow for dms
+type MaintainWindow struct {
+	ID      int    `json:"seq"`
+	Begin   string `json:"begin"`
+	End     string `json:"end"`
+	Default bool   `json:"default"`
+}
+
+// GetResult contains the body of getting detailed
+type GetResult struct {
+	golangsdk.Result
+}
+
+// Extract from GetResult
+func (r GetResult) Extract() (*GetResponse, error) {
+	var s GetResponse
+	err := r.Result.ExtractInto(&s)
+	return &s, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/maintainwindows/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/maintainwindows/urls.go
@@ -1,0 +1,16 @@
+package maintainwindows
+
+import (
+	"strings"
+
+	"github.com/chnsz/golangsdk"
+)
+
+// endpoint/instances/maintain-windows
+const resourcePath = "instances/maintain-windows"
+
+// getURL will build the get url of get function
+func getURL(client *golangsdk.ServiceClient) string {
+	// remove projectid from endpoint
+	return strings.Replace(client.ServiceURL(resourcePath), "/"+client.ProjectID, "", -1)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -58,7 +58,7 @@ github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 github.com/bgentry/go-netrc/netrc
-# github.com/chnsz/golangsdk v0.0.0-20211210025418-bfef50238f46
+# github.com/chnsz/golangsdk v0.0.0-20211222074358-97d483ca6411
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal
@@ -109,6 +109,7 @@ github.com/chnsz/golangsdk/openstack/dds/v3/flavors
 github.com/chnsz/golangsdk/openstack/dds/v3/instances
 github.com/chnsz/golangsdk/openstack/dis/v2/streams
 github.com/chnsz/golangsdk/openstack/dli/v1/queues
+github.com/chnsz/golangsdk/openstack/dms/v1/maintainwindows
 github.com/chnsz/golangsdk/openstack/dns/v2/ptrrecords
 github.com/chnsz/golangsdk/openstack/dns/v2/recordsets
 github.com/chnsz/golangsdk/openstack/dns/v2/zones


### PR DESCRIPTION
add a data source to query DMS maintain windows

fixes: #676 

## Acceptance Steps Performed
```
make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDmsMaintainWindowDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDmsMaintainWindowDataSource_basic -timeout 720m
=== RUN   TestAccDmsMaintainWindowDataSource_basic
=== PAUSE TestAccDmsMaintainWindowDataSource_basic
=== CONT  TestAccDmsMaintainWindowDataSource_basic
--- PASS: TestAccDmsMaintainWindowDataSource_basic (47.89s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 47.950s
```