### PR TITLE
feat: add dms product data source

### DIFF
--- a/docs/data-sources/dms_product.md
+++ b/docs/data-sources/dms_product.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+# flexibleengine_dms_product
+
+Use this data source to get details about an available FlexibleEngine DMS product.
+
+## Example Usage
+
+```hcl
+data "flexibleengine_dms_product" "product1" {
+  engine    = "kafka"
+  bandwidth = "300MB"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region in which to obtain the DMS products.
+  If omitted, the provider-level region will be used.
+
+* `bandwidth` - (Required, String) Specifies the bandwidth of a DMS instance.
+  The valid values are **100MB**, **300MB**, **600MB** and **1200MB**.
+
+* `engine` - (Optional, String) Specifies the name of a message engine. Only **kafka** is supported.
+
+* `version` - (Optional, String) Specifies the version of a message engine. The default value is **2.3.0**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The DMS product ID.
+
+* `availability_zones` - The list of availability zones where there are available resources.
+
+* `spec_code` - The DMS product specification, for example, dms.instance.kafka.cluster.c3.small.2.
+
+* `cpu_arch` - The CPU architecture of a DMS instance.
+
+* `ecs_flavor_id` - The flavor of the corresponding ECS.
+
+* `partition_num` - The maximum number of topics in a Kafka instance.
+
+* `storage_space` - The minimum storage capacity of the DMS product.
+
+* `storage_spec_codes` - The list of supported storage specification.
+  The item of the list can be one of **dms.physical.storage.ultra** and **dms.physical.storage.high**.
+
+* `max_tps` - The maximum number of messages per unit time.

--- a/flexibleengine/data_source_flexibleengine_dms_product.go
+++ b/flexibleengine/data_source_flexibleengine_dms_product.go
@@ -1,0 +1,155 @@
+package flexibleengine
+
+import (
+	"context"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk/openstack/dms/v2/products"
+)
+
+func dataSourceDmsProduct() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceDmsProductRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"bandwidth": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{"100MB", "300MB", "600MB", "1200MB"},
+					false,
+				),
+			},
+			"engine": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "kafka",
+				ValidateFunc: validation.StringInSlice([]string{"kafka"}, false),
+			},
+			"engine_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "2.3.0",
+			},
+
+			"availability_zones": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"spec_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cpu_arch": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ecs_flavor_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"partition_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"storage_space": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"storage_spec_codes": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"max_tps": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDmsProductRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	dmsV1Client, err := config.DmsV1Client(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error get FlexibleEngine DMS product client V1: %s", err)
+	}
+
+	bandwidth := d.Get("bandwidth").(string)
+	engine := d.Get("engine").(string)
+	version := d.Get("engine_version").(string)
+
+	v, err := products.Get(dmsV1Client, engine)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var filteredProduct *products.Detail
+	for _, pd := range v.Hourly {
+		if pd.Version != version {
+			continue
+		}
+
+		for _, value := range pd.Values {
+			for _, detail := range value.Details {
+				if detail.Bandwidth == bandwidth {
+					filteredProduct = &detail
+					break
+				}
+			}
+			if filteredProduct != nil {
+				break
+			}
+		}
+		if filteredProduct != nil {
+			break
+		}
+	}
+
+	if filteredProduct == nil {
+		return diag.Errorf("Your query returned no results. Please change your filters and try again.")
+	}
+
+	log.Printf("[DEBUG] DMS product detail : %#v", filteredProduct)
+	d.SetId(filteredProduct.ProductID)
+
+	maxTps, _ := strconv.Atoi(filteredProduct.Tps)
+	partitionNum, _ := strconv.Atoi(filteredProduct.PartitionNum)
+	volumeSize, _ := strconv.Atoi(filteredProduct.Storage)
+	storageSpecCodes := make([]string, 0, len(filteredProduct.IOs))
+	for _, v := range filteredProduct.IOs {
+		storageSpecCodes = append(storageSpecCodes, v.StorageSpecCode)
+	}
+
+	var mErr *multierror.Error
+	mErr = multierror.Append(err,
+		d.Set("bandwidth", filteredProduct.Bandwidth),
+		d.Set("ecs_flavor_id", filteredProduct.EcsFlavorId),
+		d.Set("availability_zones", filteredProduct.AvailableZones),
+		d.Set("cpu_arch", filteredProduct.ArchType),
+		d.Set("spec_code", filteredProduct.SpecCode),
+		d.Set("partition_num", partitionNum),
+		d.Set("max_tps", maxTps),
+		d.Set("storage_space", volumeSize),
+		d.Set("storage_spec_codes", storageSpecCodes),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("Error setting DMS product attributes: %s", mErr)
+	}
+
+	return nil
+}

--- a/flexibleengine/data_source_flexibleengine_dms_product_test.go
+++ b/flexibleengine/data_source_flexibleengine_dms_product_test.go
@@ -1,0 +1,53 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDmsProductDataSource_basic(t *testing.T) {
+	dataSourceName := "data.flexibleengine_dms_product.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDmsProductDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDmsProductDataSourceID(dataSourceName),
+					resource.TestCheckResourceAttr(dataSourceName, "engine", "kafka"),
+					resource.TestCheckResourceAttr(dataSourceName, "partition_num", "300"),
+					resource.TestCheckResourceAttr(dataSourceName, "storage_spec_codes.#", "2"),
+					resource.TestCheckResourceAttr(dataSourceName, "availability_zones.#", "3"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "cpu_arch"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "spec_code"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDmsProductDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find DMS product data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("DMS product data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+var testAccDmsProductDataSource_basic = fmt.Sprintf(`
+data "flexibleengine_dms_product" "test" {
+  bandwidth = "100MB"
+}
+`)

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -216,6 +216,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_cts_tracker_v1":                     dataSourceCTSTrackerV1(),
 			"flexibleengine_dcs_maintainwindow_v1":              dataSourceDcsMaintainWindowV1(),
 			"flexibleengine_dcs_product_v1":                     dataSourceDcsProductV1(),
+			"flexibleengine_dms_product":                        dataSourceDmsProduct(),
 			"flexibleengine_cce_node_v3":                        dataSourceCceNodesV3(),
 			"flexibleengine_cce_node_ids_v3":                    dataSourceCceNodeIdsV3(),
 			"flexibleengine_cce_cluster_v3":                     dataSourceCCEClusterV3(),

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/products/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/products/requests.go
@@ -1,0 +1,25 @@
+package products
+
+import (
+	"fmt"
+
+	"github.com/chnsz/golangsdk"
+)
+
+// Get products
+func Get(client *golangsdk.ServiceClient, engine string) (*GetResponse, error) {
+	if len(engine) == 0 {
+		return nil, fmt.Errorf("The parameter \"engine\" cannot be empty, it is required.")
+	}
+	url := getURL(client)
+	url = url + "?engine=" + engine
+
+	var rst golangsdk.Result
+	_, err := client.Get(url, &rst.Body, nil)
+	if err == nil {
+		var r GetResponse
+		err = rst.ExtractInto(&r)
+		return &r, err
+	}
+	return nil, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/products/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/products/results.go
@@ -1,0 +1,58 @@
+package products
+
+// GetResponse response
+type GetResponse struct {
+	Hourly  []Parameter `json:"Hourly"`
+	Monthly []Parameter `json:"Monthly"`
+}
+
+// Parameter for dms
+type Parameter struct {
+	Name    string  `json:"name"`
+	Version string  `json:"version"`
+	Values  []Value `json:"values"`
+}
+
+// Value for dms
+type Value struct {
+	Details          []Detail `json:"detail"`
+	Name             string   `json:"name"`
+	UnavailableZones []string `json:"unavailable_zones"`
+	AvailableZones   []string `json:"available_zones"`
+}
+
+// Detail for dms
+type Detail struct {
+	Storage          string        `json:"storage"`
+	ProductID        string        `json:"product_id"`
+	SpecCode         string        `json:"spec_code"`
+	VMSpecification  string        `json:"vm_specification"`
+	ProductInfos     []ProductInfo `json:"product_info"`
+	PartitionNum     string        `json:"partition_num"`
+	Bandwidth        string        `json:"bandwidth"`
+	Tps              string        `json:"tps"`
+	IOs              []IO          `json:"io"`
+	UnavailableZones []string      `json:"unavailable_zones"`
+	AvailableZones   []string      `json:"available_zones"`
+	EcsFlavorId      string        `json:"ecs_flavor_id"`
+	ArchType         string        `json:"arch_type"`
+}
+
+// ProductInfo for dms
+type ProductInfo struct {
+	Storage          string   `json:"storage"`
+	NodeNum          string   `json:"node_num"`
+	ProductID        string   `json:"product_id"`
+	SpecCode         string   `json:"spec_code"`
+	IOs              []IO     `json:"io"`
+	AvailableZones   []string `json:"available_zones"`
+	UnavailableZones []string `json:"unavailable_zones"`
+}
+
+type IO struct {
+	IOType           string   `json:"io_type"`
+	StorageSpecCode  string   `json:"storage_spec_code"`
+	AvailableZones   []string `json:"available_zones"`
+	UnavailableZones []string `json:"unavailable_zones"`
+	VolumeType       string   `json:"volume_type"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/products/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v2/products/urls.go
@@ -1,0 +1,15 @@
+package products
+
+import (
+	"strings"
+
+	"github.com/chnsz/golangsdk"
+)
+
+// endpoint/products
+const resourcePath = "products"
+
+func getURL(client *golangsdk.ServiceClient) string {
+	// remove projectid from endpoint
+	return strings.Replace(client.ServiceURL(resourcePath), "/"+client.ProjectID, "", -1)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -109,6 +109,7 @@ github.com/chnsz/golangsdk/openstack/dds/v3/flavors
 github.com/chnsz/golangsdk/openstack/dds/v3/instances
 github.com/chnsz/golangsdk/openstack/dis/v2/streams
 github.com/chnsz/golangsdk/openstack/dli/v1/queues
+github.com/chnsz/golangsdk/openstack/dms/v2/products
 github.com/chnsz/golangsdk/openstack/dns/v2/ptrrecords
 github.com/chnsz/golangsdk/openstack/dns/v2/recordsets
 github.com/chnsz/golangsdk/openstack/dns/v2/zones


### PR DESCRIPTION
related to #447, add new data source: **flexibleengine_dms_product**. 

the acceptance testing as follows:
```
make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDmsProductDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDmsProductDataSource_basic -timeout 720m
=== RUN   TestAccDmsProductDataSource_basic
=== PAUSE TestAccDmsProductDataSource_basic
=== CONT  TestAccDmsProductDataSource_basic
--- PASS: TestAccDmsProductDataSource_basic (5.80s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 5.816s
```