### PR TITLE
feat: add dms kafka instance resource

### DIFF
--- a/docs/resources/dms_kafka_instance.md
+++ b/docs/resources/dms_kafka_instance.md
@@ -1,0 +1,156 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+# flexibleengine_dms_kafka_instance
+
+Manage a DMS Kafka instance resources within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+variable vpc_id {}
+variable subnet_id {}
+variable security_group_id {}
+
+data "flexibleengine_dms_product" "test" {
+  bandwidth = "100MB"
+}
+
+resource "flexibleengine_dms_kafka_instance" "product_1" {
+  name               = "instance_1"
+  engine_version     = "2.3.0"
+  bandwidth          = "100MB"
+  availability_zones = data.flexibleengine_dms_product.product_1.availability_zones
+  product_id         = data.flexibleengine_dms_product.test.id
+  storage_space      = data.flexibleengine_dms_product.test.storage_space
+  storage_spec_code  = "dms.physical.storage.ultra"
+
+  vpc_id            = var.vpc_id
+  network_id        = var.subnet_id
+  security_group_id = var.security_group_id
+
+  access_user = "user"
+  password    = "Kafkatest@123"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the DMS Kafka instance resource.
+  If omitted, the provider-level region will be used. Changing this creates a new instance resource.
+
+* `name` - (Required, String) Specifies the name of the DMS Kafka instance. An instance name starts with a letter,
+  consists of 4 to 64 characters, and supports only letters, digits, hyphens (-) and underscores (_).
+
+* `bandwidth` - (Required, String, ForceNew) The baseline bandwidth of a Kafka instance, that is, the maximum amount of
+  data transferred per unit time. The valid values are **100MB**, **300MB**, **600MB** and **1200MB**.
+  Changing this creates a new instance resource.
+
+* `product_id` - (Required, String, ForceNew) Specifies a product ID. You can get the value from id of
+  [flexibleengine_dms_product](https://registry.terraform.io/providers/FlexibleEngineCloud/flexibleengine/latest/docs/data-sources/dms_product)
+  data source. Changing this creates a new instance resource.
+
+* `storage_space` - (Required, Int, ForceNew) Specifies the message storage capacity, the unit is GB. Value range:
+  + When bandwidth is **100MB**: 600–90,000 GB
+  + When bandwidth is **300MB**: 1,200–90,000 GB
+  + When bandwidth is **600MB**: 2,400–90,000 GB
+  + When bandwidth is **1,200MB**: 4,800–90,000 GB
+
+  Changing this creates a new instance resource.
+
+* `availability_zones` - (Required, List, ForceNew) The names of the AZ where the Kafka instance resides.
+  Changing this creates a new instance resource.
+
+  -> **NOTE:** Deploy one availability zone or at least three availability zones. Do not select two availability zones.
+  Deploy to more availability zones, the better the reliability and SLA coverage.
+
+* `vpc_id` - (Required, String, ForceNew) Specifies the ID of a VPC.
+  Changing this creates a new instance resource.
+
+* `network_id` - (Required, String, ForceNew) Specifies the ID of a subnet.
+  Changing this creates a new instance resource.
+
+* `security_group_id` - (Required, String) Specifies the ID of a security group.
+
+* `description` - (Optional, String) Specifies the description of the DMS Kafka instance.
+  It is a character string containing not more than 1,024 characters.
+
+* `engine_version` - (Optional, String, ForceNew) Specifies the version of the Kafka engine. Valid values are "1.1.0"
+  and "2.3.0". Defaults to **2.3.0**. Changing this creates a new instance resource.
+
+* `storage_spec_code` - (Optional, String, ForceNew) Specifies the storage I/O specification. Value range:
+  + When bandwidth is **100MB**: dms.physical.storage.high or dms.physical.storage.ultra
+  + When bandwidth is **300MB**: dms.physical.storage.high or dms.physical.storage.ultra
+  + When bandwidth is **600MB**: dms.physical.storage.ultra
+  + When bandwidth is **1,200MB**: dms.physical.storage.ultra
+
+  Defaults to **dms.physical.storage.ultra**. Changing this creates a new instance resource.
+
+* `access_user` - (Optional, String, ForceNew) Specifies a username who can accesse the instance with
+  SASL authentication. A username consists of 4 to 64 characters and supports only letters, digits, and hyphens (-).
+  Changing this creates a new instance resource.
+
+* `password` - (Optional, String, ForceNew) Specifies the password of the access user. A password must meet the
+  following complexity requirements: Must be 8 to 32 characters long. Must contain at least 2 of the following character
+  types: lowercase letters, uppercase letters, digits, and special characters (`~!@#$%^&*()-_=+\\|[{}]:'",<.>/?).
+  Changing this creates a new instance resource.
+
+  -> **NOTE:** If `access_user` and `password` are specified, Kafka SASL_SSL will be automatically enabled.
+
+* `maintain_begin` - (Optional, String) Specifies the time at which a maintenance time window starts. Format: HH:mm:ss.
+  The start time must be set to 22:00:00, 02:00:00, 06:00:00, 10:00:00, 14:00:00, or 18:00:00.
+  The system automatically allocates the default start time 02:00:00.
+
+* `maintain_end` - (Optional, String) Specifies the time at which a maintenance time window ends. Format: HH:mm:ss.
+  The end time is four hours later than the start time. For example, if the start time is 22:00:00, the end time is
+  02:00:00. The system automatically allocates the default end time 06:00:00.
+
+  -> **NOTE:**  The start time and end time of a maintenance time window must be set in pairs.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+* `status` - Indicates the status of the DMS Kafka instance.
+* `engine` - Indicates the message engine, the value is "kafka".
+* `engine_type` - Indicates the DMS Kafka instance type, the value is "cluster".
+* `product_spec_code` - Indicates the DMS Kafka instance specification.
+* `partition_num` - Indicates the maximum number of topics in the DMS Kafka instance.
+* `used_storage_space` - Indicates the used message storage space. Unit: GB
+* `vpc_name` - Indicates the name of a vpc.
+* `subnet_name` - Indicates the name of a subnet.
+* `security_group_name` - Indicates the name of a security group.
+* `node_num` - Indicates the count of ECS instances.
+* `connect_address` - Indicates the IP addresses of the DMS Kafka instance.
+* `port` - Indicates the port number of the DMS Kafka instance.
+* `ssl_enable` - Indicates whether the Kafka SASL_SSL is enabled.
+* `created_at` - Indicates the creation time of the DMS Kafka instance.
+
+## Import
+
+DMS Kafka instance can be imported using the instance id, e.g.
+
+```
+ $ terraform import flexibleengine_dms_kafka_instance.instance_1 8d3c7938-dc47-4937-a30f-c80de381c5e3
+```
+
+Note that the imported state may not be identical to your resource definition, because of `access_user` and `password`
+are missing from the API response due to security reason. It is generally recommended running `terraform plan` after
+importing a DMS Kafka instance. You can then decide if changes should be applied to the instance, or the resource
+definition should be updated to align with the instance. Also you can ignore changes as below.
+
+```
+resource "flexibleengine_dms_kafka_instance" "instance_1" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      access_user, password,
+    ]
+  }
+}
+```

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -251,6 +251,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_dns_recordset_v2":                   resourceDNSRecordSetV2(),
 			"flexibleengine_dns_zone_v2":                        resourceDNSZoneV2(),
 			"flexibleengine_dcs_instance_v1":                    resourceDcsInstanceV1(),
+			"flexibleengine_dms_kafka_instance":                 resourceDmsKafkaInstances(),
 			"flexibleengine_dis_stream":                         resourceDisStreamV2(),
 			"flexibleengine_fw_firewall_group_v2":               resourceFWFirewallGroupV2(),
 			"flexibleengine_fw_policy_v2":                       resourceFWPolicyV2(),

--- a/flexibleengine/resource_flexibleengine_dms_kafka_instance.go
+++ b/flexibleengine/resource_flexibleengine_dms_kafka_instance.go
@@ -1,0 +1,405 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/dms/v1/instances"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const (
+	ssdSpecCode = "dms.physical.storage.ultra"
+	sasSpecCode = "dms.physical.storage.high"
+)
+
+func resourceDmsKafkaInstances() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDmsKafkaInstancesCreate,
+		Read:   resourceDmsKafkaInstancesRead,
+		Update: resourceDmsKafkaInstancesUpdate,
+		Delete: resourceDmsKafkaInstancesDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"engine_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "2.3.0",
+			},
+
+			"bandwidth": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice(
+					[]string{"100MB", "300MB", "600MB", "1200MB"},
+					false,
+				),
+			},
+			"product_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"storage_space": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"storage_spec_code": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  ssdSpecCode,
+				ValidateFunc: validation.StringInSlice(
+					[]string{ssdSpecCode, sasSpecCode},
+					false,
+				),
+			},
+
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"network_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"security_group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"availability_zones": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"access_user": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"password"},
+			},
+			"password": {
+				Type:         schema.TypeString,
+				Sensitive:    true,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"access_user"},
+			},
+			"maintain_begin": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				RequiredWith: []string{"maintain_end"},
+			},
+			"maintain_end": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				RequiredWith: []string{"maintain_begin"},
+			},
+
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"product_spec_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"partition_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"vpc_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"subnet_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"security_group_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"node_num": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"connect_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"ssl_enable": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"used_storage_space": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDmsKafkaInstancesCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	dmsV1Client, err := config.DmsV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine DMS instance client: %s", err)
+	}
+
+	sslEnable := false
+	if d.Get("access_user").(string) != "" || d.Get("password").(string) != "" {
+		sslEnable = true
+	}
+	createOpts := &instances.CreateOps{
+		Engine:          "kafka",
+		EngineVersion:   d.Get("engine_version").(string),
+		Name:            d.Get("name").(string),
+		Description:     d.Get("description").(string),
+		Specification:   d.Get("bandwidth").(string),
+		ProductID:       d.Get("product_id").(string),
+		StorageSpace:    d.Get("storage_space").(int),
+		StorageSpecCode: d.Get("storage_spec_code").(string),
+		VPCID:           d.Get("vpc_id").(string),
+		SubnetID:        d.Get("network_id").(string),
+		SecurityGroupID: d.Get("security_group_id").(string),
+		AvailableZones:  utils.ExpandToStringList(d.Get("availability_zones").([]interface{})),
+		MaintainBegin:   d.Get("maintain_begin").(string),
+		MaintainEnd:     d.Get("maintain_end").(string),
+
+		AccessUser: d.Get("access_user").(string),
+		SslEnable:  sslEnable,
+	}
+
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	// Add password here so it wouldn't go in the above log entry
+	createOpts.Password = d.Get("password").(string)
+
+	v, err := instances.Create(dmsV1Client, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine DMS instance: %s", err)
+	}
+	log.Printf("[INFO] instance ID: %s", v.InstanceID)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:      []string{"CREATING"},
+		Target:       []string{"RUNNING"},
+		Refresh:      dmsKafkaInstancesStateRefreshFunc(dmsV1Client, v.InstanceID),
+		Timeout:      d.Timeout(schema.TimeoutCreate),
+		Delay:        120 * time.Second,
+		PollInterval: 15 * time.Second,
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf(
+			"Error waiting for instance (%s) to become ready: %s",
+			v.InstanceID, err)
+	}
+
+	// Store the instance ID now
+	d.SetId(v.InstanceID)
+
+	return resourceDmsKafkaInstancesRead(d, meta)
+}
+
+func resourceDmsKafkaInstancesRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	region := GetRegion(d, config)
+	dmsV1Client, err := config.DmsV1Client(region)
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine DMS instance client: %s", err)
+	}
+
+	v, err := instances.Get(dmsV1Client, d.Id()).Extract()
+	if err != nil {
+		return CheckDeleted(d, err, "DMS instance")
+	}
+
+	log.Printf("[DEBUG] Dms instance %s: %+v", d.Id(), v)
+
+	partitionNum, _ := strconv.Atoi(v.PartitionNum)
+
+	var mErr *multierror.Error
+	mErr = multierror.Append(err,
+		d.Set("region", region),
+		d.Set("availability_zones", v.AvailableZones),
+		d.Set("status", v.Status),
+		d.Set("name", v.Name),
+		d.Set("description", v.Description),
+		d.Set("engine", v.Engine),
+		d.Set("engine_version", v.EngineVersion),
+		d.Set("engine_type", v.Type),
+		d.Set("bandwidth", v.Specification),
+		d.Set("partition_num", partitionNum),
+		d.Set("product_id", v.ProductID),
+		d.Set("product_spec_code", v.ResourceSpecCode),
+		d.Set("storage_spec_code", v.StorageSpecCode),
+		d.Set("storage_space", v.TotalStorageSpace),
+		d.Set("used_storage_space", v.UsedStorageSpace),
+		d.Set("vpc_id", v.VPCID),
+		d.Set("vpc_name", v.VPCName),
+		d.Set("network_id", v.SubnetID),
+		d.Set("subnet_name", v.SubnetName),
+		d.Set("security_group_id", v.SecurityGroupID),
+		d.Set("security_group_name", v.SecurityGroupName),
+		d.Set("node_num", v.Nodeum),
+		d.Set("connect_address", v.ConnectAddress),
+		d.Set("port", v.Port),
+		d.Set("maintain_begin", v.MaintainBegin),
+		d.Set("maintain_end", v.MaintainEnd),
+		d.Set("ssl_enable", v.SslEnable),
+		d.Set("created_at", setResourceTimestamp(v.CreatedAt)),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return fmt.Errorf("Error setting DMS product attributes: %s", mErr)
+	}
+
+	return nil
+}
+
+func setResourceTimestamp(stamp string) string {
+	mSeconds, err := strconv.ParseInt(stamp, 10, 64)
+	if err != nil {
+		log.Printf("[WARN] failed to convert string %s to int64: %s", stamp, err)
+		return ""
+	}
+	stampTime := time.Unix(mSeconds/1000, 0)
+	return stampTime.Format(time.RFC3339)
+}
+
+func resourceDmsKafkaInstancesUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	dmsV1Client, err := config.DmsV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error updating FlexibleEngine DMS instance client: %s", err)
+	}
+
+	//lintignore:R019
+	if d.HasChanges("name", "description", "maintain_begin", "maintain_end", "security_group_id") {
+		var updateOpts instances.UpdateOpts
+		if d.HasChange("name") {
+			updateOpts.Name = d.Get("name").(string)
+		}
+		if d.HasChange("description") {
+			description := d.Get("description").(string)
+			updateOpts.Description = &description
+		}
+		if d.HasChange("maintain_begin") {
+			updateOpts.MaintainBegin = d.Get("maintain_begin").(string)
+		}
+		if d.HasChange("maintain_end") {
+			updateOpts.MaintainEnd = d.Get("maintain_end").(string)
+		}
+		if d.HasChange("security_group_id") {
+			updateOpts.SecurityGroupID = d.Get("security_group_id").(string)
+		}
+
+		err = instances.Update(dmsV1Client, d.Id(), updateOpts).Err
+		if err != nil {
+			return fmt.Errorf("Error updating FlexibleEngine Dms Instance: %s", err)
+		}
+	}
+
+	return resourceDmsKafkaInstancesRead(d, meta)
+}
+
+func resourceDmsKafkaInstancesDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	dmsV1Client, err := config.DmsV1Client(GetRegion(d, config))
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine DMS instance client: %s", err)
+	}
+
+	err = instances.Delete(dmsV1Client, d.Id()).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("Error deleting FlexibleEngine instance: %s", err)
+	}
+
+	// Wait for the instance to delete before moving on.
+	log.Printf("[DEBUG] Waiting for instance (%s) to delete", d.Id())
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"DELETING", "RUNNING"},
+		Target:     []string{"DELETED"},
+		Refresh:    dmsKafkaInstancesStateRefreshFunc(dmsV1Client, d.Id()),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf(
+			"Error waiting for instance (%s) to delete: %s",
+			d.Id(), err)
+	}
+
+	log.Printf("[DEBUG] Dms instance %s deactivated.", d.Id())
+	d.SetId("")
+	return nil
+}
+
+func dmsKafkaInstancesStateRefreshFunc(client *golangsdk.ServiceClient, instanceID string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		v, err := instances.Get(client, instanceID).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return v, "DELETED", nil
+			}
+			return nil, "", err
+		}
+
+		return v, v.Status, nil
+	}
+}

--- a/flexibleengine/resource_flexibleengine_dms_kafka_instance_test.go
+++ b/flexibleengine/resource_flexibleengine_dms_kafka_instance_test.go
@@ -1,0 +1,163 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/dms/v1/instances"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDmsKafkaInstance_basic(t *testing.T) {
+	var instanceName = fmt.Sprintf("ACCPTTEST-%s", acctest.RandString(5))
+	var instanceUpdate = instanceName + "-update"
+	resourceName := "flexibleengine_dms_kafka_instance.instance_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDmsKafkaInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDmsKafkaInstance_basic(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDmsKafkaInstanceExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "name", instanceName),
+					resource.TestCheckResourceAttr(resourceName, "engine", "kafka"),
+					resource.TestCheckResourceAttr(resourceName, "engine_version", "2.3.0"),
+					resource.TestCheckResourceAttr(resourceName, "engine_type", "cluster"),
+					resource.TestCheckResourceAttr(resourceName, "status", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "ssl_enable", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "product_spec_code"),
+					resource.TestCheckResourceAttrSet(resourceName, "port"),
+				),
+			},
+			{
+				Config: testAccDmsKafkaInstance_update(instanceName, instanceUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", instanceUpdate),
+					resource.TestCheckResourceAttr(resourceName, "description", "instance update description"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"access_user", "password",
+				},
+			},
+		},
+	})
+}
+
+func testAccCheckDmsKafkaInstanceDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	client, err := config.Config.DmsV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating DMS client, err=%s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_dms_kafka_instance" {
+			continue
+		}
+
+		_, err := instances.Get(client, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("DMS kafka instance %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckDmsKafkaInstanceExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		client, err := config.Config.DmsV1Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating DMS client, err=%s", err)
+		}
+
+		_, err = instances.Get(client, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccDmsKafkaInstance_base(resName string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_dms_product" "product_1" {
+  bandwidth = "300MB"
+}
+
+resource "flexibleengine_vpc_v1" "vpc_1" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "vpc_subnet_1" {
+  name       = "%s"
+  cidr       = "192.168.10.0/24"
+  gateway_ip = "192.168.10.1"
+  vpc_id     = flexibleengine_vpc_v1.vpc_1.id
+}
+
+resource "flexibleengine_networking_secgroup_v2" "secgroup_1" {
+  name        = "%s"
+  description = "secgroup for DMS"
+}`, resName, resName, resName)
+}
+
+func testAccDmsKafkaInstance_basic(resName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_dms_kafka_instance" "instance_1" {
+  name               = "%s"
+  access_user        = "user"
+  password           = "Dmstest@123"
+  vpc_id             = flexibleengine_vpc_v1.vpc_1.id
+  network_id         = flexibleengine_vpc_subnet_v1.vpc_subnet_1.id
+  security_group_id  = flexibleengine_networking_secgroup_v2.secgroup_1.id
+  availability_zones = data.flexibleengine_dms_product.product_1.availability_zones
+  bandwidth          = data.flexibleengine_dms_product.product_1.bandwidth
+  product_id         = data.flexibleengine_dms_product.product_1.id
+  storage_space      = data.flexibleengine_dms_product.product_1.storage_space
+  engine_version     = data.flexibleengine_dms_product.product_1.engine_version
+}`, testAccDmsKafkaInstance_base(resName), resName)
+}
+
+func testAccDmsKafkaInstance_update(resName, resUpdate string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_dms_kafka_instance" "instance_1" {
+  name               = "%s"
+  description        = "instance update description"
+  access_user        = "user"
+  password           = "Dmstest@123"
+  vpc_id             = flexibleengine_vpc_v1.vpc_1.id
+  network_id         = flexibleengine_vpc_subnet_v1.vpc_subnet_1.id
+  security_group_id  = flexibleengine_networking_secgroup_v2.secgroup_1.id
+  availability_zones = data.flexibleengine_dms_product.product_1.availability_zones
+  bandwidth          = data.flexibleengine_dms_product.product_1.bandwidth
+  product_id         = data.flexibleengine_dms_product.product_1.id
+  storage_space      = data.flexibleengine_dms_product.product_1.storage_space
+  engine_version     = data.flexibleengine_dms_product.product_1.engine_version
+  }`, testAccDmsKafkaInstance_base(resName), resUpdate)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/aws/aws-sdk-go v1.25.3
-	github.com/chnsz/golangsdk v0.0.0-20211210025418-bfef50238f46
+	github.com/chnsz/golangsdk v0.0.0-20220114013618-10830a8b3d42
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chnsz/golangsdk v0.0.0-20211210025418-bfef50238f46 h1:43hIUYGkH3u7KBDcRQs2k2748R8xKRGlkie9T7/RJy0=
 github.com/chnsz/golangsdk v0.0.0-20211210025418-bfef50238f46/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220114013618-10830a8b3d42 h1:KcVFks4zLPYE39v/MVNBeBPaNKShYbv6yZxese0jWzo=
+github.com/chnsz/golangsdk v0.0.0-20220114013618-10830a8b3d42/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/queues/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/queues/requests.go
@@ -74,6 +74,10 @@ type ActionOpts struct {
 	QueueName string `json:"-" required:"true"`
 }
 
+type UpdateCidrOpts struct {
+	Cidr string `json:"cidr_in_vpc,omitempty"`
+}
+
 // CreateOptsBuilder allows extensions to add additional parameters to the
 // Create request.
 type CreateOptsBuilder interface {
@@ -192,4 +196,15 @@ func ScaleOrRestart(c *golangsdk.ServiceClient, opts ActionOpts) (r PutResult) {
 	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{200}}
 	_, r.Err = c.Put(ActionURL(c, opts.QueueName), requstbody, &r.Body, reqOpt)
 	return
+}
+
+func UpdateCidr(c *golangsdk.ServiceClient, queueName string, opts UpdateCidrOpts) (*UpdateCidrResp, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst UpdateCidrResp
+	_, err = c.Put(resourceURL(c, queueName), b, &rst, nil)
+	return &rst, err
 }

--- a/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/queues/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dli/v1/queues/results.go
@@ -114,3 +114,8 @@ type DeleteResult struct {
 type PutResult struct {
 	golangsdk.Result
 }
+
+type UpdateCidrResp struct {
+	IsSuccess bool   `json:"is_success"`
+	Message   string `json:"message"`
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/instances/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/instances/requests.go
@@ -1,0 +1,214 @@
+package instances
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// CreateOpsBuilder is used for creating instance parameters.
+// any struct providing the parameters should implement this interface
+type CreateOpsBuilder interface {
+	ToInstanceCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOps is a struct that contains all the parameters.
+type CreateOps struct {
+	// Indicates the name of an instance.
+	// An instance name starts with a letter,
+	// consists of 4 to 64 characters, and supports
+	// only letters, digits, and hyphens (-).
+	Name string `json:"name" required:"true"`
+
+	// Indicates the description of an instance.
+	// It is a character string containing not more than 1024 characters.
+	Description string `json:"description,omitempty"`
+
+	// Indicates a message engine.
+	// Currently, only RabbitMQ is supported.
+	Engine string `json:"engine" required:"true"`
+
+	// Indicates the version of a message engine.
+	EngineVersion string `json:"engine_version,omitempty"`
+
+	// Indicates the message storage space.
+	StorageSpace int `json:"storage_space" required:"true"`
+
+	// Indicates the password of an instance.
+	// An instance password must meet the following complexity requirements:
+	// Must be 6 to 32 characters long.
+	// Must contain at least two of the following character types:
+	// Lowercase letters
+	// Uppercase letters
+	// Digits
+	// Special characters (`~!@#$%^&*()-_=+\|[{}]:'",<.>/?)
+	Password string `json:"password,omitempty"`
+
+	// Indicates a username.
+	// A username consists of 1 to 64 characters
+	// and supports only letters, digits, and hyphens (-).
+	AccessUser string `json:"access_user,omitempty"`
+
+	// Indicates the ID of a VPC.
+	VPCID string `json:"vpc_id" required:"true"`
+
+	// Indicates the ID of a security group.
+	SecurityGroupID string `json:"security_group_id" required:"true"`
+
+	// Indicates the ID of a subnet.
+	SubnetID string `json:"subnet_id" required:"true"`
+
+	// Indicates the ID of an AZ.
+	// The parameter value can be left blank or an empty array.
+	AvailableZones []string `json:"available_zones,omitempty"`
+
+	// Indicates a product ID.
+	ProductID string `json:"product_id" required:"true"`
+
+	// Indicates the time at which a maintenance time window starts.
+	// Format: HH:mm:ss
+	MaintainBegin string `json:"maintain_begin,omitempty"`
+
+	// Indicates the time at which a maintenance time window ends.
+	// Format: HH:mm:ss
+	MaintainEnd string `json:"maintain_end,omitempty"`
+
+	//This parameter is mandatory when a Kafka instance is created.
+	//Indicates the maximum number of topics in a Kafka instance.
+	PartitionNum int `json:"partition_num,omitempty"`
+
+	//Indicates whether to enable SSL-encrypted access.
+	SslEnable bool `json:"ssl_enable"`
+
+	//This parameter is mandatory if the engine is kafka.
+	//Indicates the baseline bandwidth of a Kafka instance, that is,
+	//the maximum amount of data transferred per unit time. Unit: byte/s.
+	Specification string `json:"specification,omitempty"`
+
+	//Indicates the storage I/O specification. For details on how to select a disk type
+	StorageSpecCode string `json:"storage_spec_code,omitempty"`
+}
+
+// ToInstanceCreateMap is used for type convert
+func (ops CreateOps) ToInstanceCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(ops, "")
+}
+
+// Create an instance with given parameters.
+func Create(client *golangsdk.ServiceClient, ops CreateOpsBuilder) (r CreateResult) {
+	b, err := ops.ToInstanceCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(createURL(client), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}
+
+// Delete an instance by id
+func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = client.Delete(deleteURL(client, id), &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+	})
+	return
+}
+
+//UpdateOptsBuilder is an interface which can build the map paramter of update function
+type UpdateOptsBuilder interface {
+	ToInstanceUpdateMap() (map[string]interface{}, error)
+}
+
+//UpdateOpts is a struct which represents the parameters of update function
+type UpdateOpts struct {
+	// Indicates the name of an instance.
+	// An instance name starts with a letter,
+	// consists of 4 to 64 characters,
+	// and supports only letters, digits, and hyphens (-).
+	Name string `json:"name,omitempty"`
+
+	// Indicates the description of an instance.
+	// It is a character string containing not more than 1024 characters.
+	Description *string `json:"description,omitempty"`
+
+	// Indicates the time at which a maintenance time window starts.
+	// Format: HH:mm:ss
+	MaintainBegin string `json:"maintain_begin,omitempty"`
+
+	// Indicates the time at which a maintenance time window ends.
+	// Format: HH:mm:ss
+	MaintainEnd string `json:"maintain_end,omitempty"`
+
+	// Indicates the ID of a security group.
+	SecurityGroupID string `json:"security_group_id,omitempty"`
+}
+
+// ToInstanceUpdateMap is used for type convert
+func (opts UpdateOpts) ToInstanceUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Update is a method which can be able to update the instance
+// via accessing to the service with Put method and parameters
+func Update(client *golangsdk.ServiceClient, id string, opts UpdateOptsBuilder) (r UpdateResult) {
+	body, err := opts.ToInstanceUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Put(updateURL(client, id), body, nil, &golangsdk.RequestOpts{
+		OkCodes: []int{204},
+	})
+	return
+}
+
+// Get a instance with detailed information by id
+func Get(client *golangsdk.ServiceClient, id string) (r GetResult) {
+	_, r.Err = client.Get(getURL(client, id), &r.Body, nil)
+	return
+}
+
+type ListDmsInstanceOpts struct {
+	Id                  string `q:"id"`
+	Name                string `q:"name"`
+	Engine              string `q:"engine"`
+	Status              string `q:"status"`
+	IncludeFailure      string `q:"includeFailure"`
+	ExactMatchName      string `q:"exactMatchName"`
+	EnterpriseProjectID int    `q:"enterprise_project_id"`
+}
+
+type ListDmsBuilder interface {
+	ToDmsListDetailQuery() (string, error)
+}
+
+func (opts ListDmsInstanceOpts) ToDmsListDetailQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), err
+}
+
+func List(client *golangsdk.ServiceClient, opts ListDmsBuilder) pagination.Pager {
+	url := listURL(client)
+	if opts != nil {
+		query, err := opts.ToDmsListDetailQuery()
+
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	pageDmsList := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return DmsPage{pagination.SinglePageBase(r)}
+	})
+
+	dmsheader := map[string]string{"Content-Type": "application/json"}
+	pageDmsList.Headers = dmsheader
+	return pageDmsList
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/instances/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/instances/results.go
@@ -1,0 +1,108 @@
+package instances
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// InstanceCreate response
+type InstanceCreate struct {
+	InstanceID string `json:"instance_id"`
+}
+
+// CreateResult is a struct that contains all the return parameters of creation
+type CreateResult struct {
+	golangsdk.Result
+}
+
+// Extract from CreateResult
+func (r CreateResult) Extract() (*InstanceCreate, error) {
+	var s InstanceCreate
+	err := r.Result.ExtractInto(&s)
+	return &s, err
+}
+
+// DeleteResult is a struct which contains the result of deletion
+type DeleteResult struct {
+	golangsdk.ErrResult
+}
+
+type ListDmsResponse struct {
+	Instances  []Instance `json:"instances"`
+	TotalCount int        `json:"instance_num"`
+}
+
+// Instance response
+type Instance struct {
+	Name              string   `json:"name"`
+	Engine            string   `json:"engine"`
+	EngineVersion     string   `json:"engine_version"`
+	Specification     string   `json:"specification"`
+	PartitionNum      string   `json:"partition_num"`
+	StorageSpecCode   string   `json:"storage_spec_code"`
+	StorageSpace      int      `json:"storage_space"`
+	UsedStorageSpace  int      `json:"used_storage_space"`
+	TotalStorageSpace int      `json:"total_storage_space"`
+	ConnectAddress    string   `json:"connect_address"`
+	Port              int      `json:"port"`
+	Nodeum            int      `json:"node_num"`
+	Status            string   `json:"status"`
+	SslEnable         bool     `json:"ssl_enable"`
+	Description       string   `json:"description"`
+	InstanceID        string   `json:"instance_id"`
+	ResourceSpecCode  string   `json:"resource_spec_code"`
+	Type              string   `json:"type"`
+	ChargingMode      int      `json:"charging_mode"`
+	VPCID             string   `json:"vpc_id"`
+	VPCName           string   `json:"vpc_name"`
+	CreatedAt         string   `json:"created_at"`
+	ErrorCode         string   `json:"error_code"`
+	ProductID         string   `json:"product_id"`
+	SecurityGroupID   string   `json:"security_group_id"`
+	SecurityGroupName string   `json:"security_group_name"`
+	SubnetID          string   `json:"subnet_id"`
+	SubnetName        string   `json:"subnet_name"`
+	SubnetCIDR        string   `json:"subnet_cidr"`
+	AvailableZones    []string `json:"available_zones"`
+	UserID            string   `json:"user_id"`
+	UserName          string   `json:"user_name"`
+	OrderID           string   `json:"order_id"`
+	MaintainBegin     string   `json:"maintain_begin"`
+	MaintainEnd       string   `json:"maintain_end"`
+}
+
+// UpdateResult is a struct from which can get the result of update method
+type UpdateResult struct {
+	golangsdk.Result
+}
+
+// GetResult contains the body of getting detailed
+type GetResult struct {
+	golangsdk.Result
+}
+
+// Extract from GetResult
+func (r GetResult) Extract() (*Instance, error) {
+	var s Instance
+	err := r.Result.ExtractInto(&s)
+	return &s, err
+}
+
+type DmsPage struct {
+	pagination.SinglePageBase
+}
+
+func (r DmsPage) IsEmpty() (bool, error) {
+	data, err := ExtractDmsInstances(r)
+	if err != nil {
+		return false, err
+	}
+	return len(data.Instances) == 0, err
+}
+
+// ExtractCloudServers is a function that takes a ListResult and returns the services' information.
+func ExtractDmsInstances(r pagination.Page) (ListDmsResponse, error) {
+	var s ListDmsResponse
+	err := (r.(DmsPage)).ExtractInto(&s)
+	return s, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/instances/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/instances/urls.go
@@ -1,0 +1,30 @@
+package instances
+
+import "github.com/chnsz/golangsdk"
+
+// endpoint/instances
+const resourcePath = "instances"
+
+// createURL will build the rest query url of creation
+func createURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL(resourcePath)
+}
+
+// deleteURL will build the url of deletion
+func deleteURL(client *golangsdk.ServiceClient, id string) string {
+	return client.ServiceURL(resourcePath, id)
+}
+
+// updateURL will build the url of update
+func updateURL(c *golangsdk.ServiceClient, id string) string {
+	return c.ServiceURL(resourcePath, id)
+}
+
+// getURL will build the get url of get function
+func getURL(client *golangsdk.ServiceClient, id string) string {
+	return client.ServiceURL(resourcePath, id)
+}
+
+func listURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL(resourcePath)
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/ecs/v1/cloudservers/requests.go
@@ -79,9 +79,17 @@ func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
 }
 
 type Nic struct {
-	SubnetId string `json:"subnet_id" required:"true"`
-
+	SubnetId  string `json:"subnet_id" required:"true"`
 	IpAddress string `json:"ip_address,omitempty"`
+
+	// enable ipv6 or not
+	Ipv6Enable bool `json:"ipv6_enable,omitempty"`
+	// bandWidth id when ipv6 is enabled
+	BandWidth *Ipv6BandWidth `json:"ipv6_bandwidth,omitempty"`
+}
+
+type Ipv6BandWidth struct {
+	ID string `json:"id,omitempty"`
 }
 
 type PublicIp struct {

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/bandwidths/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/bandwidths/requests.go
@@ -12,8 +12,9 @@ type UpdateOptsBuilder interface {
 
 //UpdateOpts is a struct which represents the request body of update method
 type UpdateOpts struct {
-	Size int    `json:"size,omitempty"`
-	Name string `json:"name,omitempty"`
+	Size       int    `json:"size,omitempty"`
+	Name       string `json:"name,omitempty"`
+	ChargeMode string `json:"charge_mode,omitempty"`
 }
 
 func (opts UpdateOpts) ToBWUpdateMap() (map[string]interface{}, error) {

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/bandwidths/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/bandwidths/results.go
@@ -6,11 +6,10 @@ import (
 
 //BandWidth is a struct that represents a bandwidth
 type BandWidth struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	Size      int    `json:"size"`
-	ShareType string `json:"share_type"`
-	//PublicIPInfo  string `json:"publicip_info"`
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Size          int    `json:"size"`
+	ShareType     string `json:"share_type"`
 	TenantID      string `json:"tenant_id"`
 	BandwidthType string `json:"bandwidth_type"`
 	ChargeMode    string `json:"charge_mode"`
@@ -28,7 +27,7 @@ type BandWidth struct {
 }
 
 type PublicIpinfo struct {
-	// Specifies the tenant ID of the user.
+	// Specifies the ID of EIP or IPv6 port that use the bandwidth
 	PublicipId string `json:"publicip_id"`
 
 	// Specifies the elastic IP address.

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/eips/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/eips/requests.go
@@ -23,8 +23,10 @@ type ApplyOpts struct {
 }
 
 type PublicIpOpts struct {
-	Type    string `json:"type" required:"true"`
-	Address string `json:"ip_address,omitempty"`
+	Type      string `json:"type" required:"true"`
+	Address   string `json:"ip_address,omitempty"`
+	Alias     string `json:"alias,omitempty"`
+	IPVersion int    `json:"ip_version,omitempty"`
 }
 
 type BandwidthOpts struct {
@@ -70,9 +72,12 @@ type UpdateOptsBuilder interface {
 	ToPublicIpUpdateMap() (map[string]interface{}, error)
 }
 
-//UpdateOpts is a struct which represents the request body of update method
+// UpdateOpts is a struct which represents the request body of update method
+// NOTE: ip_version and port_id can not be updated at the same time
 type UpdateOpts struct {
-	PortID string `json:"port_id,omitempty"`
+	PortID    string  `json:"port_id,omitempty"`
+	Alias     *string `json:"alias,omitempty"`
+	IPVersion int     `json:"ip_version,omitempty"`
 }
 
 func (opts UpdateOpts) ToPublicIpUpdateMap() (map[string]interface{}, error) {

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/eips/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v1/eips/results.go
@@ -40,6 +40,7 @@ type PublicIp struct {
 	OrderID                  string   `json:"order_id"`
 	CreateTime               string   `json:"create_time"`
 	BandwidthID              string   `json:"bandwidth_id"`
+	BandwidthName            string   `json:"bandwidth_name"`
 	BandwidthSize            int      `json:"bandwidth_size"`
 	BandwidthShareType       string   `json:"bandwidth_share_type"`
 	EnterpriseProjectID      string   `json:"enterprise_project_id"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -58,7 +58,7 @@ github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 github.com/bgentry/go-netrc/netrc
-# github.com/chnsz/golangsdk v0.0.0-20211210025418-bfef50238f46
+# github.com/chnsz/golangsdk v0.0.0-20220114013618-10830a8b3d42
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -109,6 +109,7 @@ github.com/chnsz/golangsdk/openstack/dds/v3/flavors
 github.com/chnsz/golangsdk/openstack/dds/v3/instances
 github.com/chnsz/golangsdk/openstack/dis/v2/streams
 github.com/chnsz/golangsdk/openstack/dli/v1/queues
+github.com/chnsz/golangsdk/openstack/dms/v1/instances
 github.com/chnsz/golangsdk/openstack/dms/v2/products
 github.com/chnsz/golangsdk/openstack/dns/v2/ptrrecords
 github.com/chnsz/golangsdk/openstack/dns/v2/recordsets


### PR DESCRIPTION
related to #447 
add a new resource `flexibleengine_dms_kafka_instance` to manage a DMS Kafka instance within FlexibleEngine.

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDmsKafkaInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDmsKafkaInstance_basic -timeout 720m
=== RUN   TestAccDmsKafkaInstance_basic
=== PAUSE TestAccDmsKafkaInstance_basic
=== CONT  TestAccDmsKafkaInstance_basic
--- PASS: TestAccDmsKafkaInstance_basic (383.54s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 383.554s
```