### PR TITLE
feat: add dms kafka topic resource

### DIFF
--- a/docs/resources/dms_kafka_topic.md
+++ b/docs/resources/dms_kafka_topic.md
@@ -1,0 +1,62 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+# flexibleengine_dms_kafka_topic
+
+Manages a DMS Kafka topic resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+variable "kafka_instance_id" {}
+
+resource "flexibleengine_dms_kafka_topic" "topic" {
+  instance_id = var.kafka_instance_id
+  name       = "topic_1"
+  partitions = 20
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the DMS Kafka topic resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the DMS Kafka instance to which the topic belongs.
+  Changing this creates a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the topic. The name starts with a letter,
+  consists of 4 to 64 characters, and supports only letters, digits, hyphens (-) and underscores (_).
+  Changing this creates a new resource.
+
+* `partitions` - (Optional, Int, ForceNew) Specifies the partition number. The value ranges from 1 to 50 and defaults to 3.
+  Changing this creates a new resource.
+
+* `replicas` - (Optional, Int, ForceNew) Specifies the replica number. The value ranges from 1 to 3 and defaults to 3.
+  Changing this creates a new resource.
+
+* `aging_time` - (Optional, Int, ForceNew) Specifies the aging time in hours. The value ranges from 1 to 720 and defaults to 72.
+  Changing this creates a new resource.
+
+* `sync_replication` - (Optional, Bool, ForceNew) Whether or not to enable synchronous replication.
+  Changing this creates a new resource.
+
+* `sync_flushing` - (Optional, Bool, ForceNew) Whether or not to enable synchronous flushing.
+  Changing this creates a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which equals to the topic name.
+
+## Import
+
+DMS Kafka topics can be imported using the Kafka instance ID and topic name separated by a slash, e.g.:
+
+```sh
+terraform import flexibleengine_dms_kafka_topic.topic c8057fe5-23a8-46ef-ad83-c0055b4e0c5c/topic_1
+```

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -252,6 +252,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_dns_zone_v2":                        resourceDNSZoneV2(),
 			"flexibleengine_dcs_instance_v1":                    resourceDcsInstanceV1(),
 			"flexibleengine_dms_kafka_instance":                 resourceDmsKafkaInstances(),
+			"flexibleengine_dms_kafka_topic":                    resourceDmsKafkaTopic(),
 			"flexibleengine_dis_stream":                         resourceDisStreamV2(),
 			"flexibleengine_fw_firewall_group_v2":               resourceFWFirewallGroupV2(),
 			"flexibleengine_fw_policy_v2":                       resourceFWPolicyV2(),

--- a/flexibleengine/resource_flexibleengine_dms_kafka_topic.go
+++ b/flexibleengine/resource_flexibleengine_dms_kafka_topic.go
@@ -1,0 +1,197 @@
+package flexibleengine
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/chnsz/golangsdk/openstack/dms/v1/topics"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// resourceDmsKafkaTopic implements the resource of "flexibleengine_dms_kafka_topic"
+func resourceDmsKafkaTopic() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDmsKafkaTopicCreate,
+		ReadContext:   resourceDmsKafkaTopicRead,
+		DeleteContext: resourceDmsKafkaTopicDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceDmsKafkaTopicImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"partitions": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"replicas": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"aging_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"sync_replication": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"sync_flushing": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceDmsKafkaTopicCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	dmsv1Client, err := config.DmsV1Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating FlexibleEngine DMS client: %s", err)
+	}
+
+	createOpts := &topics.CreateOps{
+		Name:             d.Get("name").(string),
+		Partition:        d.Get("partitions").(int),
+		Replication:      d.Get("replicas").(int),
+		RetentionTime:    d.Get("aging_time").(int),
+		SyncReplication:  d.Get("sync_replication").(bool),
+		SyncMessageFlush: d.Get("sync_flushing").(bool),
+	}
+
+	log.Printf("[DEBUG] Create Options: %#v", createOpts)
+	instanceID := d.Get("instance_id").(string)
+	v, err := topics.Create(dmsv1Client, instanceID, createOpts).Extract()
+	if err != nil {
+		return diag.Errorf("error creating FlexibleEngine DMS kafka topic: %s", err)
+	}
+
+	// use topic name as the resource ID
+	d.SetId(v.Name)
+	return resourceDmsKafkaTopicRead(ctx, d, meta)
+}
+
+func resourceDmsKafkaTopicRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	dmsv1Client, err := config.DmsV1Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating FlexibleEngine DMS client: %s", err)
+	}
+
+	instanceID := d.Get("instance_id").(string)
+	allTopics, err := topics.List(dmsv1Client, instanceID).Extract()
+	if err != nil {
+		return CheckDeletedDiag(d, err, "DMS kafka topic")
+	}
+
+	topicID := d.Id()
+	var found *topics.Topic
+	for _, item := range allTopics {
+		if item.Name == topicID {
+			found = &item
+			break
+		}
+	}
+
+	if found == nil {
+		log.Printf("[WARN] the DMS kafka topic %s does not exist in instance %s", d.Id(), instanceID)
+		d.SetId("")
+		return nil
+	}
+
+	log.Printf("[DEBUG] DMS kafka topic %s: %+v", d.Id(), found)
+
+	mErr := multierror.Append(nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("name", found.Name),
+		d.Set("partitions", found.Partition),
+		d.Set("replicas", found.Replication),
+		d.Set("aging_time", found.RetentionTime),
+		d.Set("sync_replication", found.SyncReplication),
+		d.Set("sync_flushing", found.SyncMessageFlush),
+	)
+	if mErr.ErrorOrNil() != nil {
+		return diag.FromErr(mErr)
+	}
+
+	return nil
+}
+
+func resourceDmsKafkaTopicDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	dmsv1Client, err := config.DmsV1Client(config.GetRegion(d))
+	if err != nil {
+		return diag.Errorf("error creating FlexibleEngine DMS client: %s", err)
+	}
+
+	topicID := d.Id()
+	instanceID := d.Get("instance_id").(string)
+	response, err := topics.Delete(dmsv1Client, instanceID, []string{topicID}).Extract()
+	if err != nil {
+		return diag.Errorf("error deleting DMS kafka topic: %s", err)
+	}
+
+	var success bool
+	for _, item := range response {
+		if item.Name == topicID {
+			success = item.Success
+			break
+		}
+	}
+	if !success {
+		return diag.Errorf("error deleting DMS kafka topic")
+	}
+
+	d.SetId("")
+	return nil
+}
+
+// resourceDmsKafkaTopicImport query the rules from FlexibleEngine and imports them to Terraform.
+// It is a common function in waf and is also called by other rule resources.
+func resourceDmsKafkaTopicImport(_ context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData,
+	error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		err := fmt.Errorf("Invalid format specified for DMS kafka topic. Format must be <instance id>/<topic name>")
+		return nil, err
+	}
+
+	instanceID := parts[0]
+	topicID := parts[1]
+
+	d.SetId(topicID)
+	d.Set("instance_id", instanceID)
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/flexibleengine/resource_flexibleengine_dms_kafka_topic_test.go
+++ b/flexibleengine/resource_flexibleengine_dms_kafka_topic_test.go
@@ -1,0 +1,138 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/dms/v1/topics"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDmsKafkaTopic_basic(t *testing.T) {
+	var rName = fmt.Sprintf("ACCPTTEST-%s", acctest.RandString(5))
+	topicName := "flexibleengine_dms_kafka_topic.topic"
+	instanceName := "flexibleengine_dms_kafka_instance.instance_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckKafkaTopicDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDmsKafkaTopic_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckKafkaTopicExists(topicName),
+					resource.TestCheckResourceAttr(topicName, "name", rName),
+					resource.TestCheckResourceAttr(topicName, "partitions", "10"),
+					resource.TestCheckResourceAttr(topicName, "replicas", "3"),
+					resource.TestCheckResourceAttr(topicName, "aging_time", "36"),
+					resource.TestCheckResourceAttr(topicName, "sync_replication", "false"),
+					resource.TestCheckResourceAttr(topicName, "sync_flushing", "false"),
+				),
+			},
+			{
+				ResourceName:      topicName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccKafkaTopicImportStateFunc(instanceName, topicName),
+			},
+		},
+	})
+}
+
+func testAccCheckKafkaTopicDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	client, err := config.Config.DmsV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating DMS client, err=%s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_dms_kafka_topic" {
+			continue
+		}
+
+		instanceID := rs.Primary.Attributes["instance_id"]
+		allTopics, err := topics.List(client, instanceID).Extract()
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return nil
+			}
+			return fmt.Errorf("Error listing DMS kafka topics in %s, error: %s", instanceID, err)
+		}
+
+		topicID := rs.Primary.ID
+		for _, item := range allTopics {
+			if item.Name == topicID {
+				return fmt.Errorf("DMS kafka topic %s still exists", rs.Primary.ID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckKafkaTopicExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		client, err := config.Config.DmsV1Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating DMS client, err=%s", err)
+		}
+
+		instanceID := rs.Primary.Attributes["instance_id"]
+		allTopics, err := topics.List(client, instanceID).Extract()
+		if err != nil {
+			return fmt.Errorf("Error listing DMS kafka topics in %s, error: %s", instanceID, err)
+		}
+
+		for _, item := range allTopics {
+			if item.Name == rs.Primary.ID {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("DMS kafka topic %s does not exist", rs.Primary.ID)
+	}
+}
+
+// testAccKafkaTopicImportStateFunc is used to import the resource
+func testAccKafkaTopicImportStateFunc(instance, topic string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		instanceState, ok := s.RootModule().Resources[instance]
+		if !ok {
+			return "", fmt.Errorf("DMS kafka instance not found")
+		}
+
+		topicState, ok := s.RootModule().Resources[topic]
+		if !ok {
+			return "", fmt.Errorf("DMS kafka topic not found")
+		}
+
+		return fmt.Sprintf("%s/%s", instanceState.Primary.ID, topicState.Primary.ID), nil
+	}
+}
+
+func testAccDmsKafkaTopic_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_dms_kafka_topic" "topic" {
+  instance_id = flexibleengine_dms_kafka_instance.instance_1.id
+  name        = "%s"
+  partitions  = 10
+  aging_time  = 36
+}
+`, testAccDmsKafkaInstance_basic(rName), rName)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/aws/aws-sdk-go v1.25.3
-	github.com/chnsz/golangsdk v0.0.0-20220114013618-10830a8b3d42
+	github.com/chnsz/golangsdk v0.0.0-20220117032841-13639b2647ae
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/chnsz/golangsdk v0.0.0-20211210025418-bfef50238f46 h1:43hIUYGkH3u7KBD
 github.com/chnsz/golangsdk v0.0.0-20211210025418-bfef50238f46/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chnsz/golangsdk v0.0.0-20220114013618-10830a8b3d42 h1:KcVFks4zLPYE39v/MVNBeBPaNKShYbv6yZxese0jWzo=
 github.com/chnsz/golangsdk v0.0.0-20220114013618-10830a8b3d42/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220117032841-13639b2647ae h1:ell4ZUew678up7he8Dc9tIwIJ9nJ62eaRr0F4qJncb0=
+github.com/chnsz/golangsdk v0.0.0-20220117032841-13639b2647ae/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/topics/doc.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/topics/doc.go
@@ -1,0 +1,5 @@
+/*
+Package topics is only used by terraform-provider-flexibleengine with
+DmsV1Client to manage flexibleengine_dms_kafka_topic resource.
+*/
+package topics

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/topics/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/topics/requests.go
@@ -1,0 +1,70 @@
+package topics
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// CreateOpsBuilder is an interface which is used for creating a kafka topic
+type CreateOpsBuilder interface {
+	ToTopicCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOps is a struct that contains all the parameters of create function
+type CreateOps struct {
+	// the name/ID of a topic
+	Name string `json:"id" required:"true"`
+	// topic partitions, value range: 1-50, Default value:3
+	Partition int `json:"partition,omitempty"`
+	// topic replications, value range: 1-3, Default value:3
+	Replication int `json:"replication,omitempty"`
+	// aging time in hours, value range: 1-168, , Default value:72
+	RetentionTime int `json:"retention_time,omitempty"`
+
+	SyncMessageFlush bool `json:"sync_message_flush,omitempty"`
+	SyncReplication  bool `json:"sync_replication,omitempty"`
+}
+
+// ToTopicCreateMap is used for type convert
+func (ops CreateOps) ToTopicCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(ops, "")
+}
+
+// Create a kafka topic with given parameters
+func Create(client *golangsdk.ServiceClient, instanceID string, ops CreateOpsBuilder) (r CreateResult) {
+	b, err := ops.ToTopicCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(rootURL(client, instanceID), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}
+
+// List all topics belong to the instance id
+func List(client *golangsdk.ServiceClient, instanceID string) (r ListResult) {
+	_, r.Err = client.Get(rootURL(client, instanceID), &r.Body, nil)
+	return
+}
+
+// Delete given topics belong to the instance id
+func Delete(client *golangsdk.ServiceClient, instanceID string, topics []string) (r DeleteResult) {
+	var delOpts = struct {
+		Topics []string `json:"topics" required:"true"`
+	}{Topics: topics}
+
+	b, err := golangsdk.BuildRequestBody(delOpts, "")
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(deleteURL(client, instanceID), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/topics/results.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/topics/results.go
@@ -1,0 +1,112 @@
+package topics
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/chnsz/golangsdk"
+)
+
+// CreateResponse is a struct that contains the create response
+type CreateResponse struct {
+	Name string `json:"id"`
+}
+
+// Topic includes the parameters of an topic
+type Topic struct {
+	Name             string `json:"id"`
+	Partition        int    `json:"partition"`
+	Replication      int    `json:"replication"`
+	RetentionTime    int    `json:"retention_time"`
+	TopicType        int    `json:"topic_type"`
+	PoliciesOnly     bool   `json:"policiesOnly"`
+	SyncReplication  bool   `json:"-"`
+	SyncMessageFlush bool   `json:"-"`
+}
+
+// UnmarshalJSON to override default
+func (r *Topic) UnmarshalJSON(b []byte) error {
+	type tmp Topic
+	var s struct {
+		tmp
+		SyncReplication  interface{} `json:"sync_replication"`
+		SyncMessageFlush interface{} `json:"sync_message_flush"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = Topic(s.tmp)
+
+	switch t := s.SyncReplication.(type) {
+	case string:
+		enabled, _ := strconv.ParseBool(s.SyncReplication.(string))
+		r.SyncReplication = enabled
+	case bool:
+		r.SyncReplication = t
+	}
+
+	switch t := s.SyncMessageFlush.(type) {
+	case string:
+		enabled, _ := strconv.ParseBool(s.SyncMessageFlush.(string))
+		r.SyncMessageFlush = enabled
+	case bool:
+		r.SyncMessageFlush = t
+	}
+
+	return err
+}
+
+// ListResponse is a struct that contains the list response
+type ListResponse struct {
+	Total            int     `json:"total"`
+	Size             int     `json:"size"`
+	RemainPartitions int     `json:"remain_partitions"`
+	MaxPartitions    int     `json:"max_partitions"`
+	Topics           []Topic `json:"topics"`
+}
+
+// CreateResult is a struct that contains all the return parameters of creation
+type CreateResult struct {
+	golangsdk.Result
+}
+
+// Extract from CreateResult
+func (r CreateResult) Extract() (*CreateResponse, error) {
+	var s CreateResponse
+	err := r.Result.ExtractInto(&s)
+	return &s, err
+}
+
+// ListResult contains the body of getting detailed
+type ListResult struct {
+	golangsdk.Result
+}
+
+// Extract from ListResult
+func (r ListResult) Extract() ([]Topic, error) {
+	var s ListResponse
+	err := r.Result.ExtractInto(&s)
+	return s.Topics, err
+}
+
+// DeleteResult is a struct which contains the result of deletion
+type DeleteResult struct {
+	golangsdk.Result
+}
+
+// DeleteResponse is a struct that contains the deletion response
+type DeleteResponse struct {
+	Name    string `json:"id"`
+	Success bool   `json:"success"`
+}
+
+// Extract from DeleteResult
+func (r DeleteResult) Extract() ([]DeleteResponse, error) {
+	var s struct {
+		Topics []DeleteResponse `json:"topics"`
+	}
+	err := r.Result.ExtractInto(&s)
+	return s.Topics, err
+}

--- a/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/topics/urls.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/dms/v1/topics/urls.go
@@ -1,0 +1,20 @@
+package topics
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+const (
+	resourcePath = "instances"
+	topicPath    = "topics"
+)
+
+// rootURL will build the url of create, update and list
+func rootURL(client *golangsdk.ServiceClient, instanceID string) string {
+	return client.ServiceURL(resourcePath, instanceID, topicPath)
+}
+
+// deleteURL will build the url of delete
+func deleteURL(client *golangsdk.ServiceClient, instanceID string) string {
+	return client.ServiceURL(resourcePath, instanceID, topicPath, "delete")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -58,7 +58,7 @@ github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 github.com/bgentry/go-netrc/netrc
-# github.com/chnsz/golangsdk v0.0.0-20220114013618-10830a8b3d42
+# github.com/chnsz/golangsdk v0.0.0-20220117032841-13639b2647ae
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal
@@ -110,6 +110,7 @@ github.com/chnsz/golangsdk/openstack/dds/v3/instances
 github.com/chnsz/golangsdk/openstack/dis/v2/streams
 github.com/chnsz/golangsdk/openstack/dli/v1/queues
 github.com/chnsz/golangsdk/openstack/dms/v1/instances
+github.com/chnsz/golangsdk/openstack/dms/v1/topics
 github.com/chnsz/golangsdk/openstack/dms/v2/products
 github.com/chnsz/golangsdk/openstack/dns/v2/ptrrecords
 github.com/chnsz/golangsdk/openstack/dns/v2/recordsets


### PR DESCRIPTION
related to #447 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDmsKafkaTopic_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDmsKafkaTopic_basic -timeout 720m
=== RUN   TestAccDmsKafkaTopic_basic
=== PAUSE TestAccDmsKafkaTopic_basic
=== CONT  TestAccDmsKafkaTopic_basic
--- PASS: TestAccDmsKafkaTopic_basic (363.48s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 363.489s
```