### PR TITLE
fix(lb): avoid to request empty body when only update tags

### DIFF
--- a/flexibleengine/resource_flexibleengine_lb_listener_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_lb_listener_v2_test.go
@@ -28,6 +28,12 @@ func TestAccLBV2Listener_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "http2_enable", "false"),
 					resource.TestCheckResourceAttr(resourceName, "transparent_client_ip_enable", "true"),
+				),
+			},
+			{
+				Config: testAccLBV2ListenerConfig_tags(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("listener-%s", rName)),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 				),
@@ -146,6 +152,22 @@ func testAccCheckLBV2ListenerExists(n string, listener *listeners.Listener) reso
 }
 
 func testAccLBV2ListenerConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
+  name          = "lb-%s"
+  vip_subnet_id = "%s"
+}
+
+resource "flexibleengine_lb_listener_v2" "listener_1" {
+  name            = "listener-%s"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
+}
+`, name, OS_SUBNET_ID, name)
+}
+
+func testAccLBV2ListenerConfig_tags(name string) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
   name          = "lb-%s"


### PR DESCRIPTION
fixes #680 

the testing result as follows"
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLBV2LoadBalancer_basic'==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLBV2LoadBalancer_basic -timeout 720m
=== RUN   TestAccLBV2LoadBalancer_basic
--- PASS: TestAccLBV2LoadBalancer_basic (42.93s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 42.946s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLBV2Listener_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLBV2Listener_basic -timeout 720m
=== RUN   TestAccLBV2Listener_basic
--- PASS: TestAccLBV2Listener_basic (84.22s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 84.233s
```