### PR TITLE
chore: get rid of d.Partial

### DIFF
--- a/flexibleengine/resource_flexibleengine_as_group_v1.go
+++ b/flexibleengine/resource_flexibleengine_as_group_v1.go
@@ -563,7 +563,7 @@ func resourceASGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine autoscaling client: %s", err)
 	}
-	d.Partial(true)
+
 	if d.HasChange("min_instance_number") || d.HasChange("max_instance_number") || d.HasChange("desire_instance_number") || d.HasChange("lbaas_listeners") {
 		minNum := d.Get("min_instance_number").(int)
 		maxNum := d.Get("max_instance_number").(int)
@@ -614,7 +614,6 @@ func resourceASGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	d.Partial(false)
 	return resourceASGroupRead(d, meta)
 }
 

--- a/flexibleengine/resource_flexibleengine_images_image_v2.go
+++ b/flexibleengine/resource_flexibleengine_images_image_v2.go
@@ -192,8 +192,6 @@ func resourceImagesImageV2Create(d *schema.ResourceData, meta interface{}) error
 		createOpts.Tags = resourceImagesImageV2BuildTags(tags)
 	}
 
-	d.Partial(true)
-
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 	newImg, err := images.Create(imageClient, createOpts).Extract()
 	if err != nil {
@@ -239,8 +237,6 @@ func resourceImagesImageV2Create(d *schema.ResourceData, meta interface{}) error
 	if _, err = stateConf.WaitForState(); err != nil {
 		return fmt.Errorf("Error waiting for Image: %s", err)
 	}
-
-	d.Partial(false)
 
 	return resourceImagesImageV2Read(d, meta)
 }


### PR DESCRIPTION
Partial is a legacy function that was used for capturing state of specific
attributes if an update only partially worked. Enabling this flag without
setting any specific keys with the now removed SetPartial has a useful side
effect of preserving all of the resource's previous state. Although confusing,
it has been discovered that during an update when an error is returned, the
proposed config is set into state, even without any calls to d.Set.

In practice this default behavior goes mostly unnoticed since Terraform
refreshes between operations by default. The state situation discussed is
subject to further investigation and potential change. Until then, this
function has been preserved for the specific usecase.