### PR TITLE
fix: do not update other fields when only tags was changed

### DIFF
--- a/flexibleengine/resource_flexibleengine_compute_instance_v2.go
+++ b/flexibleengine/resource_flexibleengine_compute_instance_v2.go
@@ -667,12 +667,10 @@ func resourceComputeInstanceV2Update(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error creating FlexibleEngine compute client: %s", err)
 	}
 
-	var updateOpts servers.UpdateOpts
 	if d.HasChange("name") {
-		updateOpts.Name = d.Get("name").(string)
-	}
-
-	if updateOpts != (servers.UpdateOpts{}) {
+		updateOpts := servers.UpdateOpts{
+			Name: d.Get("name").(string),
+		}
 		_, err := servers.Update(computeClient, d.Id(), updateOpts).Extract()
 		if err != nil {
 			return fmt.Errorf("Error updating FlexibleEngine server: %s", err)

--- a/flexibleengine/resource_flexibleengine_dns_ptrrecord_v2.go
+++ b/flexibleengine/resource_flexibleengine_dns_ptrrecord_v2.go
@@ -166,7 +166,7 @@ func resourceDNSPtrRecordV2Update(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 	}
 
-	if d.HasChange("name") || d.HasChange("description") || d.HasChange("ttl") {
+	if d.HasChanges("name", "description", "ttl") {
 		updateOpts := ptrrecords.CreateOpts{
 			PtrName:     d.Get("name").(string),
 			Description: d.Get("description").(string),

--- a/flexibleengine/resource_flexibleengine_dns_zone_v2.go
+++ b/flexibleengine/resource_flexibleengine_dns_zone_v2.go
@@ -282,35 +282,41 @@ func resourceDNSZoneV2Update(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	var updateOpts zones.UpdateOpts
-	if d.HasChange("email") {
-		updateOpts.Email = d.Get("email").(string)
-	}
-	if d.HasChange("ttl") {
-		updateOpts.TTL = d.Get("ttl").(int)
-	}
-	if d.HasChange("description") {
-		updateOpts.Description = d.Get("description").(string)
-	}
+	if d.HasChanges("description", "ttl", "email") {
+		var updateOpts zones.UpdateOpts
+		if d.HasChange("email") {
+			updateOpts.Email = d.Get("email").(string)
+		}
+		if d.HasChange("ttl") {
+			updateOpts.TTL = d.Get("ttl").(int)
+		}
+		if d.HasChange("description") {
+			updateOpts.Description = d.Get("description").(string)
+		}
 
-	log.Printf("[DEBUG] Updating Zone %s with options: %#v", d.Id(), updateOpts)
+		log.Printf("[DEBUG] Updating Zone %s with options: %#v", d.Id(), updateOpts)
+		_, err = zones.Update(dnsClient, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return fmt.Errorf("Error updating FlexibleEngine DNS Zone: %s", err)
+		}
 
-	_, err = zones.Update(dnsClient, d.Id(), updateOpts).Extract()
-	if err != nil {
-		return fmt.Errorf("Error updating FlexibleEngine DNS Zone: %s", err)
+		log.Printf("[DEBUG] Waiting for DNS Zone (%s) to update", d.Id())
+		stateConf := &resource.StateChangeConf{
+			Target:     []string{"ACTIVE"},
+			Pending:    []string{"PENDING"},
+			Refresh:    waitForDNSZone(dnsClient, d.Id()),
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
+			Delay:      5 * time.Second,
+			MinTimeout: 3 * time.Second,
+		}
+
+		_, err = stateConf.WaitForState()
+		if err != nil {
+			return fmt.Errorf(
+				"Error waiting for DNS Zone (%s) to become ACTIVE for update: %s",
+				d.Id(), err)
+		}
 	}
-
-	log.Printf("[DEBUG] Waiting for DNS Zone (%s) to update", d.Id())
-	stateConf := &resource.StateChangeConf{
-		Target:     []string{"ACTIVE"},
-		Pending:    []string{"PENDING"},
-		Refresh:    waitForDNSZone(dnsClient, d.Id()),
-		Timeout:    d.Timeout(schema.TimeoutUpdate),
-		Delay:      5 * time.Second,
-		MinTimeout: 3 * time.Second,
-	}
-
-	_, err = stateConf.WaitForState()
 
 	if d.HasChange("router") {
 		// when updating private zone

--- a/flexibleengine/resource_flexibleengine_vpc_subnet_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_vpc_subnet_v1_test.go
@@ -39,6 +39,7 @@ func TestAccFlexibleEngineVpcSubnetV1_basic(t *testing.T) {
 				Config: testAccFlexibleEngineVpcSubnetV1_update(rNameUpdate),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "dhcp_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_updated"),
 				),
 			},

--- a/flexibleengine/resource_flexibleengine_vpc_v1.go
+++ b/flexibleengine/resource_flexibleengine_vpc_v1.go
@@ -162,18 +162,16 @@ func resourceVirtualPrivateCloudV1Update(ctx context.Context, d *schema.Resource
 		return diag.Errorf("Error creating FlexibleEngine Vpc: %s", err)
 	}
 
-	var updateOpts vpcs.UpdateOpts
+	if d.HasChanges("name", "cidr") {
+		updateOpts := vpcs.UpdateOpts{
+			Name: d.Get("name").(string),
+			CIDR: d.Get("cidr").(string),
+		}
 
-	if d.HasChange("name") {
-		updateOpts.Name = d.Get("name").(string)
-	}
-	if d.HasChange("cidr") {
-		updateOpts.CIDR = d.Get("cidr").(string)
-	}
-
-	_, err = vpcs.Update(vpcClient, d.Id(), updateOpts).Extract()
-	if err != nil {
-		return diag.Errorf("Error updating FlexibleEngine Vpc: %s", err)
+		_, err = vpcs.Update(vpcClient, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return diag.Errorf("Error updating FlexibleEngine Vpc: %s", err)
+		}
 	}
 
 	//update tags

--- a/flexibleengine/resource_flexibleengine_vpcep_service.go
+++ b/flexibleengine/resource_flexibleengine_vpcep_service.go
@@ -290,24 +290,26 @@ func resourceVPCEndpointServiceUpdate(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("Error creating FlexibleEngine VPC endpoint client: %s", err)
 	}
 
-	updateOpts := services.UpdateOpts{
-		ServiceName: d.Get("name").(string),
-	}
+	if d.HasChanges("name", "approval", "port_id", "port_mapping") {
+		updateOpts := services.UpdateOpts{
+			ServiceName: d.Get("name").(string),
+		}
 
-	if d.HasChange("approval") {
-		approval := d.Get("approval").(bool)
-		updateOpts.Approval = &approval
-	}
-	if d.HasChange("port_id") {
-		updateOpts.PortID = d.Get("port_id").(string)
-	}
-	if d.HasChange("port_mapping") {
-		updateOpts.Ports = expandPortMappingOpts(d)
-	}
+		if d.HasChange("approval") {
+			approval := d.Get("approval").(bool)
+			updateOpts.Approval = &approval
+		}
+		if d.HasChange("port_id") {
+			updateOpts.PortID = d.Get("port_id").(string)
+		}
+		if d.HasChange("port_mapping") {
+			updateOpts.Ports = expandPortMappingOpts(d)
+		}
 
-	_, err = services.Update(vpcepClient, d.Id(), updateOpts).Extract()
-	if err != nil {
-		return fmt.Errorf("Error updating FlexibleEngine VPC endpoint service: %s", err)
+		_, err = services.Update(vpcepClient, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return fmt.Errorf("Error updating FlexibleEngine VPC endpoint service: %s", err)
+		}
 	}
 
 	//update tags


### PR DESCRIPTION
fixes #693 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDNSV2RecordSet_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDNSV2RecordSet_basic -timeout 720m
=== RUN   TestAccDNSV2RecordSet_basic
=== PAUSE TestAccDNSV2RecordSet_basic
=== CONT  TestAccDNSV2RecordSet_basic
--- PASS: TestAccDNSV2RecordSet_basic (66.84s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 66.854s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDNSV2RecordSet_readTTL'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDNSV2RecordSet_readTTL -timeout 720m
=== RUN   TestAccDNSV2RecordSet_readTTL
=== PAUSE TestAccDNSV2RecordSet_readTTL
=== CONT  TestAccDNSV2RecordSet_readTTL
--- PASS: TestAccDNSV2RecordSet_readTTL (32.03s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 32.047s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDNSV2Zone_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDNSV2Zone_basic -timeout 720m
=== RUN   TestAccDNSV2Zone_basic
=== PAUSE TestAccDNSV2Zone_basic
=== CONT  TestAccDNSV2Zone_basic
--- PASS: TestAccDNSV2Zone_basic (29.18s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 29.192s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccBlockStorageV2Volume_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccBlockStorageV2Volume_basic -timeout 720m
=== RUN   TestAccBlockStorageV2Volume_basic
--- PASS: TestAccBlockStorageV2Volume_basic (52.57s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 52.583s
```