### PR TITLE
chore: fix github check annotations

### DIFF
--- a/flexibleengine/data_source_flexibleengine_vpcep_endpoints_test.go
+++ b/flexibleengine/data_source_flexibleengine_vpcep_endpoints_test.go
@@ -15,8 +15,6 @@ func TestAccVPCEPEndpointsDataSourceBasic(t *testing.T) {
 	endpointByEndpointIdResourceName := "data.flexibleengine_vpcep_endpoints.by_endpoint_id"
 	endpointByVpcIdResourceName := "data.flexibleengine_vpcep_endpoints.by_vpc_id"
 
-	fmt.Sprintf(testAccVPCEPEndpointsDataSourceBasic(rName))
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,


### PR DESCRIPTION
GitHub Actions/build
Check failure on line 18 in flexibleengine/data_source_flexibleengine_vpcep_endpoints_test.go
result of fmt.Sprintf call not used