### PR TITLE
bugfix(elb): be able to remove a description

### DIFF
--- a/flexibleengine/resource_flexibleengine_lb_listener_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_listener_v2.go
@@ -302,7 +302,8 @@ func resourceListenerUpdate(d *schema.ResourceData, meta interface{}) error {
 		updateOpts.Name = d.Get("name").(string)
 	}
 	if d.HasChange("description") {
-		updateOpts.Description = d.Get("description").(string)
+		desc := d.Get("description").(string)
+		updateOpts.Description = &desc
 	}
 	if d.HasChange("sni_container_refs") {
 		var sniContainerRefs []string

--- a/flexibleengine/resource_flexibleengine_lb_listener_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_lb_listener_v2_test.go
@@ -25,6 +25,7 @@ func TestAccLBV2Listener_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLBV2ListenerExists(resourceName, &listener),
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("listener-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by acceptance test"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "http2_enable", "false"),
 					resource.TestCheckResourceAttr(resourceName, "transparent_client_ip_enable", "true"),
@@ -34,6 +35,7 @@ func TestAccLBV2Listener_basic(t *testing.T) {
 				Config: testAccLBV2ListenerConfig_tags(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("listener-%s", rName)),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 				),
@@ -42,6 +44,7 @@ func TestAccLBV2Listener_basic(t *testing.T) {
 				Config: testAccLBV2ListenerConfig_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("listener-%s_updated", rName)),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by acceptance test updated"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform_update"),
 				),
@@ -160,6 +163,7 @@ resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
 
 resource "flexibleengine_lb_listener_v2" "listener_1" {
   name            = "listener-%s"
+  description     = "created by acceptance test"
   protocol        = "HTTP"
   protocol_port   = 8080
   loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
@@ -197,6 +201,7 @@ resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
 
 resource "flexibleengine_lb_listener_v2" "listener_1" {
   name            = "listener-%s_updated"
+  description     = "created by acceptance test updated"
   protocol        = "HTTP"
   protocol_port   = 8080
   loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id

--- a/flexibleengine/resource_flexibleengine_lb_loadbalancer_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_loadbalancer_v2.go
@@ -240,7 +240,8 @@ func resourceLoadBalancerV2Update(d *schema.ResourceData, meta interface{}) erro
 			updateOpts.Name = d.Get("name").(string)
 		}
 		if d.HasChange("description") {
-			updateOpts.Description = d.Get("description").(string)
+			desc := d.Get("description").(string)
+			updateOpts.Description = &desc
 		}
 		if d.HasChange("admin_state_up") {
 			asu := d.Get("admin_state_up").(bool)

--- a/flexibleengine/resource_flexibleengine_lb_loadbalancer_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_lb_loadbalancer_v2_test.go
@@ -27,6 +27,7 @@ func TestAccLBV2LoadBalancer_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLBV2LoadBalancerExists(resourceName, &lb),
 					resource.TestCheckResourceAttr(resourceName, "name", "loadbalancer_1"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by acceptance test"),
 					resource.TestMatchResourceAttr(resourceName, "vip_port_id", regexp.MustCompile("^[a-f0-9-]+")),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
@@ -41,6 +42,7 @@ func TestAccLBV2LoadBalancer_basic(t *testing.T) {
 				Config: testAccLBV2LoadBalancerConfig_update,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", "loadbalancer_1_updated"),
+					resource.TestCheckResourceAttr(resourceName, "description", ""),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform_update"),
 				),
@@ -186,6 +188,7 @@ func testAccCheckLBV2LoadBalancerHasSecGroup(
 var testAccLBV2LoadBalancerConfig_basic = fmt.Sprintf(`
 resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
   name          = "loadbalancer_1"
+  description   = "created by acceptance test"
   vip_subnet_id = "%s"
 
   tags = {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/aws/aws-sdk-go v1.25.3
-	github.com/chnsz/golangsdk v0.0.0-20220129021100-893f81801b65
+	github.com/chnsz/golangsdk v0.0.0-20220221091504-96baa1e956c5
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ github.com/chnsz/golangsdk v0.0.0-20211210025418-bfef50238f46 h1:43hIUYGkH3u7KBD
 github.com/chnsz/golangsdk v0.0.0-20211210025418-bfef50238f46/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chnsz/golangsdk v0.0.0-20220129021100-893f81801b65 h1:tkoHF39sMQlz+biRV3E+bKkX/d08ZHAEJQdmkQ50Jmw=
 github.com/chnsz/golangsdk v0.0.0-20220129021100-893f81801b65/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220221091504-96baa1e956c5 h1:Mn6Xui2RUV81QEQR0DgTHXiGZVEDzLEynUzylueNBys=
+github.com/chnsz/golangsdk v0.0.0-20220221091504-96baa1e956c5/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/listeners/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/elb/v3/listeners/requests.go
@@ -143,6 +143,12 @@ type IpGroupUpdate struct {
 
 // UpdateOpts represents options for updating a Listener.
 type UpdateOpts struct {
+	// Human-readable name for the Listener. Does not have to be unique.
+	Name string `json:"name,omitempty"`
+
+	// Human-readable description for the Listener.
+	Description *string `json:"description,omitempty"`
+
 	// The administrative state of the Listener. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
@@ -156,14 +162,8 @@ type UpdateOpts struct {
 	// A reference to a container of TLS secrets.
 	DefaultTlsContainerRef *string `json:"default_tls_container_ref,omitempty"`
 
-	// Human-readable description for the Listener.
-	Description string `json:"description,omitempty"`
-
 	// whether to use HTTP2.
 	Http2Enable *bool `json:"http2_enable,omitempty"`
-
-	// Human-readable name for the Listener. Does not have to be unique.
-	Name string `json:"name,omitempty"`
 
 	// A list of references to TLS secrets.
 	SniContainerRefs *[]string `json:"sni_container_refs,omitempty"`

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners/requests.go
@@ -166,7 +166,7 @@ type UpdateOpts struct {
 	Name string `json:"name,omitempty"`
 
 	// Human-readable description for the Listener.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// The maximum number of connections allowed for the Listener.
 	ConnLimit *int `json:"connection_limit,omitempty"`

--- a/vendor/github.com/chnsz/golangsdk/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/requests.go
+++ b/vendor/github.com/chnsz/golangsdk/openstack/networking/v2/extensions/lbaas_v2/loadbalancers/requests.go
@@ -144,7 +144,7 @@ type UpdateOpts struct {
 	Name string `json:"name,omitempty"`
 
 	// Human-readable description for the Loadbalancer.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).

--- a/vendor/github.com/chnsz/golangsdk/pagination/marker.go
+++ b/vendor/github.com/chnsz/golangsdk/pagination/marker.go
@@ -33,6 +33,10 @@ func (current MarkerPageBase) NextPageURL() (string, error) {
 		return "", err
 	}
 
+	if mark == "" {
+		return "", nil
+	}
+
 	q := currentURL.Query()
 	q.Set("marker", mark)
 	currentURL.RawQuery = q.Encode()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -58,7 +58,7 @@ github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 github.com/bgentry/go-netrc/netrc
-# github.com/chnsz/golangsdk v0.0.0-20220129021100-893f81801b65
+# github.com/chnsz/golangsdk v0.0.0-20220221091504-96baa1e956c5
 ## explicit
 github.com/chnsz/golangsdk
 github.com/chnsz/golangsdk/internal


### PR DESCRIPTION
fixes #692 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLBV2LoadBalancer_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLBV2LoadBalancer_basic -timeout 720m
=== RUN   TestAccLBV2LoadBalancer_basic
--- PASS: TestAccLBV2LoadBalancer_basic (44.58s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 44.595s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLBV2Listener_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLBV2Listener_basic -timeout 720m
=== RUN   TestAccLBV2Listener_basic
--- PASS: TestAccLBV2Listener_basic (90.20s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 90.211s
```