### PR TITLE
fix(obs): update obs Location when region is not specified

### DIFF
--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -18,7 +18,6 @@ import (
 	"github.com/chnsz/golangsdk"
 	huaweisdk "github.com/chnsz/golangsdk/openstack"
 	"github.com/chnsz/golangsdk/openstack/identity/v3/domains"
-	"github.com/chnsz/golangsdk/openstack/obs"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
@@ -371,42 +370,6 @@ func (c *Config) computeS3conn(region string) (*s3.S3, error) {
 	s3conn := s3.New(awsS3Sess)
 
 	return s3conn, nil
-}
-
-func (c *Config) newObjectStorageClient(region string) (*obs.ObsClient, error) {
-	if c.AccessKey == "" || c.SecretKey == "" {
-		return nil, fmt.Errorf("missing credentials for OBS, need access_key and secret_key values for provider")
-	}
-
-	// init log
-	if logging.IsDebugOrHigher() {
-		var logfile = "./.obs-sdk.log"
-		// maxLogSize:10M, backups:10
-		if err := obs.InitLog(logfile, 1024*1024*10, 10, obs.LEVEL_DEBUG, false); err != nil {
-			log.Printf("[WARN] initial obs sdk log failed: %s", err)
-		}
-	}
-
-	obsEndpoint := getObsEndpoint(c, region)
-	return obs.New(c.AccessKey, c.SecretKey, obsEndpoint)
-}
-
-func (c *Config) objectStorageClientWithSignature(region string) (*obs.ObsClient, error) {
-	if c.AccessKey == "" || c.SecretKey == "" {
-		return nil, fmt.Errorf("missing credentials for OBS, need access_key and secret_key values for provider")
-	}
-
-	// init log
-	if logging.IsDebugOrHigher() {
-		var logfile = "./.obs-sdk.log"
-		// maxLogSize:10M, backups:10
-		if err := obs.InitLog(logfile, 1024*1024*10, 10, obs.LEVEL_DEBUG, false); err != nil {
-			log.Printf("[WARN] initial obs sdk log failed: %s", err)
-		}
-	}
-
-	obsEndpoint := getObsEndpoint(c, region)
-	return obs.New(c.AccessKey, c.SecretKey, obsEndpoint, obs.WithSignature("OBS"))
 }
 
 func (c *Config) blockStorageV2Client(region string) (*golangsdk.ServiceClient, error) {

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -457,5 +457,8 @@ func configureProvider(_ context.Context, d *schema.ResourceData) (interface{}, 
 		return nil, diag.FromErr(err)
 	}
 
+	config.Endpoints = make(map[string]string)
+	config.Endpoints["obs"] = fmt.Sprintf("https://oss.%s.%s/", region, config.Cloud)
+
 	return &config, nil
 }

--- a/flexibleengine/resource_flexibleengine_obs_bucket.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket.go
@@ -228,6 +228,7 @@ func resourceObsBucket() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 			"encryption": {
 				Type:     schema.TypeBool,
@@ -255,7 +256,8 @@ func resourceObsBucket() *schema.Resource {
 
 func resourceObsBucketCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	obsClient, err := config.newObjectStorageClient(GetRegion(d, config))
+	region := GetRegion(d, config)
+	obsClient, err := config.newObjectStorageClient(region)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
 	}
@@ -268,7 +270,7 @@ func resourceObsBucketCreate(d *schema.ResourceData, meta interface{}) error {
 		ACL:          obs.AclType(acl),
 		StorageClass: obs.ParseStringToStorageClassType(class),
 	}
-	opts.Location = d.Get("region").(string)
+	opts.Location = region
 	if _, ok := d.GetOk("multi_az"); ok {
 		opts.AvailableZone = "3az"
 	}

--- a/flexibleengine/resource_flexibleengine_obs_bucket.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket.go
@@ -257,7 +257,7 @@ func resourceObsBucket() *schema.Resource {
 func resourceObsBucketCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	region := GetRegion(d, config)
-	obsClient, err := config.newObjectStorageClient(region)
+	obsClient, err := config.ObjectStorageClient(region)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
 	}
@@ -288,7 +288,7 @@ func resourceObsBucketCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceObsBucketUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	obsClient, err := config.newObjectStorageClient(GetRegion(d, config))
+	obsClient, err := config.ObjectStorageClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
 	}
@@ -348,7 +348,7 @@ func resourceObsBucketUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceObsBucketRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	region := GetRegion(d, config)
-	obsClient, err := config.newObjectStorageClient(region)
+	obsClient, err := config.ObjectStorageClient(region)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
 	}
@@ -417,7 +417,7 @@ func resourceObsBucketRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceObsBucketDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	obsClient, err := config.newObjectStorageClient(GetRegion(d, config))
+	obsClient, err := config.ObjectStorageClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_obs_bucket_object.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket_object.go
@@ -98,7 +98,7 @@ func resourceObsBucketObjectPut(d *schema.ResourceData, meta interface{}) error 
 	var err error
 
 	config := meta.(*Config)
-	obsClient, err := config.newObjectStorageClient(GetRegion(d, config))
+	obsClient, err := config.ObjectStorageClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
 	}
@@ -211,7 +211,7 @@ func putFileToObject(obsClient *obs.ObsClient, d *schema.ResourceData) (*obs.Put
 
 func resourceObsBucketObjectRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	obsClient, err := config.newObjectStorageClient(GetRegion(d, config))
+	obsClient, err := config.ObjectStorageClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
 	}
@@ -262,7 +262,7 @@ func resourceObsBucketObjectRead(d *schema.ResourceData, meta interface{}) error
 
 func resourceObsBucketObjectDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	obsClient, err := config.newObjectStorageClient(GetRegion(d, config))
+	obsClient, err := config.ObjectStorageClient(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_obs_bucket_object_test.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket_object_test.go
@@ -26,7 +26,7 @@ func TestAccObsBucketObject_source(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketObjectDestroy,
@@ -58,7 +58,7 @@ func TestAccObsBucketObject_source(t *testing.T) {
 func TestAccObsBucketObject_content(t *testing.T) {
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketObjectDestroy,
@@ -80,7 +80,7 @@ func TestAccObsBucketObject_content(t *testing.T) {
 
 func testAccCheckObsBucketObjectDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	obsClient, err := config.newObjectStorageClient(OS_REGION_NAME)
+	obsClient, err := config.ObjectStorageClient(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
 	}
@@ -131,7 +131,7 @@ func testAccCheckObsBucketObjectExists(n string) resource.TestCheckFunc {
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		obsClient, err := config.newObjectStorageClient(OS_REGION_NAME)
+		obsClient, err := config.ObjectStorageClient(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_obs_bucket_replication.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket_replication.go
@@ -68,7 +68,7 @@ func resourceObsBucketReplication() *schema.Resource {
 
 func resourceObsBucketReplicationCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	obsClient, err := config.objectStorageClientWithSignature(GetRegion(d, config))
+	obsClient, err := config.ObjectStorageClientWithSignature(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
 	}
@@ -137,7 +137,7 @@ func resourceObsBucketReplicationCreate(d *schema.ResourceData, meta interface{}
 
 func resourceObsBucketReplicationRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	obsClient, err := config.objectStorageClientWithSignature(GetRegion(d, config))
+	obsClient, err := config.ObjectStorageClientWithSignature(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
 	}
@@ -203,7 +203,7 @@ func setObsBucketReplicationConfiguration(obsClient *obs.ObsClient, d *schema.Re
 
 func resourceObsBucketReplicationDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	obsClient, err := config.objectStorageClientWithSignature(GetRegion(d, config))
+	obsClient, err := config.ObjectStorageClientWithSignature(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_obs_bucket_replication_test.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket_replication_test.go
@@ -13,7 +13,7 @@ func TestAccObsBucketReplication_basic(t *testing.T) {
 	rName := acctest.RandString(4)
 	resourceName := "flexibleengine_obs_bucket_replication.replica"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheckOBSReplication(t)
 		},
@@ -53,7 +53,7 @@ func TestAccObsBucketReplication_basic(t *testing.T) {
 
 func testAccCheckObsBucketReplicationDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	obsClient, err := config.objectStorageClientWithSignature(OS_REGION_NAME)
+	obsClient, err := config.ObjectStorageClientWithSignature(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
 	}
@@ -83,7 +83,7 @@ func testAccCheckObsBucketReplicationExists(n string) resource.TestCheckFunc {
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		obsClient, err := config.objectStorageClientWithSignature(OS_REGION_NAME)
+		obsClient, err := config.ObjectStorageClientWithSignature(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_obs_bucket_test.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket_test.go
@@ -13,7 +13,7 @@ func TestAccObsBucket_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "flexibleengine_obs_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
@@ -56,7 +56,7 @@ func TestAccObsBucket_multiAZ(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "flexibleengine_obs_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckS3(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -79,7 +79,7 @@ func TestAccObsBucket_tags(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "flexibleengine_obs_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheckS3(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -103,7 +103,7 @@ func TestAccObsBucket_versioning(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "flexibleengine_obs_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
@@ -133,7 +133,7 @@ func TestAccObsBucket_logging(t *testing.T) {
 	target_bucket := fmt.Sprintf("tf-test-log-bucket-%d", rInt)
 	resourceName := "flexibleengine_obs_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
@@ -153,7 +153,7 @@ func TestAccObsBucket_lifecycle(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "flexibleengine_obs_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
@@ -192,7 +192,7 @@ func TestAccObsBucket_website(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "flexibleengine_obs_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
@@ -215,7 +215,7 @@ func TestAccObsBucket_cors(t *testing.T) {
 	rInt := acctest.RandInt()
 	resourceName := "flexibleengine_obs_bucket.bucket"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckS3(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckObsBucketDestroy,
@@ -242,7 +242,7 @@ func TestAccObsBucket_cors(t *testing.T) {
 
 func testAccCheckObsBucketDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	obsClient, err := config.newObjectStorageClient(OS_REGION_NAME)
+	obsClient, err := config.ObjectStorageClient(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
 	}
@@ -272,7 +272,7 @@ func testAccCheckObsBucketExists(n string) resource.TestCheckFunc {
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		obsClient, err := config.newObjectStorageClient(OS_REGION_NAME)
+		obsClient, err := config.ObjectStorageClient(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
 		}
@@ -293,7 +293,7 @@ func testAccCheckObsBucketLogging(name, target, prefix string) resource.TestChec
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		obsClient, err := config.newObjectStorageClient(OS_REGION_NAME)
+		obsClient, err := config.ObjectStorageClient(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
 		}


### PR DESCRIPTION
the testing result as follows:

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccObsBucket'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccObsBucket -timeout 720m
=== RUN   TestAccObsBucketObject_source
=== PAUSE TestAccObsBucketObject_source
=== RUN   TestAccObsBucketObject_content
=== PAUSE TestAccObsBucketObject_content
=== RUN   TestAccObsBucketReplication_basic
=== PAUSE TestAccObsBucketReplication_basic
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== RUN   TestAccObsBucket_multiAZ
=== PAUSE TestAccObsBucket_multiAZ
=== RUN   TestAccObsBucket_versioning
=== PAUSE TestAccObsBucket_versioning
=== RUN   TestAccObsBucket_logging
=== PAUSE TestAccObsBucket_logging
=== RUN   TestAccObsBucket_lifecycle
=== PAUSE TestAccObsBucket_lifecycle
=== RUN   TestAccObsBucket_website
=== PAUSE TestAccObsBucket_website
=== RUN   TestAccObsBucket_cors
=== PAUSE TestAccObsBucket_cors
=== CONT  TestAccObsBucketObject_source
=== CONT  TestAccObsBucket_versioning
=== CONT  TestAccObsBucket_website
=== CONT  TestAccObsBucket_lifecycle
--- PASS: TestAccObsBucket_website (7.81s)
=== CONT  TestAccObsBucket_cors
--- PASS: TestAccObsBucket_lifecycle (8.56s)
=== CONT  TestAccObsBucket_logging
--- PASS: TestAccObsBucket_versioning (14.20s)
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucketObject_source (15.04s)
=== CONT  TestAccObsBucket_multiAZ
--- PASS: TestAccObsBucket_cors (7.63s)
=== CONT  TestAccObsBucketReplication_basic
--- PASS: TestAccObsBucket_logging (10.62s)
=== CONT  TestAccObsBucketObject_content
--- PASS: TestAccObsBucket_multiAZ (6.71s)
--- PASS: TestAccObsBucketObject_content (7.60s)
--- PASS: TestAccObsBucket_basic (15.21s)
--- PASS: TestAccObsBucketReplication_basic (18.98s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 34.436s
```