### PR TITLE
refactor(config/s3): put s3 session out of Config struct

### DIFF
--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -11,15 +11,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/chnsz/golangsdk"
 	huaweisdk "github.com/chnsz/golangsdk/openstack"
 	"github.com/chnsz/golangsdk/openstack/identity/v3/domains"
-	"github.com/hashicorp/errwrap"
-	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	huaweiconfig "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/pathorcontents"
@@ -27,7 +21,6 @@ import (
 
 type Config struct {
 	huaweiconfig.Config
-	s3sess *session.Session
 }
 
 func (c *Config) LoadAndValidate() error {
@@ -66,7 +59,7 @@ func (c *Config) LoadAndValidate() error {
 		}
 	}
 
-	return c.newS3Session(logging.IsDebugOrHigher())
+	return nil
 }
 
 func generateTLSConfig(c *Config) (*tls.Config, error) {
@@ -258,67 +251,6 @@ func genClients(c *Config, pao, dao golangsdk.AuthOptionsProvider) error {
 	return err
 }
 
-type awsLogger struct{}
-
-func (l awsLogger) Log(args ...interface{}) {
-	tokens := make([]string, 0, len(args))
-	for _, arg := range args {
-		if token, ok := arg.(string); ok {
-			tokens = append(tokens, token)
-		}
-	}
-	log.Printf("[DEBUG] [aws-sdk-go] %s", strings.Join(tokens, " "))
-}
-
-func (c *Config) newS3Session(osDebug bool) error {
-	if c.AccessKey != "" && c.SecretKey != "" {
-		// Setup S3 client/config information for Swift S3 buckets
-		log.Println("[INFO] Building Swift S3 auth structure")
-		creds, err := GetCredentials(c)
-		if err != nil {
-			return err
-		}
-		// Call Get to check for credential provider. If nothing found, we'll get an
-		// error, and we can present it nicely to the user
-		cp, err := creds.Get()
-		if err != nil {
-			if sErr, ok := err.(awserr.Error); ok && sErr.Code() == "NoCredentialProviders" {
-				return fmt.Errorf("No valid credential sources found for S3 Provider.")
-			}
-
-			return fmt.Errorf("Error loading credentials for S3 Provider: %s", err)
-		}
-
-		log.Printf("[INFO] S3 Auth provider used: %q", cp.ProviderName)
-
-		sConfig := &aws.Config{
-			Credentials: creds,
-			Region:      aws.String(c.Region),
-			HTTPClient:  cleanhttp.DefaultClient(),
-		}
-
-		if osDebug {
-			sConfig.LogLevel = aws.LogLevel(aws.LogDebugWithHTTPBody | aws.LogDebugWithRequestRetries | aws.LogDebugWithRequestErrors)
-			sConfig.Logger = awsLogger{}
-		}
-
-		if c.Insecure {
-			transport := sConfig.HTTPClient.Transport.(*http.Transport)
-			transport.TLSClientConfig = &tls.Config{
-				InsecureSkipVerify: true,
-			}
-		}
-
-		// Set up base session for S3
-		c.s3sess, err = session.NewSession(sConfig)
-		if err != nil {
-			return errwrap.Wrapf("Error creating Swift S3 session: {{err}}", err)
-		}
-	}
-
-	return nil
-}
-
 func (c *Config) determineRegion(region string) string {
 	// If a resource-level region was not specified, and a provider-level region was set,
 	// use the provider-level region.
@@ -358,18 +290,6 @@ func (c *Config) getDomainID() (string, error) {
 	}
 
 	return all[0].ID, nil
-}
-
-func (c *Config) computeS3conn(region string) (*s3.S3, error) {
-	if c.s3sess == nil {
-		return nil, fmt.Errorf("missing credentials for Swift S3 Provider, need access_key and secret_key values for provider")
-	}
-
-	endpoint := getObsEndpoint(c, region)
-	awsS3Sess := c.s3sess.Copy(&aws.Config{Endpoint: aws.String(endpoint)})
-	s3conn := s3.New(awsS3Sess)
-
-	return s3conn, nil
 }
 
 func (c *Config) blockStorageV2Client(region string) (*golangsdk.ServiceClient, error) {
@@ -635,11 +555,4 @@ func (c *Config) sdkClient(region, serviceType string) (*golangsdk.ServiceClient
 
 func (c *Config) getHwEndpointType() golangsdk.Availability {
 	return golangsdk.AvailabilityPublic
-}
-
-func getObsEndpoint(c *Config, region string) string {
-	if endpoint, ok := c.Endpoints["oss"]; ok {
-		return endpoint
-	}
-	return fmt.Sprintf("https://oss.%s.%s/", region, c.Cloud)
 }

--- a/flexibleengine/data_source_flexibleengine_s3_bucket_object.go
+++ b/flexibleengine/data_source_flexibleengine_s3_bucket_object.go
@@ -101,7 +101,7 @@ func dataSourceS3BucketObject() *schema.Resource {
 
 func dataSourceS3BucketObjectRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	conn, err := config.computeS3conn(GetRegion(d, config))
+	conn, err := computeS3conn(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 	}

--- a/flexibleengine/data_source_flexibleengine_s3_bucket_object_test.go
+++ b/flexibleengine/data_source_flexibleengine_s3_bucket_object_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceS3BucketObject_basic(t *testing.T) {
 	var rObj s3.GetObjectOutput
 	var dsObj s3.GetObjectOutput
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { testAccPreCheck(t) },
 		Providers:                 testAccProviders,
 		PreventPostDestroyRefresh: true,
@@ -53,7 +53,7 @@ func TestAccDataSourceS3BucketObject_readableBody(t *testing.T) {
 	var rObj s3.GetObjectOutput
 	var dsObj s3.GetObjectOutput
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { testAccPreCheck(t) },
 		Providers:                 testAccProviders,
 		PreventPostDestroyRefresh: true,
@@ -87,7 +87,7 @@ func TestAccDataSourceS3BucketObject_allParams(t *testing.T) {
 	var rObj s3.GetObjectOutput
 	var dsObj s3.GetObjectOutput
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                  func() { testAccPreCheck(t) },
 		Providers:                 testAccProviders,
 		PreventPostDestroyRefresh: true,
@@ -138,7 +138,7 @@ func testAccCheckS3ObjectDataSourceExists(n string, obj *s3.GetObjectOutput) res
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		s3conn, err := config.computeS3conn(OS_REGION_NAME)
+		s3conn, err := computeS3conn(config, OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 		}

--- a/flexibleengine/import_flexibleengine_s3_bucket.go
+++ b/flexibleengine/import_flexibleengine_s3_bucket.go
@@ -18,7 +18,7 @@ func resourceS3BucketImportState(
 	results[0] = d
 
 	config := meta.(*Config)
-	conn, err := config.computeS3conn(GetRegion(d, config))
+	conn, err := computeS3conn(config, GetRegion(d, config))
 	if err != nil {
 		return nil, fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_obs_bucket.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket.go
@@ -1190,6 +1190,10 @@ func deleteAllBucketObjects(obsClient *obs.ObsClient, bucket string) error {
 	return nil
 }
 
+func bucketDomainName(bucket, region string) string {
+	return fmt.Sprintf("%s.oss.%s.prod-cloud-ocb.orange-business.com", bucket, region)
+}
+
 func getObsError(action string, bucket string, err error) error {
 	if obsError, ok := err.(obs.ObsError); ok {
 		return fmt.Errorf("%s %s: %s,\n Reason: %s", action, bucket, obsError.Code, obsError.Message)

--- a/flexibleengine/resource_flexibleengine_s3_bucket.go
+++ b/flexibleengine/resource_flexibleengine_s3_bucket.go
@@ -280,7 +280,7 @@ func resourceS3Bucket() *schema.Resource {
 
 func resourceS3BucketCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	s3conn, err := config.computeS3conn(GetRegion(d, config))
+	s3conn, err := computeS3conn(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 	}
@@ -346,7 +346,7 @@ func resourceS3BucketCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceS3BucketUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	s3conn, err := config.computeS3conn(GetRegion(d, config))
+	s3conn, err := computeS3conn(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 	}
@@ -397,7 +397,7 @@ func resourceS3BucketUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	s3conn, err := config.computeS3conn(GetRegion(d, config))
+	s3conn, err := computeS3conn(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 	}
@@ -424,7 +424,7 @@ func resourceS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("bucket", d.Id())
 	}
 
-	domainName := bucketDomainName(d.Get("bucket").(string), GetRegion(d, config))
+	domainName := s3BucketDomainName(d.Get("bucket").(string), GetRegion(d, config))
 	d.Set("bucket_domain_name", domainName)
 
 	// Read the policy
@@ -768,7 +768,7 @@ func resourceS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceS3BucketDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	s3conn, err := config.computeS3conn(GetRegion(d, config))
+	s3conn, err := computeS3conn(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 	}
@@ -1083,7 +1083,7 @@ func websiteEndpoint(s3conn *s3.S3, d *schema.ResourceData) (*S3Website, error) 
 	return WebsiteEndpoint(bucket, region), nil
 }
 
-func bucketDomainName(bucket, region string) string {
+func s3BucketDomainName(bucket, region string) string {
 	return fmt.Sprintf("%s.oss.%s.prod-cloud-ocb.orange-business.com", bucket, region)
 }
 

--- a/flexibleengine/resource_flexibleengine_s3_bucket_object.go
+++ b/flexibleengine/resource_flexibleengine_s3_bucket_object.go
@@ -113,7 +113,7 @@ func resourceS3BucketObject() *schema.Resource {
 
 func resourceS3BucketObjectPut(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	s3conn, err := config.computeS3conn(GetRegion(d, config))
+	s3conn, err := computeS3conn(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 	}
@@ -192,7 +192,7 @@ func resourceS3BucketObjectPut(d *schema.ResourceData, meta interface{}) error {
 
 func resourceS3BucketObjectRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	s3conn, err := config.computeS3conn(GetRegion(d, config))
+	s3conn, err := computeS3conn(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 	}
@@ -233,7 +233,7 @@ func resourceS3BucketObjectRead(d *schema.ResourceData, meta interface{}) error 
 
 func resourceS3BucketObjectDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	s3conn, err := config.computeS3conn(GetRegion(d, config))
+	s3conn, err := computeS3conn(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_s3_bucket_object_test.go
+++ b/flexibleengine/resource_flexibleengine_s3_bucket_object_test.go
@@ -204,7 +204,7 @@ func testAccCheckS3BucketObjectVersionIdDiffers(first, second *s3.GetObjectOutpu
 
 func testAccCheckS3BucketObjectDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	s3conn, err := config.computeS3conn(OS_REGION_NAME)
+	s3conn, err := computeS3conn(config, OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 	}
@@ -239,7 +239,7 @@ func testAccCheckS3BucketObjectExists(n string, obj *s3.GetObjectOutput) resourc
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		s3conn, err := config.computeS3conn(OS_REGION_NAME)
+		s3conn, err := computeS3conn(config, OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 		}
@@ -305,7 +305,7 @@ func testAccCheckS3BucketObjectAcl(n string, expectedPerms []string) resource.Te
 	return func(s *terraform.State) error {
 		rs, _ := s.RootModule().Resources[n]
 		config := testAccProvider.Meta().(*Config)
-		s3conn, err := config.computeS3conn(OS_REGION_NAME)
+		s3conn, err := computeS3conn(config, OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 		}
@@ -393,7 +393,7 @@ func testAccCheckS3BucketObjectSSE(n, expectedSSE string) resource.TestCheckFunc
 	return func(s *terraform.State) error {
 		rs, _ := s.RootModule().Resources[n]
 		config := testAccProvider.Meta().(*Config)
-		s3conn, err := config.computeS3conn(OS_REGION_NAME)
+		s3conn, err := computeS3conn(config, OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_s3_bucket_policy.go
+++ b/flexibleengine/resource_flexibleengine_s3_bucket_policy.go
@@ -38,7 +38,7 @@ func resourceS3BucketPolicy() *schema.Resource {
 
 func resourceS3BucketPolicyPut(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	s3conn, err := config.computeS3conn(GetRegion(d, config))
+	s3conn, err := computeS3conn(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 	}
@@ -76,7 +76,7 @@ func resourceS3BucketPolicyPut(d *schema.ResourceData, meta interface{}) error {
 
 func resourceS3BucketPolicyRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	s3conn, err := config.computeS3conn(GetRegion(d, config))
+	s3conn, err := computeS3conn(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 	}
@@ -99,7 +99,7 @@ func resourceS3BucketPolicyRead(d *schema.ResourceData, meta interface{}) error 
 
 func resourceS3BucketPolicyDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	s3conn, err := config.computeS3conn(GetRegion(d, config))
+	s3conn, err := computeS3conn(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_s3_bucket_policy_test.go
+++ b/flexibleengine/resource_flexibleengine_s3_bucket_policy_test.go
@@ -82,7 +82,7 @@ func testAccCheckS3BucketHasPolicy(n string, expectedPolicyText string) resource
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		conn, err := config.computeS3conn(OS_REGION_NAME)
+		conn, err := computeS3conn(config, OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_s3_bucket_test.go
+++ b/flexibleengine/resource_flexibleengine_s3_bucket_test.go
@@ -6,13 +6,12 @@ import (
 	"reflect"
 	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -360,7 +359,7 @@ func TestAccS3Bucket_Cors(t *testing.T) {
 			}
 
 			config := testAccProvider.Meta().(*Config)
-			conn, err := config.computeS3conn(OS_REGION_NAME)
+			conn, err := computeS3conn(config, OS_REGION_NAME)
 			if err != nil {
 				return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 			}
@@ -599,7 +598,7 @@ func testAccCheckS3BucketExistsWithProviders(n string, providers *[]*schema.Prov
 			}
 
 			config := testAccProvider.Meta().(*Config)
-			conn, err := config.computeS3conn(OS_REGION_NAME)
+			conn, err := computeS3conn(config, OS_REGION_NAME)
 			if err != nil {
 				return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 			}
@@ -629,7 +628,7 @@ func testAccCheckS3DestroyBucket(n string) resource.TestCheckFunc {
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		conn, err := config.computeS3conn(OS_REGION_NAME)
+		conn, err := computeS3conn(config, OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 		}
@@ -648,7 +647,7 @@ func testAccCheckS3BucketPolicy(n string, policy string) resource.TestCheckFunc 
 	return func(s *terraform.State) error {
 		rs, _ := s.RootModule().Resources[n]
 		config := testAccProvider.Meta().(*Config)
-		conn, err := config.computeS3conn(OS_REGION_NAME)
+		conn, err := computeS3conn(config, OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 		}
@@ -699,7 +698,7 @@ func testAccCheckS3BucketWebsite(n string, indexDoc string, errorDoc string, red
 	return func(s *terraform.State) error {
 		rs, _ := s.RootModule().Resources[n]
 		config := testAccProvider.Meta().(*Config)
-		conn, err := config.computeS3conn(OS_REGION_NAME)
+		conn, err := computeS3conn(config, OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 		}
@@ -759,7 +758,7 @@ func testAccCheckS3BucketWebsiteRoutingRules(n string, routingRules []*s3.Routin
 	return func(s *terraform.State) error {
 		rs, _ := s.RootModule().Resources[n]
 		config := testAccProvider.Meta().(*Config)
-		conn, err := config.computeS3conn(OS_REGION_NAME)
+		conn, err := computeS3conn(config, OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 		}
@@ -787,7 +786,7 @@ func testAccCheckS3BucketVersioning(n string, versioningStatus string) resource.
 	return func(s *terraform.State) error {
 		rs, _ := s.RootModule().Resources[n]
 		config := testAccProvider.Meta().(*Config)
-		conn, err := config.computeS3conn(OS_REGION_NAME)
+		conn, err := computeS3conn(config, OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 		}
@@ -818,7 +817,7 @@ func testAccCheckS3BucketCors(n string, corsRules []*s3.CORSRule) resource.TestC
 	return func(s *terraform.State) error {
 		rs, _ := s.RootModule().Resources[n]
 		config := testAccProvider.Meta().(*Config)
-		conn, err := config.computeS3conn(OS_REGION_NAME)
+		conn, err := computeS3conn(config, OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 		}
@@ -843,7 +842,7 @@ func testAccCheckS3BucketLogging(n, b, p string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, _ := s.RootModule().Resources[n]
 		config := testAccProvider.Meta().(*Config)
-		conn, err := config.computeS3conn(OS_REGION_NAME)
+		conn, err := computeS3conn(config, OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine s3 client: %s", err)
 		}

--- a/flexibleengine/s3session.go
+++ b/flexibleengine/s3session.go
@@ -1,0 +1,106 @@
+package flexibleengine
+
+import (
+	"crypto/tls"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+)
+
+var s3Session *session.Session
+var s3Mutex = new(sync.Mutex)
+
+type awsLogger struct{}
+
+func (l awsLogger) Log(args ...interface{}) {
+	tokens := make([]string, 0, len(args))
+	for _, arg := range args {
+		if token, ok := arg.(string); ok {
+			tokens = append(tokens, token)
+		}
+	}
+	log.Printf("[DEBUG] [aws-sdk-go] %s", strings.Join(tokens, " "))
+}
+
+func computeS3conn(c *Config, region string) (*s3.S3, error) {
+	s3Mutex.Lock()
+	defer s3Mutex.Unlock()
+
+	var err error
+	if s3Session == nil {
+		log.Printf("[DEBUG] initialize Swift S3 session")
+		s3Session, err = newS3Session(c, logging.IsDebugOrHigher())
+		if err != nil {
+			return nil, errwrap.Wrapf("Error creating Swift S3 session: {{err}}", err)
+		}
+	}
+
+	endpoint := getOssEndpoint(c, region)
+	awsS3Sess := s3Session.Copy(&aws.Config{Endpoint: aws.String(endpoint)})
+	s3conn := s3.New(awsS3Sess)
+
+	return s3conn, nil
+}
+
+func newS3Session(c *Config, osDebug bool) (*session.Session, error) {
+	if c.AccessKey == "" || c.SecretKey == "" {
+		return nil, fmt.Errorf("missing credentials for Swift S3 Provider, need access_key and secret_key values for provider")
+	}
+
+	// Setup S3 client/config information for Swift S3 buckets
+	log.Println("[INFO] Building Swift S3 auth structure")
+	creds, err := GetCredentials(c)
+	if err != nil {
+		return nil, err
+	}
+	// Call Get to check for credential provider. If nothing found, we'll get an
+	// error, and we can present it nicely to the user
+	cp, err := creds.Get()
+	if err != nil {
+		if sErr, ok := err.(awserr.Error); ok && sErr.Code() == "NoCredentialProviders" {
+			return nil, fmt.Errorf("No valid credential sources found for S3 Provider")
+		}
+
+		return nil, fmt.Errorf("Error loading credentials for S3 Provider: %s", err)
+	}
+
+	log.Printf("[INFO] S3 Auth provider used: %q", cp.ProviderName)
+
+	sConfig := &aws.Config{
+		Credentials: creds,
+		Region:      aws.String(c.Region),
+		HTTPClient:  cleanhttp.DefaultClient(),
+	}
+
+	if osDebug {
+		sConfig.LogLevel = aws.LogLevel(aws.LogDebugWithHTTPBody | aws.LogDebugWithRequestRetries | aws.LogDebugWithRequestErrors)
+		sConfig.Logger = awsLogger{}
+	}
+
+	if c.Insecure {
+		transport := sConfig.HTTPClient.Transport.(*http.Transport)
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	}
+
+	// Set up base session for S3
+	return session.NewSession(sConfig)
+}
+
+func getOssEndpoint(c *Config, region string) string {
+	if endpoint, ok := c.Endpoints["oss"]; ok {
+		return endpoint
+	}
+	return fmt.Sprintf("https://oss.%s.%s/", region, c.Cloud)
+}


### PR DESCRIPTION
the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDataSourceS3BucketObject'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDataSourceS3BucketObject -timeout 720m
=== RUN   TestAccDataSourceS3BucketObject_basic
=== PAUSE TestAccDataSourceS3BucketObject_basic
=== RUN   TestAccDataSourceS3BucketObject_readableBody
=== PAUSE TestAccDataSourceS3BucketObject_readableBody
=== RUN   TestAccDataSourceS3BucketObject_allParams
=== PAUSE TestAccDataSourceS3BucketObject_allParams
=== CONT  TestAccDataSourceS3BucketObject_basic
=== CONT  TestAccDataSourceS3BucketObject_allParams
=== CONT  TestAccDataSourceS3BucketObject_readableBody
--- PASS: TestAccDataSourceS3BucketObject_readableBody (138.47s)
--- PASS: TestAccDataSourceS3BucketObject_basic (140.53s)
--- PASS: TestAccDataSourceS3BucketObject_allParams (143.39s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 143.443s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccS3Bucket'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccS3Bucket -timeout 720m
=== RUN   TestAccS3BucketObject_source
--- PASS: TestAccS3BucketObject_source (72.63s)
=== RUN   TestAccS3BucketObject_content
--- PASS: TestAccS3BucketObject_content (72.65s)
=== RUN   TestAccS3BucketObject_withContentCharacteristics
--- PASS: TestAccS3BucketObject_withContentCharacteristics (73.92s)
=== RUN   TestAccS3BucketObject_updates
--- PASS: TestAccS3BucketObject_updates (132.34s)
=== RUN   TestAccS3BucketObject_updatesWithVersioning
--- PASS: TestAccS3BucketObject_updatesWithVersioning (134.96s)
=== RUN   TestAccS3BucketObject_acl
--- PASS: TestAccS3BucketObject_acl (135.05s)
=== RUN   TestAccS3BucketPolicy_basic
--- PASS: TestAccS3BucketPolicy_basic (71.25s)
=== RUN   TestAccS3BucketPolicy_policyUpdate
--- PASS: TestAccS3BucketPolicy_policyUpdate (132.12s)
=== RUN   TestAccS3Bucket_basic
--- PASS: TestAccS3Bucket_basic (65.72s)
=== RUN   TestAccS3Bucket_namePrefix
--- PASS: TestAccS3Bucket_namePrefix (65.31s)
=== RUN   TestAccS3Bucket_generatedName
--- PASS: TestAccS3Bucket_generatedName (67.38s)
=== RUN   TestAccS3Bucket_region
--- PASS: TestAccS3Bucket_region (68.76s)
=== RUN   TestAccS3Bucket_Policy
--- PASS: TestAccS3Bucket_Policy (200.49s)
=== RUN   TestAccS3Bucket_UpdateAcl
--- PASS: TestAccS3Bucket_UpdateAcl (140.01s)
=== RUN   TestAccS3Bucket_Website_Simple
--- PASS: TestAccS3Bucket_Website_Simple (219.43s)
=== RUN   TestAccS3Bucket_WebsiteRedirect
--- PASS: TestAccS3Bucket_WebsiteRedirect (219.53s)
=== RUN   TestAccS3Bucket_WebsiteRoutingRules
--- PASS: TestAccS3Bucket_WebsiteRoutingRules (149.21s)
=== RUN   TestAccS3Bucket_shouldFailNotFound
--- PASS: TestAccS3Bucket_shouldFailNotFound (58.33s)
=== RUN   TestAccS3Bucket_Versioning
--- PASS: TestAccS3Bucket_Versioning (209.96s)
=== RUN   TestAccS3Bucket_Cors
--- PASS: TestAccS3Bucket_Cors (147.82s)

PASS
ok    github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 2477.984s
```