### PR TITLE
chore: update RDS DDS and DCS service endpoints

### DIFF
--- a/docs/resources/dcs_instance_v1.md
+++ b/docs/resources/dcs_instance_v1.md
@@ -194,39 +194,20 @@ Changing this creates a new instance.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
-
-* `name` - See Argument Reference above.
-* `description` - See Argument Reference above.
-* `engine` - See Argument Reference above.
-* `engine_version` - See Argument Reference above.
-* `capacity` - See Argument Reference above.
-* `access_user` - See Argument Reference above.
-* `password` - See Argument Reference above.
-* `vpc_id` - See Argument Reference above.
+* `id` - The resource ID in UUID format.
+* `status` - Status of the Cache instance.
 * `vpc_name` - Indicates the name of a vpc.
-* `security_group_id` - See Argument Reference above.
-* `security_group_name` - Indicates the name of a security group.
 * `subnet_name` - Indicates the name of a subnet.
-* `available_zones` - See Argument Reference above.
-* `product_id` - See Argument Reference above.
-* `maintain_begin` - See Argument Reference above.
-* `maintain_end` - See Argument Reference above.
-* `save_days` - See Argument Reference above.
-* `backup_type` - See Argument Reference above.
-* `begin_at` - See Argument Reference above.
-* `period_type` - See Argument Reference above.
-* `backup_at` - See Argument Reference above.
-* `order_id` - An order ID is generated only in the monthly or yearly billing mode.
-    In other billing modes, no value is returned for this parameter.
+* `security_group_name` - Indicates the name of a security group.
+* `ip` - Cache node's IP address in tenant's VPC.
 * `port` - Port of the cache node.
 * `resource_spec_code` - Resource specifications.
     dcs.single_node: indicates a DCS instance in single-node mode.
     dcs.master_standby: indicates a DCS instance in master/standby mode.
     dcs.cluster: indicates a DCS instance in cluster mode.
-* `used_memory` - Size of the used memory. Unit: MB.
 * `internal_version` - Internal DCS version.
 * `max_memory` - Overall memory size. Unit: MB.
+* `used_memory` - Size of the used memory. Unit: MB.
 * `user_id` - Indicates a user ID.
-* `ip` - Cache node's IP address in tenant's VPC.

--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -451,13 +451,6 @@ func (c *Config) ctsV1Client(region string) (*golangsdk.ServiceClient, error) {
 	})
 }
 
-func (c *Config) dcsV1Client(region string) (*golangsdk.ServiceClient, error) {
-	return huaweisdk.NewDCSServiceV1(c.HwClient, golangsdk.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: c.getHwEndpointType(),
-	})
-}
-
 func (c *Config) cceV3Client(region string) (*golangsdk.ServiceClient, error) {
 	return huaweisdk.NewCCEV3(c.HwClient, golangsdk.EndpointOpts{
 		Region:       c.determineRegion(region),

--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -472,20 +472,6 @@ func (c *Config) kmsKeyV1Client(region string) (*golangsdk.ServiceClient, error)
 	})
 }
 
-func (c *Config) rdsV1Client(region string) (*golangsdk.ServiceClient, error) {
-	return huaweisdk.NewRDSV1(c.HwClient, golangsdk.EndpointOpts{
-		Region:       region,
-		Availability: c.getHwEndpointType(),
-	})
-}
-
-func (c *Config) rdsV3Client(region string) (*golangsdk.ServiceClient, error) {
-	return huaweisdk.NewRDSV3(c.HwClient, golangsdk.EndpointOpts{
-		Region:       region,
-		Availability: c.getHwEndpointType(),
-	})
-}
-
 func (c *Config) ddsV3Client(region string) (*golangsdk.ServiceClient, error) {
 	return huaweisdk.NewDDSV3(c.HwClient, golangsdk.EndpointOpts{
 		Region:       region,

--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -472,13 +472,6 @@ func (c *Config) kmsKeyV1Client(region string) (*golangsdk.ServiceClient, error)
 	})
 }
 
-func (c *Config) ddsV3Client(region string) (*golangsdk.ServiceClient, error) {
-	return huaweisdk.NewDDSV3(c.HwClient, golangsdk.EndpointOpts{
-		Region:       region,
-		Availability: c.getHwEndpointType(),
-	})
-}
-
 func (c *Config) sdrsV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return huaweisdk.NewSDRSV1(c.HwClient, golangsdk.EndpointOpts{
 		Region:       region,

--- a/flexibleengine/config_test.go
+++ b/flexibleengine/config_test.go
@@ -366,7 +366,7 @@ func TestAccServiceEndpoints_Database(t *testing.T) {
 	testCheckServiceURL(t, expectedURL, actualURL, "RDS v3")
 
 	// test the endpoint of DDS v3 service
-	serviceClient, err = config.ddsV3Client(OS_REGION_NAME)
+	serviceClient, err = config.DdsV3Client(OS_REGION_NAME)
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine DDS v3 client: %s", err)
 	}

--- a/flexibleengine/config_test.go
+++ b/flexibleengine/config_test.go
@@ -425,9 +425,9 @@ func TestAccServiceEndpoints_Application(t *testing.T) {
 	config := testProvider.Meta().(*Config)
 
 	// test the endpoint of DCS v1 service
-	serviceClient, err = config.dcsV1Client(OS_REGION_NAME)
+	serviceClient, err = config.DcsV1Client(OS_REGION_NAME)
 	if err != nil {
-		t.Fatalf("Error creating FlexibleEngine dcs v1 client: %s", err)
+		t.Fatalf("Error creating FlexibleEngine DCS v1 client: %s", err)
 	}
 	expectedURL = fmt.Sprintf("https://dcs.%s.%s/v1.0/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()

--- a/flexibleengine/config_test.go
+++ b/flexibleengine/config_test.go
@@ -348,16 +348,16 @@ func TestAccServiceEndpoints_Database(t *testing.T) {
 	config := testProvider.Meta().(*Config)
 
 	// test the endpoint of RDS v1 service
-	serviceClient, err = config.rdsV1Client(OS_REGION_NAME)
+	serviceClient, err = config.RdsV1Client(OS_REGION_NAME)
 	if err != nil {
-		t.Fatalf("Error creating FlexibleEngine rds v1 client: %s", err)
+		t.Fatalf("Error creating FlexibleEngine RDS v1 client: %s", err)
 	}
 	expectedURL = fmt.Sprintf("https://rds.%s.%s/rds/v1/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "RDS v1")
 
 	// test the endpoint of RDS v3 service
-	serviceClient, err = config.rdsV3Client(OS_REGION_NAME)
+	serviceClient, err = config.RdsV3Client(OS_REGION_NAME)
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine RDS v3 client: %s", err)
 	}

--- a/flexibleengine/data_source_flexibleengine_dcs_az_v1.go
+++ b/flexibleengine/data_source_flexibleengine_dcs_az_v1.go
@@ -36,7 +36,7 @@ func dataSourceDcsAZV1() *schema.Resource {
 
 func dataSourceDcsAZV1Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dcsV1Client, err := config.dcsV1Client(GetRegion(d, config))
+	dcsV1Client, err := config.DcsV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating dcs key client: %s", err)
 	}

--- a/flexibleengine/data_source_flexibleengine_dcs_maintainwindow_v1.go
+++ b/flexibleengine/data_source_flexibleengine_dcs_maintainwindow_v1.go
@@ -40,7 +40,7 @@ func dataSourceDcsMaintainWindowV1() *schema.Resource {
 
 func dataSourceDcsMaintainWindowV1Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dcsV1Client, err := config.dcsV1Client(GetRegion(d, config))
+	dcsV1Client, err := config.DcsV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating dcs key client: %s", err)
 	}

--- a/flexibleengine/data_source_flexibleengine_dcs_product_v1.go
+++ b/flexibleengine/data_source_flexibleengine_dcs_product_v1.go
@@ -43,7 +43,7 @@ func dataSourceDcsProductV1() *schema.Resource {
 
 func dataSourceDcsProductV1Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dcsV1Client, err := config.dcsV1Client(GetRegion(d, config))
+	dcsV1Client, err := config.DcsV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error get dcs product client: %s", err)
 	}

--- a/flexibleengine/data_source_flexibleengine_dds_flavor_v3.go
+++ b/flexibleengine/data_source_flexibleengine_dds_flavor_v3.go
@@ -48,7 +48,7 @@ func dataSourceDDSFlavorV3() *schema.Resource {
 
 func dataSourceDDSFlavorV3Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	ddsClient, err := config.ddsV3Client(GetRegion(d, config))
+	ddsClient, err := config.DdsV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DDS client: %s", err)
 	}

--- a/flexibleengine/data_source_flexibleengine_dds_flavors_v3.go
+++ b/flexibleengine/data_source_flexibleengine_dds_flavors_v3.go
@@ -74,7 +74,7 @@ func dataSourceDDSFlavorsV3() *schema.Resource {
 func dataSourceDDSFlavorsV3Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	region := GetRegion(d, config)
-	ddsClient, err := config.ddsV3Client(region)
+	ddsClient, err := config.DdsV3Client(region)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DDS client: %s", err)
 	}

--- a/flexibleengine/data_source_flexibleengine_rds_flavors_v1.go
+++ b/flexibleengine/data_source_flexibleengine_rds_flavors_v1.go
@@ -56,11 +56,8 @@ func dataSourceRdsFlavorV1() *schema.Resource {
 
 func dataSourcedataSourceRdsFlavorV1Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	log.Printf("[DEBUG] dataSourcedataSourceRdsFlavorV1Read config.OsClient %+v ", config.HwClient)
-	log.Printf("[DEBUG] dataSourcedataSourceRdsFlavorV1Read config %+v ", config)
-	log.Printf("[DEBUG] dataSourcedataSourceRdsFlavorV1Read d %+v ", d)
-
-	rdsClient, err := config.rdsV1Client(GetRegion(d, config))
+	region := GetRegion(d, config)
+	rdsClient, err := config.RdsV1Client(region)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine rds client: %s", err)
 	}
@@ -84,7 +81,7 @@ func dataSourcedataSourceRdsFlavorV1Read(d *schema.ResourceData, meta interface{
 	}
 	log.Printf("[DEBUG] Received datastore Id: %s", datastoreId)
 
-	flavorsList, err := flavors.List(rdsClient, datastoreId, d.Get("region").(string)).Extract()
+	flavorsList, err := flavors.List(rdsClient, datastoreId, region).Extract()
 	if err != nil {
 		return fmt.Errorf("Unable to retrieve flavors: %s", err)
 	}
@@ -112,7 +109,7 @@ func dataSourcedataSourceRdsFlavorV1Read(d *schema.ResourceData, meta interface{
 	d.Set("name", rdsFlavor.Name)
 	d.Set("ram", rdsFlavor.Ram)
 	d.Set("speccode", rdsFlavor.SpecCode)
-	d.Set("region", GetRegion(d, config))
+	d.Set("region", region)
 
 	return nil
 }

--- a/flexibleengine/data_source_flexibleengine_rds_flavors_v1_test.go
+++ b/flexibleengine/data_source_flexibleengine_rds_flavors_v1_test.go
@@ -37,7 +37,7 @@ func TestAccRdsFlavorV1DataSource_speccode(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingNetworkV2DataSourceID("data.flexibleengine_rds_flavors_v1.flavor"),
 					resource.TestCheckResourceAttr(
-						"data.flexibleengine_rds_flavors_v1.flavor", "speccode", "rds.mysql.s1.medium"),
+						"data.flexibleengine_rds_flavors_v1.flavor", "speccode", "rds.mysql.s3.medium.4"),
 				),
 			},
 		},
@@ -60,20 +60,16 @@ func testAccCheckRdsFlavorV1DataSourceID(n string) resource.TestCheckFunc {
 }
 
 var testAccRdsFlavorV1DataSource_basic = `
-
 data "flexibleengine_rds_flavors_v1" "flavor" {
-    region = "eu-west-0"
-	datastore_name = "MySQL"
-    datastore_version = "5.6.30"
+  datastore_name    = "MySQL"
+  datastore_version = "5.6.30"
 }
 `
 
 var testAccRdsFlavorV1DataSource_speccode = `
-
 data "flexibleengine_rds_flavors_v1" "flavor" {
-    region = "eu-west-0"
-	datastore_name = "MySQL"
-    datastore_version = "5.6.30"
-    speccode = "rds.mysql.s1.medium"
+  datastore_name    = "MySQL"
+  datastore_version = "5.6.30"
+  speccode          = "rds.mysql.s3.medium.4"
 }
 `

--- a/flexibleengine/data_source_flexibleengine_rds_flavors_v3.go
+++ b/flexibleengine/data_source_flexibleengine_rds_flavors_v3.go
@@ -3,7 +3,6 @@ package flexibleengine
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/chnsz/golangsdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -64,12 +63,10 @@ func dataSourceRdsFlavorV3() *schema.Resource {
 
 func dataSourceRdsFlavorV3Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-
-	client, err := config.rdsV1Client(GetRegion(d, config))
+	client, err := config.RdsV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine rds client: %s", err)
 	}
-	client.Endpoint = strings.Replace(client.Endpoint, "/rds/v1/", "/v3/", 1)
 
 	link := fmt.Sprintf("flavors/%s?version_name=%s", d.Get("db_type").(string), d.Get("db_version").(string))
 	url := client.ServiceURL(link)

--- a/flexibleengine/data_source_flexibleengine_rds_flavors_v3_test.go
+++ b/flexibleengine/data_source_flexibleengine_rds_flavors_v3_test.go
@@ -39,10 +39,9 @@ func testAccCheckRdsFlavorV3DataSourceID(n string) resource.TestCheckFunc {
 }
 
 var testAccRdsFlavorV3DataSource_basic = `
-
 data "flexibleengine_rds_flavors_v3" "flavor" {
-  db_type = "PostgreSQL"
-  db_version = "9.5"
+  db_type       = "PostgreSQL"
+  db_version    = "9.5"
   instance_mode = "ha"
 }
 `

--- a/flexibleengine/resource_flexibleengine_dcs_instance_v1.go
+++ b/flexibleengine/resource_flexibleengine_dcs_instance_v1.go
@@ -129,11 +129,11 @@ func resourceDcsInstanceV1() *schema.Resource {
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeInt},
 			},
-			"order_id": {
+			"vpc_name": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"vpc_name": {
+			"subnet_name": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -141,7 +141,7 @@ func resourceDcsInstanceV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"subnet_name": {
+			"ip": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -153,23 +153,19 @@ func resourceDcsInstanceV1() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"used_memory": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
 			"internal_version": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"max_memory": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"user_id": {
-				Type:     schema.TypeString,
+			"used_memory": {
+				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"ip": {
+			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -236,7 +232,7 @@ func getDcsProductId(client *golangsdk.ServiceClient, instanceType string) (stri
 
 func resourceDcsInstancesV1Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dcsV1Client, err := config.dcsV1Client(GetRegion(d, config))
+	dcsV1Client, err := config.DcsV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine dcs instance client: %s", err)
 	}
@@ -317,7 +313,7 @@ func resourceDcsInstancesV1Create(d *schema.ResourceData, meta interface{}) erro
 func resourceDcsInstancesV1Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	dcsV1Client, err := config.dcsV1Client(GetRegion(d, config))
+	dcsV1Client, err := config.DcsV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine dcs instance client: %s", err)
 	}
@@ -334,6 +330,7 @@ func resourceDcsInstancesV1Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("engine_version", v.EngineVersion)
 	d.Set("used_memory", v.UsedMemory)
 	d.Set("max_memory", v.MaxMemory)
+	d.Set("ip", v.IP)
 	d.Set("port", v.Port)
 	d.Set("status", v.Status)
 	d.Set("description", v.Description)
@@ -342,18 +339,13 @@ func resourceDcsInstancesV1Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("vpc_id", v.VPCID)
 	d.Set("network_id", v.SubnetID)
 	d.Set("vpc_name", v.VPCName)
-	d.Set("created_at", v.CreatedAt)
 	d.Set("product_id", v.ProductID)
 	d.Set("security_group_id", v.SecurityGroupID)
 	d.Set("security_group_name", v.SecurityGroupName)
 	d.Set("subnet_name", v.SubnetName)
-	d.Set("user_id", v.UserID)
-	d.Set("user_name", v.UserName)
-	d.Set("order_id", v.OrderID)
 	d.Set("maintain_begin", v.MaintainBegin)
 	d.Set("maintain_end", v.MaintainEnd)
 	d.Set("access_user", v.AccessUser)
-	d.Set("ip", v.IP)
 
 	// set capacity by Capacity and CapacityMinor
 	var capacity float64 = float64(v.Capacity)
@@ -369,7 +361,7 @@ func resourceDcsInstancesV1Read(d *schema.ResourceData, meta interface{}) error 
 
 func resourceDcsInstancesV1Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dcsV1Client, err := config.dcsV1Client(GetRegion(d, config))
+	dcsV1Client, err := config.DcsV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error updating FlexibleEngine dcs instance client: %s", err)
 	}
@@ -409,7 +401,7 @@ func resourceDcsInstancesV1Update(d *schema.ResourceData, meta interface{}) erro
 
 func resourceDcsInstancesV1Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dcsV1Client, err := config.dcsV1Client(GetRegion(d, config))
+	dcsV1Client, err := config.DcsV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine dcs instance client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_dcs_instance_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_dcs_instance_v1_test.go
@@ -13,7 +13,8 @@ import (
 
 func TestAccDcsInstancesV1_basic(t *testing.T) {
 	var instance instances.Instance
-	var instanceName = fmt.Sprintf("dcs_instance_%s", acctest.RandString(5))
+	var randName = fmt.Sprintf("acc_test_%s", acctest.RandString(5))
+	resourceName := "flexibleengine_dcs_instance_v1.instance_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,13 +22,11 @@ func TestAccDcsInstancesV1_basic(t *testing.T) {
 		CheckDestroy: testAccCheckDcsV1InstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDcsV1Instance_basic(instanceName),
+				Config: testAccDcsV1Instance_basic(randName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDcsV1InstanceExists("flexibleengine_dcs_instance_v1.instance_1", instance),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_dcs_instance_v1.instance_1", "name", instanceName),
-					resource.TestCheckResourceAttr(
-						"flexibleengine_dcs_instance_v1.instance_1", "engine", "Redis"),
+					testAccCheckDcsV1InstanceExists(resourceName, instance),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "engine", "Redis"),
 				),
 			},
 		},
@@ -36,7 +35,7 @@ func TestAccDcsInstancesV1_basic(t *testing.T) {
 
 func testAccCheckDcsV1InstanceDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	dcsClient, err := config.dcsV1Client(OS_REGION_NAME)
+	dcsClient, err := config.DcsV1Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating Flexibleengine instance client: %s", err)
 	}
@@ -48,7 +47,7 @@ func testAccCheckDcsV1InstanceDestroy(s *terraform.State) error {
 
 		_, err := instances.Get(dcsClient, rs.Primary.ID).Extract()
 		if err == nil {
-			return fmt.Errorf("The Dcs instance still exists.")
+			return fmt.Errorf("The Dcs instance still exists")
 		}
 	}
 	return nil
@@ -66,7 +65,7 @@ func testAccCheckDcsV1InstanceExists(n string, instance instances.Instance) reso
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		dcsClient, err := config.dcsV1Client(OS_REGION_NAME)
+		dcsClient, err := config.DcsV1Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating Flexibleengine instance client: %s", err)
 		}
@@ -84,20 +83,20 @@ func testAccCheckDcsV1InstanceExists(n string, instance instances.Instance) reso
 	}
 }
 
-func testAccDcsV1Instance_basic(instanceName string) string {
+func testAccDcsV1Instance_basic(rName string) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_networking_secgroup_v2" "secgroup_1" {
-  name        = "secgroup_1"
+  name        = "%s"
   description = "secgroup_1"
 }
 
 resource "flexibleengine_vpc_v1" "vpc_1" {
-  name = "terraform_vpc1"
+  name = "%s"
   cidr = "192.168.0.0/16"
 }
 
 resource "flexibleengine_vpc_subnet_v1" "subnet_1" {
-  name       = "terraform_subnet"
+  name       = "%s"
   cidr       = "192.168.0.0/24"
   gateway_ip = "192.168.0.1"
   vpc_id     = flexibleengine_vpc_v1.vpc_1.id
@@ -121,5 +120,5 @@ resource "flexibleengine_dcs_instance_v1" "instance_1" {
   period_type = "weekly"
   backup_at   = [1]
 }
-	`, instanceName)
+`, rName, rName, rName, rName)
 }

--- a/flexibleengine/resource_flexibleengine_dds_instance_v3.go
+++ b/flexibleengine/resource_flexibleengine_dds_instance_v3.go
@@ -305,7 +305,7 @@ func DdsInstanceStateRefreshFunc(client *golangsdk.ServiceClient, instanceID str
 
 func resourceDdsInstanceV3Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.ddsV3Client(GetRegion(d, config))
+	client, err := config.DdsV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DDS client: %s ", err)
 	}
@@ -368,7 +368,7 @@ func resourceDdsInstanceV3Create(d *schema.ResourceData, meta interface{}) error
 
 func resourceDdsInstanceV3Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.ddsV3Client(GetRegion(d, config))
+	client, err := config.DdsV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DDS client: %s", err)
 	}
@@ -461,7 +461,7 @@ func resourceDdsInstanceV3Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceDdsInstanceV3Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.ddsV3Client(GetRegion(d, config))
+	client, err := config.DdsV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DDS client: %s ", err)
 	}
@@ -478,7 +478,7 @@ func resourceDdsInstanceV3Update(d *schema.ResourceData, meta interface{}) error
 
 func resourceDdsInstanceV3Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.ddsV3Client(GetRegion(d, config))
+	client, err := config.DdsV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DDS client: %s ", err)
 	}

--- a/flexibleengine/resource_flexibleengine_dds_instance_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_dds_instance_v3_test.go
@@ -37,7 +37,7 @@ func TestAccDDSV3Instance_basic(t *testing.T) {
 
 func testAccCheckDDSV3InstanceDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	client, err := config.ddsV3Client(OS_REGION_NAME)
+	client, err := config.DdsV3Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DDS client: %s", err)
 	}
@@ -79,7 +79,7 @@ func testAccCheckDDSV3InstanceExists(n string, instance *instances.Instance) res
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		client, err := config.ddsV3Client(OS_REGION_NAME)
+		client, err := config.DdsV3Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine DDS client: %s ", err)
 		}

--- a/flexibleengine/resource_flexibleengine_rds_configuration_v3.go
+++ b/flexibleengine/resource_flexibleengine_rds_configuration_v3.go
@@ -3,7 +3,6 @@ package flexibleengine
 import (
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/chnsz/golangsdk"
@@ -123,12 +122,10 @@ func getDatastore(d *schema.ResourceData) configurations.DataStore {
 
 func resourceRdsConfigurationV3Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-
-	rdsClient, err := config.rdsV1Client(GetRegion(d, config))
+	rdsClient, err := config.RdsV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine RDS Client: %s", err)
 	}
-	rdsClient.Endpoint = strings.Replace(rdsClient.Endpoint, "/rds/v1/", "/v3/", 1)
 
 	createOpts := configurations.CreateOpts{
 		Name:        d.Get("name").(string),
@@ -150,15 +147,13 @@ func resourceRdsConfigurationV3Create(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceRdsConfigurationV3Read(d *schema.ResourceData, meta interface{}) error {
-
 	config := meta.(*Config)
-	rdsClient, err := config.rdsV1Client(GetRegion(d, config))
+	rdsClient, err := config.RdsV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine RDS client: %s", err)
 	}
-	rdsClient.Endpoint = strings.Replace(rdsClient.Endpoint, "/rds/v1/", "/v3/", 1)
-	n, err := configurations.Get(rdsClient, d.Id()).Extract()
 
+	n, err := configurations.Get(rdsClient, d.Id()).Extract()
 	if err != nil {
 		if _, ok := err.(golangsdk.ErrDefault404); ok {
 			d.SetId("")
@@ -197,13 +192,12 @@ func resourceRdsConfigurationV3Read(d *schema.ResourceData, meta interface{}) er
 
 func resourceRdsConfigurationV3Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	rdsClient, err := config.rdsV1Client(GetRegion(d, config))
+	rdsClient, err := config.RdsV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine RDS Client: %s", err)
 	}
-	rdsClient.Endpoint = strings.Replace(rdsClient.Endpoint, "/rds/v1/", "/v3/", 1)
-	var updateOpts configurations.UpdateOpts
 
+	var updateOpts configurations.UpdateOpts
 	if d.HasChange("name") {
 		updateOpts.Name = d.Get("name").(string)
 	}
@@ -224,11 +218,10 @@ func resourceRdsConfigurationV3Update(d *schema.ResourceData, meta interface{}) 
 
 func resourceRdsConfigurationV3Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	rdsClient, err := config.rdsV1Client(GetRegion(d, config))
+	rdsClient, err := config.RdsV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine RDS client: %s", err)
 	}
-	rdsClient.Endpoint = strings.Replace(rdsClient.Endpoint, "/rds/v1/", "/v3/", 1)
 
 	err = configurations.Delete(rdsClient, d.Id()).ExtractErr()
 	if err != nil {

--- a/flexibleengine/resource_flexibleengine_rds_configuration_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_rds_configuration_v3_test.go
@@ -2,7 +2,6 @@ package flexibleengine
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -14,7 +13,7 @@ import (
 func TestAccRdsConfigurationV3_basic(t *testing.T) {
 	var config configurations.Configuration
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRdsConfigV3Destroy,
@@ -45,11 +44,10 @@ func TestAccRdsConfigurationV3_basic(t *testing.T) {
 
 func testAccCheckRdsConfigV3Destroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	rdsClient, err := config.rdsV1Client(OS_REGION_NAME)
+	rdsClient, err := config.RdsV3Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine RDS client: %s", err)
 	}
-	rdsClient.Endpoint = strings.Replace(rdsClient.Endpoint, "/rds/v1/", "/v3/", 1)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "flexibleengine_rds_parametergroup_v3" {
@@ -77,11 +75,10 @@ func testAccCheckRdsConfigV3Exists(n string, configuration *configurations.Confi
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		rdsClient, err := config.rdsV1Client(OS_REGION_NAME)
+		rdsClient, err := config.RdsV3Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine RDS client: %s", err)
 		}
-		rdsClient.Endpoint = strings.Replace(rdsClient.Endpoint, "/rds/v1/", "/v3/", 1)
 
 		found, err := configurations.Get(rdsClient, rs.Primary.ID).Extract()
 		if err != nil {

--- a/flexibleengine/resource_flexibleengine_rds_instance_v1.go
+++ b/flexibleengine/resource_flexibleengine_rds_instance_v1.go
@@ -312,7 +312,7 @@ func InstanceStateRefreshFunc(client *golangsdk.ServiceClient, instanceID string
 
 func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.rdsV1Client(GetRegion(d, config))
+	client, err := config.RdsV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine rds client: %s ", err)
 	}
@@ -365,7 +365,7 @@ func resourceInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.rdsV1Client(GetRegion(d, config))
+	client, err := config.RdsV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine rds client: %s", err)
 	}
@@ -446,7 +446,7 @@ func resourceInstanceRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceInstanceDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.rdsV1Client(GetRegion(d, config))
+	client, err := config.RdsV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine rds client: %s ", err)
 	}
@@ -512,7 +512,7 @@ func InstanceStateFlavorUpdateRefreshFunc(client *golangsdk.ServiceClient, insta
 
 func resourceInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.rdsV1Client(GetRegion(d, config))
+	client, err := config.RdsV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error Updating FlexibleEngine rds client: %s ", err)
 	}

--- a/flexibleengine/resource_flexibleengine_rds_instance_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_rds_instance_v1_test.go
@@ -52,7 +52,7 @@ func TestAccRDSV1Instance_PostgreSQL(t *testing.T) {
 
 func testAccCheckRDSV1InstanceDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	rdsClient, err := config.rdsV1Client(OS_REGION_NAME)
+	rdsClient, err := config.RdsV1Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine rds: %s", err)
 	}
@@ -83,7 +83,7 @@ func testAccCheckRDSV1InstanceExists(n string, instance *instances.Instance) res
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		rdsClient, err := config.rdsV1Client(OS_REGION_NAME)
+		rdsClient, err := config.RdsV1Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine rds client: %s ", err)
 		}

--- a/flexibleengine/resource_flexibleengine_rds_instance_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_rds_instance_v3_test.go
@@ -16,7 +16,7 @@ func TestAccRdsInstanceV3_basic(t *testing.T) {
 	resourceType := "flexibleengine_rds_instance_v3"
 	resourceName := "flexibleengine_rds_instance_v3.instance"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRdsInstanceV3Destroy(resourceType),

--- a/flexibleengine/resource_flexibleengine_rds_read_replica_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_rds_read_replica_v3_test.go
@@ -14,7 +14,7 @@ func TestAccRdsReplicaInstanceV3_basic(t *testing.T) {
 	resourceName := "flexibleengine_rds_read_replica_v3.replica_instance"
 	resourceType := "flexibleengine_rds_read_replica_v3"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRdsInstanceV3Destroy(resourceType),


### PR DESCRIPTION
the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDDSV3Instance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDDSV3Instance_basic -timeout 720m
=== RUN   TestAccDDSV3Instance_basic
--- PASS: TestAccDDSV3Instance_basic (885.68s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 885.740s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDDSFlavor'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDDSFlavor -timeout 720m
=== RUN   TestAccDDSFlavorV3DataSource_basic
--- PASS: TestAccDDSFlavorV3DataSource_basic (63.11s)
=== RUN   TestAccDDSFlavorsV3DataSource_basic
--- PASS: TestAccDDSFlavorsV3DataSource_basic (57.04s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 120.212s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccRdsFlavor'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccRdsFlavor -timeout 720m
=== RUN   TestAccRdsFlavorV1DataSource_basic
--- PASS: TestAccRdsFlavorV1DataSource_basic (52.48s)
=== RUN   TestAccRdsFlavorV1DataSource_speccode
--- PASS: TestAccRdsFlavorV1DataSource_speccode (37.07s)
=== RUN   TestAccRdsFlavorV3DataSource_basic
--- PASS: TestAccRdsFlavorV3DataSource_basic (52.72s)
PASS
ok    github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 142.322s

$ make testacc TEST='./flexibleengine' TESTARGS='-run  TestAccDcs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run  TestAccDcs -timeout 720m
=== RUN   TestAccDcsAZV1DataSource_basic
--- PASS: TestAccDcsAZV1DataSource_basic (54.40s)
=== RUN   TestAccDcsMaintainWindowV1DataSource_basic
--- PASS: TestAccDcsMaintainWindowV1DataSource_basic (50.19s)
=== RUN   TestAccDcsProductV1DataSource_basic
--- PASS: TestAccDcsProductV1DataSource_basic (57.17s)
=== RUN   TestAccDcsInstancesV1_basic
--- PASS: TestAccDcsInstancesV1_basic (528.61s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 690.417s
```