### PR TITLE
chore: update enhanced lb service endpoint

### DIFF
--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"math"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/chnsz/golangsdk"
@@ -352,16 +351,6 @@ func (c *Config) otcV1Client(region string) (*golangsdk.ServiceClient, error) {
 		Region:       c.determineRegion(region),
 		Availability: c.getHwEndpointType(),
 	}, "elb")
-}
-
-func (c *Config) elbV2Client(region string) (*golangsdk.ServiceClient, error) {
-	sc, err := c.sdkClient(region, "network")
-	if err == nil {
-		sc.Endpoint = strings.Replace(sc.Endpoint, "vpc", "elb", 1)
-		sc.ResourceBase = sc.Endpoint + fmt.Sprintf("v2.0/%s/", c.HwClient.ProjectID)
-	}
-
-	return sc, err
 }
 
 func (c *Config) SmnV2Client(region string) (*golangsdk.ServiceClient, error) {

--- a/flexibleengine/config_test.go
+++ b/flexibleengine/config_test.go
@@ -305,13 +305,13 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 
 	// test endpoint of elb v2.0
 	serviceClient, err = nil, nil
-	serviceClient, err = config.elbV2Client(OS_REGION_NAME)
+	serviceClient, err = config.ElbV2Client(OS_REGION_NAME)
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://elb.%s.%s/v2.0/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://elb.%s.%s/v2.0/", OS_REGION_NAME, defaultCloud)
 	actualURL = serviceClient.ResourceBaseURL()
-	testCheckServiceURL(t, expectedURL, actualURL, "elb v2.0")
+	testCheckServiceURL(t, expectedURL, actualURL, "ELB v2.0")
 
 	// test the endpoint of DNS service
 	serviceClient, err = config.dnsV2Client(OS_REGION_NAME)

--- a/flexibleengine/data_source_flexibleengine_lb_certificates_v2.go
+++ b/flexibleengine/data_source_flexibleengine_lb_certificates_v2.go
@@ -59,9 +59,9 @@ func dataSourceCertificateV2() *schema.Resource {
 
 func dataSourceCertificateV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	listOpts := certificates.ListOpts{
@@ -71,7 +71,7 @@ func dataSourceCertificateV2Read(d *schema.ResourceData, meta interface{}) error
 		Type:        d.Get("type").(string),
 		Domain:      d.Get("domain").(string),
 	}
-	allPages, err := certificates.List(networkingClient, listOpts).AllPages()
+	allPages, err := certificates.List(lbClient, listOpts).AllPages()
 	if err != nil {
 		return fmt.Errorf("Error retrieving flexibleengine_lb_certificate_v2: %s", err)
 	}

--- a/flexibleengine/data_source_flexibleengine_lb_certificates_v2_test.go
+++ b/flexibleengine/data_source_flexibleengine_lb_certificates_v2_test.go
@@ -46,9 +46,9 @@ func testAccCheckCertificateV2DataSourceID(n string) resource.TestCheckFunc {
 
 const testAccDataSourceCertificateV2Config = `
 resource "flexibleengine_lb_certificate_v2" "certificate_1" {
-  name = "certificate_test"
+  name        = "certificate_test"
   description = "terraform test certificate"
-  domain = "www.elb.com"
+  domain      = "www.elb.com"
   private_key = <<EOT
 -----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN2s8tZ/6LC3X82fajpVsYqF1x
@@ -106,14 +106,14 @@ EOT
 }
 
 data "flexibleengine_lb_certificate_v2" "by_id" {
-  id = "${flexibleengine_lb_certificate_v2.certificate_1.id}"
+  id = flexibleengine_lb_certificate_v2.certificate_1.id
 }
 
 data "flexibleengine_lb_certificate_v2" "by_domain" {
-  domain = "${flexibleengine_lb_certificate_v2.certificate_1.domain}"
+  domain = flexibleengine_lb_certificate_v2.certificate_1.domain
 }
 
 data "flexibleengine_lb_certificate_v2" "by_name" {
-  name = "${flexibleengine_lb_certificate_v2.certificate_1.name}"
+  name = flexibleengine_lb_certificate_v2.certificate_1.name
 }
 `

--- a/flexibleengine/lb_v2_shared.go
+++ b/flexibleengine/lb_v2_shared.go
@@ -24,13 +24,13 @@ var lbPendingDeleteStatuses = []string{"ERROR", "PENDING_UPDATE", "PENDING_DELET
 
 var lbSkipLBStatuses = []string{"ERROR", "ACTIVE"}
 
-func waitForLBV2Listener(networkingClient *golangsdk.ServiceClient, id string, target string, pending []string, timeout time.Duration) error {
+func waitForLBV2Listener(lbClient *golangsdk.ServiceClient, id string, target string, pending []string, timeout time.Duration) error {
 	log.Printf("[DEBUG] Waiting for listener %s to become %s.", id, target)
 
 	stateConf := &resource.StateChangeConf{
 		Target:     []string{target},
 		Pending:    pending,
-		Refresh:    resourceLBV2ListenerRefreshFunc(networkingClient, id),
+		Refresh:    resourceLBV2ListenerRefreshFunc(lbClient, id),
 		Timeout:    timeout,
 		Delay:      5 * time.Second,
 		MinTimeout: 1 * time.Second,
@@ -52,9 +52,9 @@ func waitForLBV2Listener(networkingClient *golangsdk.ServiceClient, id string, t
 	return nil
 }
 
-func resourceLBV2ListenerRefreshFunc(networkingClient *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
+func resourceLBV2ListenerRefreshFunc(lbClient *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		listener, err := listeners.Get(networkingClient, id).Extract()
+		listener, err := listeners.Get(lbClient, id).Extract()
 		if err != nil {
 			return nil, "", err
 		}
@@ -64,13 +64,13 @@ func resourceLBV2ListenerRefreshFunc(networkingClient *golangsdk.ServiceClient, 
 	}
 }
 
-func waitForLBV2LoadBalancer(networkingClient *golangsdk.ServiceClient, id string, target string, pending []string, timeout time.Duration) error {
+func waitForLBV2LoadBalancer(lbClient *golangsdk.ServiceClient, id string, target string, pending []string, timeout time.Duration) error {
 	log.Printf("[DEBUG] Waiting for loadbalancer %s to become %s.", id, target)
 
 	stateConf := &resource.StateChangeConf{
 		Target:     []string{target},
 		Pending:    pending,
-		Refresh:    resourceLBV2LoadBalancerRefreshFunc(networkingClient, id),
+		Refresh:    resourceLBV2LoadBalancerRefreshFunc(lbClient, id),
 		Timeout:    timeout,
 		Delay:      5 * time.Second,
 		MinTimeout: 1 * time.Second,
@@ -92,9 +92,9 @@ func waitForLBV2LoadBalancer(networkingClient *golangsdk.ServiceClient, id strin
 	return nil
 }
 
-func resourceLBV2LoadBalancerRefreshFunc(networkingClient *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
+func resourceLBV2LoadBalancerRefreshFunc(lbClient *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		lb, err := loadbalancers.Get(networkingClient, id).Extract()
+		lb, err := loadbalancers.Get(lbClient, id).Extract()
 		if err != nil {
 			return nil, "", err
 		}
@@ -103,13 +103,13 @@ func resourceLBV2LoadBalancerRefreshFunc(networkingClient *golangsdk.ServiceClie
 	}
 }
 
-func waitForLBV2Member(networkingClient *golangsdk.ServiceClient, poolID, memberID string, target string, pending []string, timeout time.Duration) error {
+func waitForLBV2Member(lbClient *golangsdk.ServiceClient, poolID, memberID string, target string, pending []string, timeout time.Duration) error {
 	log.Printf("[DEBUG] Waiting for member %s to become %s.", memberID, target)
 
 	stateConf := &resource.StateChangeConf{
 		Target:     []string{target},
 		Pending:    pending,
-		Refresh:    resourceLBV2MemberRefreshFunc(networkingClient, poolID, memberID),
+		Refresh:    resourceLBV2MemberRefreshFunc(lbClient, poolID, memberID),
 		Timeout:    timeout,
 		Delay:      5 * time.Second,
 		MinTimeout: 1 * time.Second,
@@ -131,9 +131,9 @@ func waitForLBV2Member(networkingClient *golangsdk.ServiceClient, poolID, member
 	return nil
 }
 
-func resourceLBV2MemberRefreshFunc(networkingClient *golangsdk.ServiceClient, poolID, memberID string) resource.StateRefreshFunc {
+func resourceLBV2MemberRefreshFunc(lbClient *golangsdk.ServiceClient, poolID, memberID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		member, err := pools.GetMember(networkingClient, poolID, memberID).Extract()
+		member, err := pools.GetMember(lbClient, poolID, memberID).Extract()
 		if err != nil {
 			return nil, "", err
 		}
@@ -143,13 +143,13 @@ func resourceLBV2MemberRefreshFunc(networkingClient *golangsdk.ServiceClient, po
 	}
 }
 
-func waitForLBV2Monitor(networkingClient *golangsdk.ServiceClient, id string, target string, pending []string, timeout time.Duration) error {
+func waitForLBV2Monitor(lbClient *golangsdk.ServiceClient, id string, target string, pending []string, timeout time.Duration) error {
 	log.Printf("[DEBUG] Waiting for monitor %s to become %s.", id, target)
 
 	stateConf := &resource.StateChangeConf{
 		Target:     []string{target},
 		Pending:    pending,
-		Refresh:    resourceLBV2MonitorRefreshFunc(networkingClient, id),
+		Refresh:    resourceLBV2MonitorRefreshFunc(lbClient, id),
 		Timeout:    timeout,
 		Delay:      5 * time.Second,
 		MinTimeout: 1 * time.Second,
@@ -171,9 +171,9 @@ func waitForLBV2Monitor(networkingClient *golangsdk.ServiceClient, id string, ta
 	return nil
 }
 
-func resourceLBV2MonitorRefreshFunc(networkingClient *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
+func resourceLBV2MonitorRefreshFunc(lbClient *golangsdk.ServiceClient, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		monitor, err := monitors.Get(networkingClient, id).Extract()
+		monitor, err := monitors.Get(lbClient, id).Extract()
 		if err != nil {
 			return nil, "", err
 		}
@@ -183,13 +183,13 @@ func resourceLBV2MonitorRefreshFunc(networkingClient *golangsdk.ServiceClient, i
 	}
 }
 
-func waitForLBV2Pool(networkingClient *golangsdk.ServiceClient, id string, target string, pending []string, timeout time.Duration) error {
+func waitForLBV2Pool(lbClient *golangsdk.ServiceClient, id string, target string, pending []string, timeout time.Duration) error {
 	log.Printf("[DEBUG] Waiting for pool %s to become %s.", id, target)
 
 	stateConf := &resource.StateChangeConf{
 		Target:     []string{target},
 		Pending:    pending,
-		Refresh:    resourceLBV2PoolRefreshFunc(networkingClient, id),
+		Refresh:    resourceLBV2PoolRefreshFunc(lbClient, id),
 		Timeout:    timeout,
 		Delay:      5 * time.Second,
 		MinTimeout: 1 * time.Second,
@@ -211,9 +211,9 @@ func waitForLBV2Pool(networkingClient *golangsdk.ServiceClient, id string, targe
 	return nil
 }
 
-func resourceLBV2PoolRefreshFunc(networkingClient *golangsdk.ServiceClient, poolID string) resource.StateRefreshFunc {
+func resourceLBV2PoolRefreshFunc(lbClient *golangsdk.ServiceClient, poolID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		pool, err := pools.Get(networkingClient, poolID).Extract()
+		pool, err := pools.Get(lbClient, poolID).Extract()
 		if err != nil {
 			return nil, "", err
 		}
@@ -223,8 +223,8 @@ func resourceLBV2PoolRefreshFunc(networkingClient *golangsdk.ServiceClient, pool
 	}
 }
 
-func waitForLBV2viaPool(networkingClient *golangsdk.ServiceClient, id string, target string, timeout time.Duration) error {
-	pool, err := pools.Get(networkingClient, id).Extract()
+func waitForLBV2viaPool(lbClient *golangsdk.ServiceClient, id string, target string, timeout time.Duration) error {
+	pool, err := pools.Get(lbClient, id).Extract()
 	if err != nil {
 		return err
 	}
@@ -232,19 +232,19 @@ func waitForLBV2viaPool(networkingClient *golangsdk.ServiceClient, id string, ta
 	if pool.Loadbalancers != nil {
 		// each pool has an LB in Octavia lbaasv2 API
 		lbID := pool.Loadbalancers[0].ID
-		return waitForLBV2LoadBalancer(networkingClient, lbID, target, nil, timeout)
+		return waitForLBV2LoadBalancer(lbClient, lbID, target, nil, timeout)
 	}
 
 	if pool.Listeners != nil {
 		// each pool has a listener in Neutron lbaasv2 API
 		listenerID := pool.Listeners[0].ID
-		listener, err := listeners.Get(networkingClient, listenerID).Extract()
+		listener, err := listeners.Get(lbClient, listenerID).Extract()
 		if err != nil {
 			return err
 		}
 		if listener.Loadbalancers != nil {
 			lbID := listener.Loadbalancers[0].ID
-			return waitForLBV2LoadBalancer(networkingClient, lbID, target, nil, timeout)
+			return waitForLBV2LoadBalancer(lbClient, lbID, target, nil, timeout)
 		}
 	}
 
@@ -252,7 +252,7 @@ func waitForLBV2viaPool(networkingClient *golangsdk.ServiceClient, id string, ta
 	return fmt.Errorf("No Load Balancer on pool %s", id)
 }
 
-func resourceLBV2LoadBalancerStatusRefreshFuncNeutron(lbClient *golangsdk.ServiceClient, lbID, resourceType, resourceID string) resource.StateRefreshFunc {
+func resourceLBV2LoadBalancerStatusRefreshFunc(lbClient *golangsdk.ServiceClient, lbID, resourceType, resourceID string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
 		statuses, err := loadbalancers.GetStatuses(lbClient, lbID).Extract()
 		if err != nil {
@@ -361,7 +361,7 @@ func resourceLBV2L7PolicyRefreshFunc(lbClient *golangsdk.ServiceClient, lbID str
 		}
 	}
 
-	return resourceLBV2LoadBalancerStatusRefreshFuncNeutron(lbClient, lbID, "l7policy", l7policy.ID)
+	return resourceLBV2LoadBalancerStatusRefreshFunc(lbClient, lbID, "l7policy", l7policy.ID)
 }
 
 func waitForLBV2L7Policy(lbClient *golangsdk.ServiceClient, parentListener *listeners.Listener, l7policy *l7policies.L7Policy, target string, pending []string, timeout time.Duration) error {
@@ -445,7 +445,7 @@ func resourceLBV2L7RuleRefreshFunc(lbClient *golangsdk.ServiceClient, lbID strin
 		}
 	}
 
-	return resourceLBV2LoadBalancerStatusRefreshFuncNeutron(lbClient, lbID, "l7rule", l7rule.ID)
+	return resourceLBV2LoadBalancerStatusRefreshFunc(lbClient, lbID, "l7rule", l7rule.ID)
 }
 
 func waitForLBV2L7Rule(lbClient *golangsdk.ServiceClient, parentListener *listeners.Listener, parentL7policy *l7policies.L7Policy, l7rule *l7policies.Rule, target string, pending []string, timeout time.Duration) error {

--- a/flexibleengine/resource_flexibleengine_lb_certificate_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_certificate_v2.go
@@ -74,9 +74,9 @@ func resourceCertificateV2() *schema.Resource {
 
 func resourceCertificateV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	createOpts := certificates.CreateOpts{
@@ -88,7 +88,7 @@ func resourceCertificateV2Create(d *schema.ResourceData, meta interface{}) error
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
-	c, err := certificates.Create(networkingClient, createOpts).Extract()
+	c, err := certificates.Create(lbClient, createOpts).Extract()
 	if err != nil {
 		return fmt.Errorf("Error creating Certificate: %s", err)
 	}
@@ -101,12 +101,12 @@ func resourceCertificateV2Create(d *schema.ResourceData, meta interface{}) error
 
 func resourceCertificateV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
-	c, err := certificates.Get(networkingClient, d.Id()).Extract()
+	c, err := certificates.Get(lbClient, d.Id()).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "certificate")
 	}
@@ -127,9 +127,9 @@ func resourceCertificateV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceCertificateV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	var updateOpts certificates.UpdateOpts
@@ -153,7 +153,7 @@ func resourceCertificateV2Update(d *schema.ResourceData, meta interface{}) error
 
 	timeout := d.Timeout(schema.TimeoutUpdate)
 	err = resource.Retry(timeout, func() *resource.RetryError {
-		_, err := certificates.Update(networkingClient, d.Id(), updateOpts).Extract()
+		_, err := certificates.Update(lbClient, d.Id(), updateOpts).Extract()
 		if err != nil {
 			return checkForRetryableError(err)
 		}
@@ -168,15 +168,15 @@ func resourceCertificateV2Update(d *schema.ResourceData, meta interface{}) error
 
 func resourceCertificateV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	log.Printf("[DEBUG] Deleting certificate %s", d.Id())
 	timeout := d.Timeout(schema.TimeoutDelete)
 	err = resource.Retry(timeout, func() *resource.RetryError {
-		err := certificates.Delete(networkingClient, d.Id()).ExtractErr()
+		err := certificates.Delete(lbClient, d.Id()).ExtractErr()
 		if err != nil {
 			return checkForRetryableError(err)
 		}

--- a/flexibleengine/resource_flexibleengine_lb_certificate_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_lb_certificate_v2_test.go
@@ -37,9 +37,9 @@ func TestAccLBV2Certificate_basic(t *testing.T) {
 
 func testAccCheckLBV2CertificateDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+	lbClient, err := config.ElbV2Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -47,7 +47,7 @@ func testAccCheckLBV2CertificateDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := certificates.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := certificates.Get(lbClient, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("Certificate still exists: %s", rs.Primary.ID)
 		}
@@ -69,12 +69,12 @@ func testAccCheckLBV2CertificateExists(
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+		lbClient, err := config.ElbV2Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+			return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 		}
 
-		found, err := certificates.Get(networkingClient, rs.Primary.ID).Extract()
+		found, err := certificates.Get(lbClient, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
@@ -91,9 +91,9 @@ func testAccCheckLBV2CertificateExists(
 
 const testAccLBV2CertificateConfig_basic = `
 resource "flexibleengine_lb_certificate_v2" "certificate_1" {
-  name = "certificate_1"
+  name        = "certificate_1"
   description = "terraform test certificate"
-  domain = "www.elb.com"
+  domain      = "www.elb.com"
   private_key = <<EOT
 -----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN2s8tZ/6LC3X82fajpVsYqF1x
@@ -148,20 +148,14 @@ i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
 i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+8Kg==
 -----END CERTIFICATE-----
 EOT
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
 }
 `
 
 const testAccLBV2CertificateConfig_update = `
 resource "flexibleengine_lb_certificate_v2" "certificate_1" {
-  name = "certificate_1_updated"
+  name        = "certificate_1_updated"
   description = "terraform test certificate"
-  domain = "www.elb.com"
+  domain      = "www.elb.com"
   private_key = <<EOT
 -----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN2s8tZ/6LC3X82fajpVsYqF1x
@@ -216,11 +210,5 @@ i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
 i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+9Aa==
 -----END CERTIFICATE-----
 EOT
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
 }
 `

--- a/flexibleengine/resource_flexibleengine_lb_l7policy_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_l7policy_v2.go
@@ -101,9 +101,9 @@ func resourceL7PolicyV2() *schema.Resource {
 
 func resourceL7PolicyV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.networkingV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	// Assign some required variables for use in creation.
@@ -190,9 +190,9 @@ func resourceL7PolicyV2Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceL7PolicyV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.networkingV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	l7Policy, err := l7policies.Get(lbClient, d.Id()).Extract()
@@ -217,9 +217,9 @@ func resourceL7PolicyV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceL7PolicyV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.networkingV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	// Assign some required variables for use in updating.
@@ -316,9 +316,9 @@ func resourceL7PolicyV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceL7PolicyV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.networkingV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	timeout := d.Timeout(schema.TimeoutDelete)
@@ -365,9 +365,9 @@ func resourceL7PolicyV2Delete(d *schema.ResourceData, meta interface{}) error {
 
 func resourceL7PolicyV2Import(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
-	lbClient, err := config.networkingV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
-		return nil, fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return nil, fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	l7Policy, err := l7policies.Get(lbClient, d.Id()).Extract()

--- a/flexibleengine/resource_flexibleengine_lb_l7policy_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_lb_l7policy_v2_test.go
@@ -42,9 +42,9 @@ func TestAccLBV2L7Policy_basic(t *testing.T) {
 
 func testAccCheckLBV2L7PolicyDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	lbClient, err := config.networkingV2Client(OS_REGION_NAME)
+	lbClient, err := config.ElbV2Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine load balancing client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -73,9 +73,9 @@ func testAccCheckLBV2L7PolicyExists(n string, l7Policy *l7policies.L7Policy) res
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		lbClient, err := config.networkingV2Client(OS_REGION_NAME)
+		lbClient, err := config.ElbV2Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating FlexibleEngine load balancing client: %s", err)
+			return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 		}
 
 		found, err := l7policies.Get(lbClient, rs.Primary.ID).Extract()
@@ -95,30 +95,30 @@ func testAccCheckLBV2L7PolicyExists(n string, l7Policy *l7policies.L7Policy) res
 
 var testAccCheckLBV2L7PolicyConfig_basic = fmt.Sprintf(`
 resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
-  name = "loadbalancer_1"
+  name          = "loadbalancer_1"
   vip_subnet_id = "%s"
 }
 
 resource "flexibleengine_lb_listener_v2" "listener_1" {
-  name = "listener_1"
-  protocol = "HTTP"
-  protocol_port = 8080
-  loadbalancer_id = "${flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id}"
+  name            = "listener_1"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
 }
 
 resource "flexibleengine_lb_pool_v2" "pool_1" {
   name            = "pool_1"
   protocol        = "HTTP"
   lb_method       = "ROUND_ROBIN"
-  loadbalancer_id = "${flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id}"
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
 }
 
 resource "flexibleengine_lb_l7policy_v2" "l7policy_1" {
-  name         = "test"
-  action       = "REDIRECT_TO_POOL"
-  description  = "test description"
-  position     = 1
-  listener_id  = "${flexibleengine_lb_listener_v2.listener_1.id}"
-  redirect_pool_id = "${flexibleengine_lb_pool_v2.pool_1.id}"
+  name             = "test"
+  action           = "REDIRECT_TO_POOL"
+  description      = "test description"
+  position         = 1
+  listener_id      = flexibleengine_lb_listener_v2.listener_1.id
+  redirect_pool_id = flexibleengine_lb_pool_v2.pool_1.id
 }
 `, OS_SUBNET_ID)

--- a/flexibleengine/resource_flexibleengine_lb_l7rule_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_l7rule_v2.go
@@ -102,9 +102,9 @@ func resourceL7RuleV2() *schema.Resource {
 
 func resourceL7RuleV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.networkingV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	// Assign some required variables for use in creation.
@@ -190,9 +190,9 @@ func resourceL7RuleV2Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceL7RuleV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.networkingV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	l7policyID := d.Get("l7policy_id").(string)
@@ -217,9 +217,9 @@ func resourceL7RuleV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceL7RuleV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.networkingV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	// Assign some required variables for use in updating.
@@ -306,9 +306,9 @@ func resourceL7RuleV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceL7RuleV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	lbClient, err := config.networkingV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	timeout := d.Timeout(schema.TimeoutDelete)
@@ -369,9 +369,9 @@ func resourceL7RuleV2Import(d *schema.ResourceData, meta interface{}) ([]*schema
 	}
 
 	config := meta.(*Config)
-	lbClient, err := config.networkingV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
-		return nil, fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return nil, fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	listenerID := ""

--- a/flexibleengine/resource_flexibleengine_lb_l7rule_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_lb_l7rule_v2_test.go
@@ -38,7 +38,7 @@ func TestAccLBV2L7Rule_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckLBV2L7RuleConfig_update2,
+				Config: testAccCheckLBV2L7RuleConfig_update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLBV2L7RuleExists("flexibleengine_lb_l7rule_v2.l7rule_1", &l7rule),
 					resource.TestCheckResourceAttr(
@@ -57,9 +57,9 @@ func TestAccLBV2L7Rule_basic(t *testing.T) {
 
 func testAccCheckLBV2L7RuleDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	lbClient, err := config.networkingV2Client(OS_REGION_NAME)
+	lbClient, err := config.ElbV2Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine load balancing client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -100,9 +100,9 @@ func testAccCheckLBV2L7RuleExists(n string, l7rule *l7rules.Rule) resource.TestC
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		lbClient, err := config.networkingV2Client(OS_REGION_NAME)
+		lbClient, err := config.ElbV2Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating FlexibleEngine load balancing client: %s", err)
+			return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 		}
 
 		l7policyID := ""
@@ -134,22 +134,22 @@ func testAccCheckLBV2L7RuleExists(n string, l7rule *l7rules.Rule) resource.TestC
 
 var testAccCheckLBV2L7RuleConfig = fmt.Sprintf(`
 resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
-  name = "loadbalancer_1"
+  name          = "loadbalancer_1"
   vip_subnet_id = "%s"
 }
 
 resource "flexibleengine_lb_listener_v2" "listener_1" {
-  name = "listener_1"
-  protocol = "HTTP"
-  protocol_port = 8080
-  loadbalancer_id = "${flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id}"
+  name            = "listener_1"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
 }
 
 resource "flexibleengine_lb_pool_v2" "pool_1" {
   name            = "pool_1"
   protocol        = "HTTP"
   lb_method       = "ROUND_ROBIN"
-  loadbalancer_id = "${flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id}"
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
 }
 
 resource "flexibleengine_lb_l7policy_v2" "l7policy_1" {
@@ -157,8 +157,8 @@ resource "flexibleengine_lb_l7policy_v2" "l7policy_1" {
   action       = "REDIRECT_TO_POOL"
   description  = "test description"
   position     = 1
-  listener_id  = "${flexibleengine_lb_listener_v2.listener_1.id}"
-  redirect_pool_id = "${flexibleengine_lb_pool_v2.pool_1.id}"
+  listener_id  = flexibleengine_lb_listener_v2.listener_1.id
+  redirect_pool_id = flexibleengine_lb_pool_v2.pool_1.id
 }
 `, OS_SUBNET_ID)
 
@@ -166,18 +166,18 @@ var testAccCheckLBV2L7RuleConfig_basic = fmt.Sprintf(`
 %s
 
 resource "flexibleengine_lb_l7rule_v2" "l7rule_1" {
-  l7policy_id  = "${flexibleengine_lb_l7policy_v2.l7policy_1.id}"
+  l7policy_id  = flexibleengine_lb_l7policy_v2.l7policy_1.id
   type         = "PATH"
   compare_type = "EQUAL_TO"
   value        = "/api"
 }
 `, testAccCheckLBV2L7RuleConfig)
 
-var testAccCheckLBV2L7RuleConfig_update2 = fmt.Sprintf(`
+var testAccCheckLBV2L7RuleConfig_update = fmt.Sprintf(`
 %s
 
 resource "flexibleengine_lb_l7rule_v2" "l7rule_1" {
-  l7policy_id  = "${flexibleengine_lb_l7policy_v2.l7policy_1.id}"
+  l7policy_id  = flexibleengine_lb_l7policy_v2.l7policy_1.id
   type         = "PATH"
   compare_type = "STARTS_WITH"
   value        = "/images"

--- a/flexibleengine/resource_flexibleengine_lb_loadbalancer_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_lb_loadbalancer_v2_test.go
@@ -109,9 +109,9 @@ func TestAccLBV2LoadBalancer_secGroup(t *testing.T) {
 
 func testAccCheckLBV2LoadBalancerDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+	lbClient, err := config.ElbV2Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -119,7 +119,7 @@ func testAccCheckLBV2LoadBalancerDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := loadbalancers.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := loadbalancers.Get(lbClient, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("LoadBalancer still exists: %s", rs.Primary.ID)
 		}
@@ -141,12 +141,12 @@ func testAccCheckLBV2LoadBalancerExists(
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+		lbClient, err := config.ElbV2Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+			return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 		}
 
-		found, err := loadbalancers.Get(networkingClient, rs.Primary.ID).Extract()
+		found, err := loadbalancers.Get(lbClient, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
@@ -165,7 +165,7 @@ func testAccCheckLBV2LoadBalancerHasSecGroup(
 	lb *loadbalancers.LoadBalancer, sg *groups.SecGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+		networkingClient, err := config.NetworkingV2Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_lb_member_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_lb_member_v2_test.go
@@ -19,7 +19,7 @@ func TestAccLBV2Member_basic(t *testing.T) {
 		CheckDestroy: testAccCheckLBV2MemberDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:             TestAccLBV2MemberConfig_basic,
+				Config:             testAccLBV2MemberConfig_basic,
 				ExpectNonEmptyPlan: true, // Because admin_state_up remains false, unfinished elb?
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLBV2MemberExists("flexibleengine_lb_member_v2.member_1", &member_1),
@@ -27,7 +27,7 @@ func TestAccLBV2Member_basic(t *testing.T) {
 				),
 			},
 			{
-				Config:             TestAccLBV2MemberConfig_update,
+				Config:             testAccLBV2MemberConfig_update,
 				ExpectNonEmptyPlan: true, // Because admin_state_up remains false, unfinished elb?
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("flexibleengine_lb_member_v2.member_1", "weight", "10"),
@@ -40,9 +40,9 @@ func TestAccLBV2Member_basic(t *testing.T) {
 
 func testAccCheckLBV2MemberDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+	lbClient, err := config.ElbV2Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -51,7 +51,7 @@ func testAccCheckLBV2MemberDestroy(s *terraform.State) error {
 		}
 
 		poolId := rs.Primary.Attributes["pool_id"]
-		_, err := pools.GetMember(networkingClient, poolId, rs.Primary.ID).Extract()
+		_, err := pools.GetMember(lbClient, poolId, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("Member still exists: %s", rs.Primary.ID)
 		}
@@ -72,13 +72,13 @@ func testAccCheckLBV2MemberExists(n string, member *pools.Member) resource.TestC
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+		lbClient, err := config.ElbV2Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+			return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 		}
 
 		poolId := rs.Primary.Attributes["pool_id"]
-		found, err := pools.GetMember(networkingClient, poolId, rs.Primary.ID).Extract()
+		found, err := pools.GetMember(lbClient, poolId, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
@@ -93,100 +93,76 @@ func testAccCheckLBV2MemberExists(n string, member *pools.Member) resource.TestC
 	}
 }
 
-const TestAccLBV2MemberConfig_basic = `
+var testAccLBV2MemberConfig_basic = fmt.Sprintf(`
 resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
-  name = "loadbalancer_1"
-  vip_subnet_id = "2c0a74a9-4395-4e62-a17b-e3e86fbf66b7"
+  name          = "loadbalancer_1"
+  vip_subnet_id = "%[1]s"
 }
 
 resource "flexibleengine_lb_listener_v2" "listener_1" {
-  name = "listener_1"
-  protocol = "HTTP"
-  protocol_port = 8080
-  loadbalancer_id = "${flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id}"
+  name            = "listener_1"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
 }
 
 resource "flexibleengine_lb_pool_v2" "pool_1" {
-  name = "pool_1"
-  protocol = "HTTP"
-  lb_method = "ROUND_ROBIN"
-  listener_id = "${flexibleengine_lb_listener_v2.listener_1.id}"
+  name        = "pool_1"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = flexibleengine_lb_listener_v2.listener_1.id
 }
 
 resource "flexibleengine_lb_member_v2" "member_1" {
-  address = "172.16.10.10"
+  address       = "172.16.10.10"
   protocol_port = 8080
-  pool_id = "${flexibleengine_lb_pool_v2.pool_1.id}"
-  subnet_id = "2c0a74a9-4395-4e62-a17b-e3e86fbf66b7"
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
+  pool_id       = flexibleengine_lb_pool_v2.pool_1.id
+  subnet_id     = "%[1]s"
 }
 
 resource "flexibleengine_lb_member_v2" "member_2" {
-  address = "172.16.10.11"
+  address       = "172.16.10.11"
   protocol_port = 8080
-  pool_id = "${flexibleengine_lb_pool_v2.pool_1.id}"
-  subnet_id = "2c0a74a9-4395-4e62-a17b-e3e86fbf66b7"
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
+  pool_id       = flexibleengine_lb_pool_v2.pool_1.id
+  subnet_id     = "%[1]s"
 }
-`
+`, OS_SUBNET_ID)
 
-const TestAccLBV2MemberConfig_update = `
+var testAccLBV2MemberConfig_update = fmt.Sprintf(`
 resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
-  name = "loadbalancer_1"
-  vip_subnet_id = "2c0a74a9-4395-4e62-a17b-e3e86fbf66b7"
+  name          = "loadbalancer_1"
+  vip_subnet_id = "%[1]s"
 }
 
 resource "flexibleengine_lb_listener_v2" "listener_1" {
-  name = "listener_1"
-  protocol = "HTTP"
-  protocol_port = 8080
-  loadbalancer_id = "${flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id}"
+  name            = "listener_1"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
 }
 
 resource "flexibleengine_lb_pool_v2" "pool_1" {
-  name = "pool_1"
-  protocol = "HTTP"
-  lb_method = "ROUND_ROBIN"
-  listener_id = "${flexibleengine_lb_listener_v2.listener_1.id}"
+  name        = "pool_1"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = flexibleengine_lb_listener_v2.listener_1.id
 }
 
 resource "flexibleengine_lb_member_v2" "member_1" {
-  address = "172.16.10.10"
-  protocol_port = 8080
-  weight = 10
+  address        = "172.16.10.10"
+  protocol_port  = 8080
+  weight         = 10
   admin_state_up = "true"
-  pool_id = "${flexibleengine_lb_pool_v2.pool_1.id}"
-  subnet_id = "2c0a74a9-4395-4e62-a17b-e3e86fbf66b7"
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
+  pool_id        = flexibleengine_lb_pool_v2.pool_1.id
+  subnet_id      = "%[1]s"
 }
 
 resource "flexibleengine_lb_member_v2" "member_2" {
-  address = "172.16.10.11"
-  protocol_port = 8080
-  weight = 15
+  address        = "172.16.10.11"
+  protocol_port  = 8080
+  weight         = 15
   admin_state_up = "true"
-  pool_id = "${flexibleengine_lb_pool_v2.pool_1.id}"
-  subnet_id = "2c0a74a9-4395-4e62-a17b-e3e86fbf66b7"
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
+  pool_id        = flexibleengine_lb_pool_v2.pool_1.id
+  subnet_id      = "%[1]s"
 }
-`
+`, OS_SUBNET_ID)

--- a/flexibleengine/resource_flexibleengine_lb_monitor_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_lb_monitor_v2_test.go
@@ -47,9 +47,9 @@ func TestAccLBV2Monitor_basic(t *testing.T) {
 
 func testAccCheckLBV2MonitorDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+	lbClient, err := config.ElbV2Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -57,7 +57,7 @@ func testAccCheckLBV2MonitorDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := monitors.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := monitors.Get(lbClient, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("Monitor still exists: %s", rs.Primary.ID)
 		}
@@ -78,12 +78,12 @@ func testAccCheckLBV2MonitorExists(t *testing.T, n string, monitor *monitors.Mon
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+		lbClient, err := config.ElbV2Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+			return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 		}
 
-		found, err := monitors.Get(networkingClient, rs.Primary.ID).Extract()
+		found, err := monitors.Get(lbClient, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}

--- a/flexibleengine/resource_flexibleengine_lb_whitelist_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_whitelist_v2.go
@@ -52,9 +52,9 @@ func resourceWhitelistV2() *schema.Resource {
 
 func resourceWhitelistV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	enableWhitelist := d.Get("enable_whitelist").(bool)
@@ -66,7 +66,7 @@ func resourceWhitelistV2Create(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
-	wl, err := whitelists.Create(networkingClient, createOpts).Extract()
+	wl, err := whitelists.Create(lbClient, createOpts).Extract()
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine Whitelist: %s", err)
 	}
@@ -77,12 +77,12 @@ func resourceWhitelistV2Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceWhitelistV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
-	wl, err := whitelists.Get(networkingClient, d.Id()).Extract()
+	wl, err := whitelists.Get(lbClient, d.Id()).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "whitelist")
 	}
@@ -100,9 +100,9 @@ func resourceWhitelistV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceWhitelistV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	var updateOpts whitelists.UpdateOpts
@@ -115,7 +115,7 @@ func resourceWhitelistV2Update(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Updating whitelist %s with options: %#v", d.Id(), updateOpts)
-	_, err = whitelists.Update(networkingClient, d.Id(), updateOpts).Extract()
+	_, err = whitelists.Update(lbClient, d.Id(), updateOpts).Extract()
 	if err != nil {
 		return fmt.Errorf("Unable to update whitelist %s: %s", d.Id(), err)
 	}
@@ -125,13 +125,13 @@ func resourceWhitelistV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceWhitelistV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.networkingV2Client(GetRegion(d, config))
+	lbClient, err := config.ElbV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	log.Printf("[DEBUG] Attempting to delete whitelist %s", d.Id())
-	err = whitelists.Delete(networkingClient, d.Id()).ExtractErr()
+	err = whitelists.Delete(lbClient, d.Id()).ExtractErr()
 	if err != nil {
 		return fmt.Errorf("Error deleting FlexibleEngine whitelist: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_lb_whitelist_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_lb_whitelist_v2_test.go
@@ -18,13 +18,13 @@ func TestAccLBV2Whitelist_basic(t *testing.T) {
 		CheckDestroy: testAccCheckLBV2WhitelistDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: TestAccLBV2WhitelistConfig_basic,
+				Config: testAccLBV2WhitelistConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLBV2WhitelistExists("flexibleengine_lb_whitelist_v2.whitelist_1", &whitelist),
 				),
 			},
 			{
-				Config: TestAccLBV2WhitelistConfig_update,
+				Config: testAccLBV2WhitelistConfig_update,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("flexibleengine_lb_whitelist_v2.whitelist_1", "enable_whitelist", "true"),
 				),
@@ -35,9 +35,9 @@ func TestAccLBV2Whitelist_basic(t *testing.T) {
 
 func testAccCheckLBV2WhitelistDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+	lbClient, err := config.ElbV2Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -45,7 +45,7 @@ func testAccCheckLBV2WhitelistDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := whitelists.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := whitelists.Get(lbClient, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("Whitelist still exists: %s", rs.Primary.ID)
 		}
@@ -66,12 +66,12 @@ func testAccCheckLBV2WhitelistExists(n string, whitelist *whitelists.Whitelist) 
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+		lbClient, err := config.ElbV2Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+			return fmt.Errorf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 		}
 
-		found, err := whitelists.Get(networkingClient, rs.Primary.ID).Extract()
+		found, err := whitelists.Get(lbClient, rs.Primary.ID).Extract()
 		if err != nil {
 			return err
 		}
@@ -86,42 +86,42 @@ func testAccCheckLBV2WhitelistExists(n string, whitelist *whitelists.Whitelist) 
 	}
 }
 
-var TestAccLBV2WhitelistConfig_basic = fmt.Sprintf(`
+var testAccLBV2WhitelistConfig_basic = fmt.Sprintf(`
 resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
-  name = "loadbalancer_1"
+  name          = "loadbalancer_1"
   vip_subnet_id = "%s"
 }
 
 resource "flexibleengine_lb_listener_v2" "listener_1" {
-  name = "listener_1"
-  protocol = "HTTP"
-  protocol_port = 8080
-  loadbalancer_id = "${flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id}"
+  name            = "listener_1"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
 }
 
 resource "flexibleengine_lb_whitelist_v2" "whitelist_1" {
   enable_whitelist = true
-  whitelist = "192.168.11.1,192.168.0.1/24"
-  listener_id = "${flexibleengine_lb_listener_v2.listener_1.id}"
+  whitelist        = "192.168.11.1,192.168.0.1/24"
+  listener_id      = flexibleengine_lb_listener_v2.listener_1.id
 }
 `, OS_SUBNET_ID)
 
-var TestAccLBV2WhitelistConfig_update = fmt.Sprintf(`
+var testAccLBV2WhitelistConfig_update = fmt.Sprintf(`
 resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
-  name = "loadbalancer_1"
+  name          = "loadbalancer_1"
   vip_subnet_id = "%s"
 }
 
 resource "flexibleengine_lb_listener_v2" "listener_1" {
-  name = "listener_1"
-  protocol = "HTTP"
-  protocol_port = 8080
-  loadbalancer_id = "${flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id}"
+  name            = "listener_1"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
 }
 
 resource "flexibleengine_lb_whitelist_v2" "whitelist_1" {
   enable_whitelist = true
-  whitelist = "192.168.11.1,192.168.0.1/24,192.168.201.18/8"
-  listener_id = "${flexibleengine_lb_listener_v2.listener_1.id}"
+  whitelist        = "192.168.11.1,192.168.0.1/24,192.168.201.18/8"
+  listener_id      = flexibleengine_lb_listener_v2.listener_1.id
 }
 `, OS_SUBNET_ID)


### PR DESCRIPTION
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLBV2LoadBalancer'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLBV2LoadBalancer -timeout 720m
=== RUN   TestAccLBV2LoadBalancer_basic
--- PASS: TestAccLBV2LoadBalancer_basic (137.30s)
=== RUN   TestAccLBV2LoadBalancer_secGroup
--- PASS: TestAccLBV2LoadBalancer_secGroup (202.89s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 340.237s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLBV2Listener_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLBV2Listener_basic -timeout 720m
=== RUN   TestAccLBV2Listener_basic
--- PASS: TestAccLBV2Listener_basic (220.67s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 220.718s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLBV2Pool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLBV2Pool_basic -timeout 720m
=== RUN   TestAccLBV2Pool_basic
--- PASS: TestAccLBV2Pool_basic (180.01s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 180.068s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLBV2Member'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLBV2Member -timeout 720m
=== RUN   TestAccLBV2Member_basic
--- PASS: TestAccLBV2Member_basic (204.12s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 204.172s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLBV2Monitor_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLBV2Monitor_basic -timeout 720m
=== RUN   TestAccLBV2Monitor_basic
--- PASS: TestAccLBV2Monitor_basic (229.80s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 229.860s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLBV2Whitelist_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLBV2Whitelist_basic -timeout 720m
=== RUN   TestAccLBV2Whitelist_basic
--- PASS: TestAccLBV2Whitelist_basic (169.29s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 169.363s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLBV2L7'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLBV2L7 -timeout 720m
=== RUN   TestAccLBV2L7Policy_basic
--- PASS: TestAccLBV2L7Policy_basic (125.67s)
=== RUN   TestAccLBV2L7Rule_basic
--- PASS: TestAccLBV2L7Rule_basic (192.17s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 317.917s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLBV2Certificate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLBV2Certificate_basic -timeout 720m
=== RUN   TestAccLBV2Certificate_basic
--- PASS: TestAccLBV2Certificate_basic (96.04s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 96.087s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccELBV2LoadbalancerDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccELBV2LoadbalancerDataSource_basic -timeout 720m
=== RUN   TestAccELBV2LoadbalancerDataSource_basic
--- PASS: TestAccELBV2LoadbalancerDataSource_basic (77.25s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 77.292s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCertificateV2DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCertificateV2DataSource_basic -timeout 720m
=== RUN   TestAccCertificateV2DataSource_basic
--- PASS: TestAccCertificateV2DataSource_basic (58.39s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 58.439s
```