### PR TITLE
chore: update data analysis services endpoints

### DIFF
--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -353,27 +353,6 @@ func (c *Config) otcV1Client(region string) (*golangsdk.ServiceClient, error) {
 	}, "elb")
 }
 
-func (c *Config) SmnV2Client(region string) (*golangsdk.ServiceClient, error) {
-	return huaweisdk.NewSMNV2(c.HwClient, golangsdk.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: c.getHwEndpointType(),
-	})
-}
-
-func (c *Config) MlsV1Client(region string) (*golangsdk.ServiceClient, error) {
-	return huaweisdk.NewMLSV1(c.HwClient, golangsdk.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: c.getHwEndpointType(),
-	})
-}
-
-func (c *Config) MrsV1Client(region string) (*golangsdk.ServiceClient, error) {
-	return huaweisdk.NewMapReduceV1(c.HwClient, golangsdk.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: c.getHwEndpointType(),
-	})
-}
-
 func (c *Config) natV2Client(region string) (*golangsdk.ServiceClient, error) {
 	return huaweisdk.NewNatV2(c.HwClient, golangsdk.EndpointOpts{
 		Region:       c.determineRegion(region),
@@ -390,13 +369,6 @@ func (c *Config) drsV2Client(region string) (*golangsdk.ServiceClient, error) {
 
 func (c *Config) orchestrationV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return huaweisdk.NewOrchestrationV1(c.HwClient, golangsdk.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: c.getHwEndpointType(),
-	})
-}
-
-func (c *Config) dwsV1Client(region string) (*golangsdk.ServiceClient, error) {
-	return huaweisdk.NewDWSClient(c.HwClient, golangsdk.EndpointOpts{
 		Region:       c.determineRegion(region),
 		Availability: c.getHwEndpointType(),
 	})

--- a/flexibleengine/config_test.go
+++ b/flexibleengine/config_test.go
@@ -477,7 +477,7 @@ func TestAccServiceEndpoints_EnterpriseIntelligence(t *testing.T) {
 	testCheckServiceURL(t, expectedURL, actualURL, "SMN v2")
 
 	// test the endpoint of DWS service
-	serviceClient, err = config.dwsV1Client(OS_REGION_NAME)
+	serviceClient, err = config.DwsV1Client(OS_REGION_NAME)
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine DWS client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_dws_cluster_v1.go
+++ b/flexibleengine/resource_flexibleengine_dws_cluster_v1.go
@@ -192,7 +192,7 @@ func getPublicIP(d *schema.ResourceData) *cluster.PublicIpOpts {
 
 func resourceDWSClusterV1Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.dwsV1Client(GetRegion(d, config))
+	client, err := config.DwsV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine client: %s", err)
 	}
@@ -240,7 +240,7 @@ func resourceDWSClusterV1Create(d *schema.ResourceData, meta interface{}) error 
 
 func resourceDWSClusterV1Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.dwsV1Client(GetRegion(d, config))
+	client, err := config.DwsV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine client: %s", err)
 	}
@@ -282,7 +282,7 @@ func resourceDWSClusterV1Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceDWSClusterV1Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.dwsV1Client(GetRegion(d, config))
+	client, err := config.DwsV1Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_dws_cluster_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_dws_cluster_v1_test.go
@@ -29,7 +29,7 @@ func TestDWSClusterBasic(t *testing.T) {
 
 func testDWSClusterDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	client, err := config.dwsV1Client(OS_REGION_NAME)
+	client, err := config.DwsV1Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DWS client: %s", err)
 	}
@@ -61,7 +61,7 @@ func testDWSClusterExists(n string, ar *cluster.Cluster) resource.TestCheckFunc 
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		client, err := config.dwsV1Client(OS_REGION_NAME)
+		client, err := config.DwsV1Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine DWS client: %s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_mls_instance_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_mls_instance_v1_test.go
@@ -82,48 +82,21 @@ func testAccCheckMLSV1InstanceExists(n string, instance *instances.Instance) res
 }
 
 var TestAccMLSInstanceV1Config_basic = fmt.Sprintf(`
-resource "flexibleengine_mrs_cluster_v1" "cluster1" {
-  cluster_name = "mrs-cluster-acc"
-  region = "%s"
-  billing_type = 12
-  master_node_num = 2
-  core_node_num = 3
-  master_node_size = "s1.4xlarge.linux.mrs"
-  core_node_size = "s1.xlarge.linux.mrs"
-  available_zone_id = "%s"
-  vpc_id = "%s"
-  subnet_id = "%s"
-  cluster_version = "MRS 1.3.0"
-  volume_type = "SATA"
-  volume_size = 100
-  safe_mode = 0
-  cluster_type = 0
-  node_public_cert_name = "KeyPair-ci"
-  cluster_admin_secret = ""
-  component_list {
-      component_name = "Hadoop"
-  }
-  component_list {
-      component_name = "Spark"
-  }
-  component_list {
-      component_name = "Hive"
-  }
-}
+%s
 
 resource "flexibleengine_mls_instance_v1" "instance" {
-  name = "terraform-mls-instance"
+  name    = "terraform-mls-instance"
   version = "1.2.0"
-  flavor = "mls.c2.2xlarge.common"
+  flavor  = "mls.c2.2xlarge.common"
   network {
-    vpc_id = "%s"
-    subnet_id = "%s"
+    vpc_id         = "%s"
+    subnet_id      = "%s"
 	available_zone = "%s"
 	public_ip {
 	  bind_type = "not_use"
 	}
   }
   mrs_cluster {
-    id = "${flexibleengine_mrs_cluster_v1.cluster1.id}"
+    id = flexibleengine_mrs_cluster_v1.cluster1.id
   }
-}`, OS_REGION_NAME, OS_AVAILABILITY_ZONE, OS_VPC_ID, OS_NETWORK_ID, OS_VPC_ID, OS_NETWORK_ID, OS_AVAILABILITY_ZONE)
+}`, testAccMRSV1ClusterConfig_basic, OS_VPC_ID, OS_NETWORK_ID, OS_AVAILABILITY_ZONE)

--- a/flexibleengine/resource_flexibleengine_mrs_cluster_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_mrs_cluster_v1_test.go
@@ -20,7 +20,7 @@ func TestAccMRSV1Cluster_basic(t *testing.T) {
 		CheckDestroy: testAccCheckMRSV1ClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: TestAccMRSV1ClusterConfig_basic,
+				Config: testAccMRSV1ClusterConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckMRSV1ClusterExists("flexibleengine_mrs_cluster_v1.cluster1", &clusterGet),
 					resource.TestCheckResourceAttr(
@@ -91,7 +91,7 @@ func testAccCheckMRSV1ClusterExists(n string, clusterGet *cluster.Cluster) resou
 	}
 }
 
-var TestAccMRSV1ClusterConfig_basic = fmt.Sprintf(`
+var testAccMRSV1ClusterConfig_basic = fmt.Sprintf(`
 resource "flexibleengine_mrs_cluster_v1" "cluster1" {
   region            = "%s"
   available_zone_id = "%s"

--- a/flexibleengine/resource_flexibleengine_smn_subscription_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_smn_subscription_v2_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccSMNV2Subscription_basic(t *testing.T) {
-	var subscription2 subscriptions.SubscriptionGet
+	var subscription subscriptions.SubscriptionGet
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -20,9 +20,9 @@ func TestAccSMNV2Subscription_basic(t *testing.T) {
 			{
 				Config: TestAccSMNV2SubscriptionConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckSMNV2SubscriptionExists("flexibleengine_smn_subscription_v2.subscription_2", &subscription2),
+					testAccCheckSMNV2SubscriptionExists("flexibleengine_smn_subscription_v2.subscription_1", &subscription),
 					resource.TestCheckResourceAttr(
-						"flexibleengine_smn_subscription_v2.subscription_2", "endpoint",
+						"flexibleengine_smn_subscription_v2.subscription_1", "endpoint",
 						"13600000000"),
 				),
 			},
@@ -94,21 +94,14 @@ func testAccCheckSMNV2SubscriptionExists(n string, subscription *subscriptions.S
 
 var TestAccSMNV2SubscriptionConfig_basic = `
 resource "flexibleengine_smn_topic_v2" "topic_1" {
-  name		  = "topic_1"
-  display_name    = "The display name of topic_1"
+  name         = "topic_1"
+  display_name = "The display name of topic_1"
 }
 
-#resource "flexibleengine_smn_subscription_v2" "subscription_1" {
-#  topic_urn       = "${flexibleengine_smn_topic_v2.topic_1.id}"
-#  endpoint        = "mailtest@gmail.com"
-#  protocol        = "email"
-#  remark          = "O&M"
-#}
-
-resource "flexibleengine_smn_subscription_v2" "subscription_2" {
-  topic_urn       = "${flexibleengine_smn_topic_v2.topic_1.id}"
-  endpoint        = "13600000000"
-  protocol        = "sms"
-  remark          = ""
+resource "flexibleengine_smn_subscription_v2" "subscription_1" {
+  topic_urn = flexibleengine_smn_topic_v2.topic_1.id
+  endpoint  = "13600000000"
+  protocol  = "sms"
+  remark    = ""
 }
 `

--- a/flexibleengine/resource_flexibleengine_smn_topic_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_smn_topic_v2_test.go
@@ -97,14 +97,14 @@ func testAccCheckSMNV2TopicExists(n string, topic *topics.TopicGet) resource.Tes
 
 var TestAccSMNV2TopicConfig_basic = `
 resource "flexibleengine_smn_topic_v2" "topic_1" {
-  name		  = "topic_1"
-  display_name    = "The display name of topic_1"
+  name         = "topic_1"
+  display_name = "The display name of topic_1"
 }
 `
 
 var TestAccSMNV2TopicConfig_update = `
 resource "flexibleengine_smn_topic_v2" "topic_1" {
-  name		  = "topic_1"
-  display_name    = "The update display name of topic_1"
+  name         = "topic_1"
+  display_name = "The update display name of topic_1"
 }
 `


### PR DESCRIPTION
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccSMNV2'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccSMNV2 -timeout 720m
=== RUN   TestAccSMNV2Subscription_basic
--- PASS: TestAccSMNV2Subscription_basic (53.57s)
=== RUN   TestAccSMNV2Topic_basic
--- PASS: TestAccSMNV2Topic_basic (91.67s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 145.298s

 $ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccMRSV1Cluster_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccMRSV1Cluster_basic -timeout 720m
=== RUN   TestAccMRSV1Cluster_basic
--- PASS: TestAccMRSV1Cluster_basic (1444.22s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 1444.288s
```