### PR TITLE
deprecate classic load balancers as they are no longer provided

### DIFF
--- a/docs/resources/elb_backend.md
+++ b/docs/resources/elb_backend.md
@@ -1,8 +1,10 @@
 ---
-subcategory: "Elastic Load Balance (ELB)"
+subcategory: "Deprecated"
 ---
 
 # flexibleengine_elb_backend
+
+!> **Warning:** Classic load balancers are no longer provided, using elastic load balancers instead.
 
 Manages a **classic** lb backend resource within FlexibleEngine.
 

--- a/docs/resources/elb_health.md
+++ b/docs/resources/elb_health.md
@@ -1,8 +1,10 @@
 ---
-subcategory: "Elastic Load Balance (ELB)"
+subcategory: "Deprecated"
 ---
 
 # flexibleengine_elb_health
+
+!> **Warning:** Classic load balancers are no longer provided, using elastic load balancers instead.
 
 Manages a **classic** lb health check resource within FlexibleEngine.
 

--- a/docs/resources/elb_listener.md
+++ b/docs/resources/elb_listener.md
@@ -1,8 +1,10 @@
 ---
-subcategory: "Elastic Load Balance (ELB)"
+subcategory: "Deprecated"
 ---
 
 # flexibleengine_elb_listener
+
+!> **Warning:** Classic load balancers are no longer provided, using elastic load balancers instead.
 
 Manages a **classic** lb listener resource within FlexibleEngine.
 

--- a/docs/resources/elb_loadbalancer.md
+++ b/docs/resources/elb_loadbalancer.md
@@ -1,8 +1,10 @@
 ---
-subcategory: "Elastic Load Balance (ELB)"
+subcategory: "Deprecated"
 ---
 
 # flexibleengine_elb_loadbalancer
+
+!> **Warning:** Classic load balancers are no longer provided, using elastic load balancers instead.
 
 Manages a **classic** load balancer resource within FlexibleEngine.
 

--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -346,13 +346,6 @@ func (c *Config) networkingV2Client(region string) (*golangsdk.ServiceClient, er
 	})
 }
 
-func (c *Config) otcV1Client(region string) (*golangsdk.ServiceClient, error) {
-	return huaweisdk.NewElbV1(c.HwClient, golangsdk.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: c.getHwEndpointType(),
-	}, "elb")
-}
-
 func (c *Config) natV2Client(region string) (*golangsdk.ServiceClient, error) {
 	return huaweisdk.NewNatV2(c.HwClient, golangsdk.EndpointOpts{
 		Region:       c.determineRegion(region),
@@ -421,4 +414,11 @@ func (c *Config) sdkClient(region, serviceType string) (*golangsdk.ServiceClient
 
 func (c *Config) getHwEndpointType() golangsdk.Availability {
 	return golangsdk.AvailabilityPublic
+}
+
+func otcV1Client(c *Config, region string) (*golangsdk.ServiceClient, error) {
+	return huaweisdk.NewElbV1(c.HwClient, golangsdk.EndpointOpts{
+		Region:       c.determineRegion(region),
+		Availability: c.getHwEndpointType(),
+	}, "elb")
 }

--- a/flexibleengine/config_test.go
+++ b/flexibleengine/config_test.go
@@ -295,7 +295,7 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 
 	// test endpoint of elb/otc v1.0
 	serviceClient, err = nil, nil
-	serviceClient, err = config.otcV1Client(OS_REGION_NAME)
+	serviceClient, err = otcV1Client(config, OS_REGION_NAME)
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine ELB/otc v1.0 client: %s", err)
 	}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -293,10 +293,6 @@ func Provider() *schema.Provider {
 			"flexibleengine_obs_bucket":                         resourceObsBucket(),
 			"flexibleengine_obs_bucket_object":                  resourceObsBucketObject(),
 			"flexibleengine_obs_bucket_replication":             resourceObsBucketReplication(),
-			"flexibleengine_elb_loadbalancer":                   resourceELoadBalancer(),
-			"flexibleengine_elb_listener":                       resourceEListener(),
-			"flexibleengine_elb_backend":                        resourceBackend(),
-			"flexibleengine_elb_health":                         resourceHealth(),
 			"flexibleengine_as_group_v1":                        resourceASGroup(),
 			"flexibleengine_as_configuration_v1":                resourceASConfiguration(),
 			"flexibleengine_as_policy_v1":                       resourceASPolicy(),
@@ -359,8 +355,13 @@ func Provider() *schema.Provider {
 			"flexibleengine_waf_rule_precise_protection":        resourceWafRulePreciseProtection(),
 			"flexibleengine_waf_rule_web_tamper_protection":     resourceWafRuleWebTamperProtection(),
 			"flexibleengine_dli_queue":                          ResourceDliQueueV1(),
+
 			// Deprecated resource
-			"flexibleengine_rds_instance_v1": resourceRdsInstance(),
+			"flexibleengine_elb_loadbalancer": resourceELoadBalancer(),
+			"flexibleengine_elb_listener":     resourceEListener(),
+			"flexibleengine_elb_backend":      resourceBackend(),
+			"flexibleengine_elb_health":       resourceHealth(),
+			"flexibleengine_rds_instance_v1":  resourceRdsInstance(),
 		},
 		// configuring the provider
 		ConfigureContextFunc: configureProvider,

--- a/flexibleengine/resource_flexibleengine_elb_backend.go
+++ b/flexibleengine/resource_flexibleengine_elb_backend.go
@@ -23,6 +23,7 @@ func resourceBackend() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		DeprecationMessage: "It has been deprecated, using enhanced load balancer instead",
 		Schema: map[string]*schema.Schema{
 			"listener_id": {
 				Type:     schema.TypeString,

--- a/flexibleengine/resource_flexibleengine_elb_backend.go
+++ b/flexibleengine/resource_flexibleengine_elb_backend.go
@@ -47,7 +47,7 @@ func resourceBackend() *schema.Resource {
 
 func resourceBackendCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.otcV1Client(GetRegion(d, config))
+	client, err := otcV1Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}
@@ -97,7 +97,7 @@ func resourceBackendCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceBackendRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.otcV1Client(GetRegion(d, config))
+	client, err := otcV1Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}
@@ -126,7 +126,7 @@ func resourceBackendRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceBackendDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.otcV1Client(GetRegion(d, config))
+	client, err := otcV1Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_elb_backend_test.go
+++ b/flexibleengine/resource_flexibleengine_elb_backend_test.go
@@ -14,7 +14,7 @@ func TestAccELBBackend_basic(t *testing.T) {
 	var backend backendmember.Backend
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckDeprecated(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckELBBackendDestroy,
 		Steps: []resource.TestStep{

--- a/flexibleengine/resource_flexibleengine_elb_backend_test.go
+++ b/flexibleengine/resource_flexibleengine_elb_backend_test.go
@@ -30,7 +30,7 @@ func TestAccELBBackend_basic(t *testing.T) {
 
 func testAccCheckELBBackendDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	client, err := config.otcV1Client(OS_REGION_NAME)
+	client, err := otcV1Client(config, OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}
@@ -61,7 +61,7 @@ func testAccCheckELBBackendExists(n string, backend *backendmember.Backend) reso
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		client, err := config.otcV1Client(OS_REGION_NAME)
+		client, err := otcV1Client(config, OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_elb_health.go
+++ b/flexibleengine/resource_flexibleengine_elb_health.go
@@ -71,7 +71,7 @@ func resourceHealth() *schema.Resource {
 
 func resourceHealthCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.otcV1Client(GetRegion(d, config))
+	client, err := otcV1Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}
@@ -100,12 +100,12 @@ func resourceHealthCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceHealthRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.otcV1Client(GetRegion(d, config))
+	client, err := otcV1Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}
 
-	health, err := healthcheck.Get(networkingClient, d.Id()).Extract()
+	health, err := healthcheck.Get(client, d.Id()).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "health")
 	}
@@ -129,7 +129,7 @@ func resourceHealthRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceHealthUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.otcV1Client(GetRegion(d, config))
+	client, err := otcV1Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}
@@ -159,7 +159,7 @@ func resourceHealthUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Updating health %s with options: %#v", d.Id(), updateOpts)
 
-	_, err = healthcheck.Update(networkingClient, d.Id(), updateOpts).Extract()
+	_, err = healthcheck.Update(client, d.Id(), updateOpts).Extract()
 	if err != nil {
 		return err
 	}
@@ -169,7 +169,7 @@ func resourceHealthUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceHealthDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.otcV1Client(GetRegion(d, config))
+	client, err := otcV1Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_elb_health.go
+++ b/flexibleengine/resource_flexibleengine_elb_health.go
@@ -23,6 +23,7 @@ func resourceHealth() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		DeprecationMessage: "It has been deprecated, using enhanced load balancer instead",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/flexibleengine/resource_flexibleengine_elb_health_test.go
+++ b/flexibleengine/resource_flexibleengine_elb_health_test.go
@@ -15,7 +15,7 @@ func TestAccELBHealth_basic(t *testing.T) {
 	var health healthcheck.Health
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckDeprecated(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckELBHealthDestroy,
 		Steps: []resource.TestStep{

--- a/flexibleengine/resource_flexibleengine_elb_health_test.go
+++ b/flexibleengine/resource_flexibleengine_elb_health_test.go
@@ -40,7 +40,7 @@ func TestAccELBHealth_basic(t *testing.T) {
 
 func testAccCheckELBHealthDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.otcV1Client(OS_REGION_NAME)
+	client, err := otcV1Client(config, OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}
@@ -50,7 +50,7 @@ func testAccCheckELBHealthDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := healthcheck.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := healthcheck.Get(client, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("Health still exists: %s", rs.Primary.ID)
 		}
@@ -72,7 +72,7 @@ func testAccCheckELBHealthExists(t *testing.T, n string, health *healthcheck.Hea
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		client, err := config.otcV1Client(OS_REGION_NAME)
+		client, err := otcV1Client(config, OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_elb_listener.go
+++ b/flexibleengine/resource_flexibleengine_elb_listener.go
@@ -35,6 +35,7 @@ func resourceEListener() *schema.Resource {
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
+		DeprecationMessage: "It has been deprecated, using enhanced load balancer instead",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/flexibleengine/resource_flexibleengine_elb_listener.go
+++ b/flexibleengine/resource_flexibleengine_elb_listener.go
@@ -152,7 +152,7 @@ func resourceEListener() *schema.Resource {
 
 func resourceEListenerCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.otcV1Client(GetRegion(d, config))
+	client, err := otcV1Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}
@@ -198,7 +198,7 @@ func resourceEListenerCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceEListenerRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.otcV1Client(GetRegion(d, config))
+	client, err := otcV1Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}
@@ -237,7 +237,7 @@ func resourceEListenerRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceEListenerUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.otcV1Client(GetRegion(d, config))
+	client, err := otcV1Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}
@@ -288,7 +288,7 @@ func resourceEListenerUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceEListenerDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.otcV1Client(GetRegion(d, config))
+	client, err := otcV1Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_elb_listener_test.go
+++ b/flexibleengine/resource_flexibleengine_elb_listener_test.go
@@ -36,7 +36,7 @@ func TestAccELBListener_basic(t *testing.T) {
 
 func testAccCheckELBListenerDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.otcV1Client(OS_REGION_NAME)
+	client, err := otcV1Client(config, OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}
@@ -46,7 +46,7 @@ func testAccCheckELBListenerDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := listeners.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := listeners.Get(client, rs.Primary.ID).Extract()
 		if err == nil {
 			return fmt.Errorf("Listener still exists: %s", rs.Primary.ID)
 		}
@@ -67,7 +67,7 @@ func testAccCheckELBListenerExists(n string, listener *listeners.Listener) resou
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		client, err := config.otcV1Client(OS_REGION_NAME)
+		client, err := otcV1Client(config, OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_elb_listener_test.go
+++ b/flexibleengine/resource_flexibleengine_elb_listener_test.go
@@ -13,7 +13,7 @@ func TestAccELBListener_basic(t *testing.T) {
 	var listener listeners.Listener
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckDeprecated(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckELBListenerDestroy,
 		Steps: []resource.TestStep{

--- a/flexibleengine/resource_flexibleengine_elb_loadbalancer.go
+++ b/flexibleengine/resource_flexibleengine_elb_loadbalancer.go
@@ -24,6 +24,7 @@ func resourceELoadBalancer() *schema.Resource {
 			Delete: schema.DefaultTimeout(5 * time.Minute),
 		},
 
+		DeprecationMessage: "It has been deprecated, using enhanced load balancer instead",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/flexibleengine/resource_flexibleengine_elb_loadbalancer.go
+++ b/flexibleengine/resource_flexibleengine_elb_loadbalancer.go
@@ -103,7 +103,7 @@ func resourceELoadBalancer() *schema.Resource {
 
 func resourceELoadBalancerCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.otcV1Client(GetRegion(d, config))
+	client, err := otcV1Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}
@@ -151,12 +151,12 @@ func resourceELoadBalancerCreate(d *schema.ResourceData, meta interface{}) error
 
 func resourceELoadBalancerRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.otcV1Client(GetRegion(d, config))
+	client, err := otcV1Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}
 
-	lb, err := loadbalancer_elbs.Get(networkingClient, d.Id()).Extract()
+	lb, err := loadbalancer_elbs.Get(client, d.Id()).Extract()
 	if err != nil {
 		return CheckDeleted(d, err, "loadbalancer")
 	}
@@ -191,7 +191,7 @@ func resourceELoadBalancerRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceELoadBalancerUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.otcV1Client(GetRegion(d, config))
+	client, err := otcV1Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}
@@ -222,7 +222,7 @@ func resourceELoadBalancerUpdate(d *schema.ResourceData, meta interface{}) error
 
 func resourceELoadBalancerDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.otcV1Client(GetRegion(d, config))
+	client, err := otcV1Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_elb_loadbalancer_test.go
+++ b/flexibleengine/resource_flexibleengine_elb_loadbalancer_test.go
@@ -2,7 +2,6 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -73,10 +72,8 @@ func TestAccELBLoadBalancer_secGroup(t *testing.T) {
 
 func testAccCheckELBLoadBalancerDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.otcV1Client(OS_REGION_NAME)
+	client, err := otcV1Client(config, OS_REGION_NAME)
 	if err != nil {
-		fmt.Printf("@@@@@@@@@@@@@@@@ testAccCheckELBLoadBalancerDestroy FlexibleEngine networking client: %s", err)
-
 		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 	}
 
@@ -85,10 +82,8 @@ func testAccCheckELBLoadBalancerDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := loadbalancer_elbs.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := loadbalancer_elbs.Get(client, rs.Primary.ID).Extract()
 		if err == nil {
-			fmt.Printf("@@@@@@@@@@@@@@@@ testAccCheckELBLoadBalancerDestroy LoadBalancer still exists: %s", rs.Primary.ID)
-
 			return fmt.Errorf("LoadBalancer still exists: %s", rs.Primary.ID)
 		}
 	}
@@ -102,34 +97,25 @@ func testAccCheckELBLoadBalancerExists(
 
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			fmt.Printf("@@@@@@@@@@@@@@@@ testAccCheckELBLoadBalancerExists Not found: %s \n", n)
-
 			return fmt.Errorf("Not found: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
-			fmt.Printf("@@@@@@@@@@@@@@@@ testAccCheckELBLoadBalancerExists No ID is set \n")
 			return fmt.Errorf("No ID is set")
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.otcV1Client(OS_REGION_NAME)
+		client, err := otcV1Client(config, OS_REGION_NAME)
 		if err != nil {
-			fmt.Printf("@@@@@@@@@@@@@@@@ testAccCheckELBLoadBalancerExists Error creating FlexibleEngine networking client: %s", err)
 			return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 		}
-		fmt.Printf("@@@@@@@@@@@@@@@@ testAccCheckELBLoadBalancerExists  middle \n ")
-		found, err := loadbalancer_elbs.Get(networkingClient, rs.Primary.ID).Extract()
-		if err != nil {
-			log.Printf("[#####ERR#####] : %v", err)
 
-			fmt.Printf("@@@@@@@@@@@@@@@@ testAccCheckELBLoadBalancerExists err1 =%v\n ", err)
+		found, err := loadbalancer_elbs.Get(client, rs.Primary.ID).Extract()
+		if err != nil {
 			return err
 		}
 
 		if found.ID != rs.Primary.ID {
-			fmt.Printf("@@@@@@@@@@@@@@@@ testAccCheckELBLoadBalancerExists err2 Member not found \n ")
-
 			return fmt.Errorf("Member not found")
 		}
 
@@ -143,7 +129,7 @@ func testAccCheckELBLoadBalancerHasSecGroup(
 	lb *loadbalancer_elbs.LoadBalancer, sg *groups.SecGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
-		_, err := config.otcV1Client(OS_REGION_NAME)
+		_, err := otcV1Client(config, OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_elb_loadbalancer_test.go
+++ b/flexibleengine/resource_flexibleengine_elb_loadbalancer_test.go
@@ -16,7 +16,7 @@ func TestAccELBLoadBalancer_basic(t *testing.T) {
 	var lb loadbalancer_elbs.LoadBalancer
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckDeprecated(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckELBLoadBalancerDestroy,
 		Steps: []resource.TestStep{
@@ -42,7 +42,7 @@ func TestAccELBLoadBalancer_secGroup(t *testing.T) {
 	var sg_1, sg_2 groups.SecGroup
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckDeprecated(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckELBLoadBalancerDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccELB'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccELB -timeout 720m
=== RUN   TestAccELBV2LoadbalancerDataSource_basic
--- PASS: TestAccELBV2LoadbalancerDataSource_basic (81.07s)
=== RUN   TestAccELBBackend_basic
    provider_test.go:111: This environment does not support deprecated tests
--- SKIP: TestAccELBBackend_basic (0.01s)
=== RUN   TestAccELBHealth_basic
    provider_test.go:111: This environment does not support deprecated tests
--- SKIP: TestAccELBHealth_basic (0.00s)
=== RUN   TestAccELBListener_basic
    provider_test.go:111: This environment does not support deprecated tests
--- SKIP: TestAccELBListener_basic (0.00s)
=== RUN   TestAccELBLoadBalancer_basic
    provider_test.go:111: This environment does not support deprecated tests
--- SKIP: TestAccELBLoadBalancer_basic (0.00s)
=== RUN   TestAccELBLoadBalancer_secGroup
    provider_test.go:111: This environment does not support deprecated tests
--- SKIP: TestAccELBLoadBalancer_secGroup (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 81.138s
```