### PR TITLE
deprecate DRS service as the APIs are not exist

### DIFF
--- a/docs/resources/drs_replication_v2.md
+++ b/docs/resources/drs_replication_v2.md
@@ -1,8 +1,10 @@
 ---
-subcategory: "Data Replication Service (DRS)"
+subcategory: "Deprecated"
 ---
 
 # flexibleengine_drs_replication_v2
+
+!> **Warning:** It has been deprecated.
 
 Manages a V2 replication resource within FlexibleEngine.
 

--- a/docs/resources/drs_replicationconsistencygroup_v2.md
+++ b/docs/resources/drs_replicationconsistencygroup_v2.md
@@ -1,8 +1,10 @@
 ---
-subcategory: "Data Replication Service (DRS)"
+subcategory: "Deprecated"
 ---
 
 # flexibleengine_drs_replicationconsistencygroup_v2
+
+!> **Warning:** It has been deprecated.
 
 Manages a V2 replicationconsistencygroup resource within FlexibleEngine.
 

--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -353,13 +353,6 @@ func (c *Config) natV2Client(region string) (*golangsdk.ServiceClient, error) {
 	})
 }
 
-func (c *Config) drsV2Client(region string) (*golangsdk.ServiceClient, error) {
-	return huaweisdk.NewDRSServiceV2(c.HwClient, golangsdk.EndpointOpts{
-		Region:       c.determineRegion(region),
-		Availability: c.getHwEndpointType(),
-	})
-}
-
 func (c *Config) orchestrationV1Client(region string) (*golangsdk.ServiceClient, error) {
 	return huaweisdk.NewOrchestrationV1(c.HwClient, golangsdk.EndpointOpts{
 		Region:       c.determineRegion(region),
@@ -407,4 +400,11 @@ func otcV1Client(c *Config, region string) (*golangsdk.ServiceClient, error) {
 		Region:       c.determineRegion(region),
 		Availability: c.getHwEndpointType(),
 	}, "elb")
+}
+
+func drsV2Client(c *Config, region string) (*golangsdk.ServiceClient, error) {
+	return huaweisdk.NewDRSServiceV2(c.HwClient, golangsdk.EndpointOpts{
+		Region:       c.determineRegion(region),
+		Availability: c.getHwEndpointType(),
+	})
 }

--- a/flexibleengine/config_test.go
+++ b/flexibleengine/config_test.go
@@ -502,7 +502,7 @@ func TestAccServiceEndpoints_Others(t *testing.T) {
 	config := testProvider.Meta().(*Config)
 
 	// test the endpoint of DRS service
-	serviceClient, err = config.drsV2Client(OS_REGION_NAME)
+	serviceClient, err = drsV2Client(config, OS_REGION_NAME)
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine DRS client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_drs_replication_v2.go
+++ b/flexibleengine/resource_flexibleengine_drs_replication_v2.go
@@ -21,6 +21,7 @@ func resourceReplication() *schema.Resource {
 		Read:   resourceReplicationRead,
 		Delete: resourceReplicationDelete,
 
+		DeprecationMessage: "It has been deprecated",
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/flexibleengine/resource_flexibleengine_drs_replication_v2.go
+++ b/flexibleengine/resource_flexibleengine_drs_replication_v2.go
@@ -155,7 +155,7 @@ func resourceShutdownInstance(d *schema.ResourceData, meta interface{}) error {
 // resourceReplicationCreate creates a replication resource
 func resourceReplicationCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.drsV2Client(GetRegion(d, config))
+	client, err := drsV2Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine drs client: %s", err)
 	}
@@ -213,7 +213,7 @@ func resourceVolumeIDsFromString(VolumeIDs string) []string {
 // resourceReplicationRead returns a replication resource
 func resourceReplicationRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.drsV2Client(GetRegion(d, config))
+	client, err := drsV2Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine drs client: %s", err)
 	}
@@ -267,7 +267,7 @@ func replicationStateRefreshFunc(client *golangsdk.ServiceClient, id string) res
 // resourceReplicationDelete deletes a replication resource
 func resourceReplicationDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.drsV2Client(GetRegion(d, config))
+	client, err := drsV2Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine drs client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_drs_replication_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_drs_replication_v2_test.go
@@ -32,7 +32,7 @@ func TestAccDRSV2Replication_basic(t *testing.T) {
 // testAccCheckDRSV2ReplicationDestroy checks destory.
 func testAccCheckDRSV2ReplicationDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	client, err := config.drsV2Client(OS_REGION_NAME)
+	client, err := drsV2Client(config, OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine drs client: %s", err)
 	}
@@ -66,7 +66,7 @@ func testAccCheckDRSV2ReplicationExists(n string, replication *replications.Repl
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		client, err := config.drsV2Client(OS_REGION_NAME)
+		client, err := drsV2Client(config, OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine drs client: %s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_drs_replication_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_drs_replication_v2_test.go
@@ -15,7 +15,7 @@ func TestAccDRSV2Replication_basic(t *testing.T) {
 	var replication replications.Replication
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckDeprecated(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDRSV2ReplicationDestroy,
 		Steps: []resource.TestStep{

--- a/flexibleengine/resource_flexibleengine_drs_replicationconsistencygroup_v2.go
+++ b/flexibleengine/resource_flexibleengine_drs_replicationconsistencygroup_v2.go
@@ -85,7 +85,7 @@ func resourceReplicationIDsFromSchema(d *schema.ResourceData) []string {
 // resourceReplicationConsistencyGroupCreate creates a replication consistency group resource
 func resourceReplicationConsistencyGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.drsV2Client(GetRegion(d, config))
+	client, err := drsV2Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine drs client: %s", err)
 	}
@@ -136,7 +136,7 @@ func resourceReplicationConsistencyGroupCreate(d *schema.ResourceData, meta inte
 // resourceReplicationConsistencyGroupRead returns a replication consistency group resource
 func resourceReplicationConsistencyGroupRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.drsV2Client(GetRegion(d, config))
+	client, err := drsV2Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine drs client: %s", err)
 	}
@@ -185,7 +185,7 @@ func replicationconsistencygroupStateRefreshFunc(client *golangsdk.ServiceClient
 // resourceReplicationConsistencyGroupDelete deletes a replication consistency group resource
 func resourceReplicationConsistencyGroupDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.drsV2Client(GetRegion(d, config))
+	client, err := drsV2Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine drs client: %s", err)
 	}
@@ -271,7 +271,7 @@ func resourceReplicationConsistencyGroupDelete(d *schema.ResourceData, meta inte
 // resourceReplicationConsistencyGroupUpdate updates a replication consistency group resource
 func resourceReplicationConsistencyGroupUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	client, err := config.drsV2Client(GetRegion(d, config))
+	client, err := drsV2Client(config, GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine drs client: %s", err)
 	}
@@ -351,7 +351,7 @@ func resourceReplicationConsistencyGroupUpdate(d *schema.ResourceData, meta inte
 // resourceGetReplicationIDs returns add and remove replication ids
 func resourceGetReplicationIDs(d *schema.ResourceData, meta interface{}) ([]string, []string, error) {
 	config := meta.(*Config)
-	client, err := config.drsV2Client(GetRegion(d, config))
+	client, err := drsV2Client(config, GetRegion(d, config))
 	if err != nil {
 		return nil, nil, fmt.Errorf("Error creating FlexibleEngine drs client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_drs_replicationconsistencygroup_v2.go
+++ b/flexibleengine/resource_flexibleengine_drs_replicationconsistencygroup_v2.go
@@ -19,6 +19,7 @@ func resourceReplicationConsistencyGroup() *schema.Resource {
 		Delete: resourceReplicationConsistencyGroupDelete,
 		Update: resourceReplicationConsistencyGroupUpdate,
 
+		DeprecationMessage: "It has been deprecated",
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/flexibleengine/resource_flexibleengine_drs_replicationconsistencygroup_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_drs_replicationconsistencygroup_v2_test.go
@@ -15,7 +15,7 @@ func TestAccDRSV2ReplicationConsistencyGroup_basic(t *testing.T) {
 	var rcg replicationconsistencygroups.ReplicationConsistencyGroup
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckDeprecated(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDRSV2ReplicationConsistencyGroupDestroy,
 		Steps: []resource.TestStep{

--- a/flexibleengine/resource_flexibleengine_drs_replicationconsistencygroup_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_drs_replicationconsistencygroup_v2_test.go
@@ -47,7 +47,7 @@ func TestAccDRSV2ReplicationConsistencyGroup_basic(t *testing.T) {
 // testAccCheckDRSV2ReplicationConsistencyGroupDestroy checks destory.
 func testAccCheckDRSV2ReplicationConsistencyGroupDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	client, err := config.drsV2Client(OS_REGION_NAME)
+	client, err := drsV2Client(config, OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine drs client: %s", err)
 	}
@@ -81,7 +81,7 @@ func testAccCheckDRSV2ReplicationConsistencyGroupExists(n string, rcg *replicati
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		client, err := config.drsV2Client(OS_REGION_NAME)
+		client, err := drsV2Client(config, OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine drs client: %s", err)
 		}


### PR DESCRIPTION
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDRSV2Replication'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDRSV2Replication -timeout 720m
=== RUN   TestAccDRSV2Replication_basic
    provider_test.go:111: This environment does not support deprecated tests
--- SKIP: TestAccDRSV2Replication_basic (0.00s)
=== RUN   TestAccDRSV2ReplicationConsistencyGroup_basic
    provider_test.go:111: This environment does not support deprecated tests
--- SKIP: TestAccDRSV2ReplicationConsistencyGroup_basic (0.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 0.047s
```

**issue:**
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDRSV2Replication_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDRSV2Replication_basic -timeout 720m
=== RUN   TestAccDRSV2Replication_basic
    resource_flexibleengine_drs_replication_v2_test.go:17: Step 1/1 error: Error running apply: exit status 1
        2022/03/10 19:41:39 [DEBUG] Using modified User-Agent: Terraform/0.12.28 HashiCorp-terraform-exec/0.14.0

        Error: Error getting replication from result: Resource not found: [POST https://evs.eu-west-0.prod-cloud-ocb.orange-business.com/v2/d8cb0fdcf29b4badb9ed8b2525a3286f/os-vendor-replications], error message: {"error_msg":"The API does not exist or has not been published in the environment","error_code":"APIGW.0101","request_id":"31bb5c27aae3268f1cac45bb6985080b"}


          on terraform_plugin_test.tf line 14, in resource "flexibleengine_drs_replication_v2" "replication_1":
          14: resource "flexibleengine_drs_replication_v2" "replication_1" {


--- FAIL: TestAccDRSV2Replication_basic (61.11s)
FAIL
FAIL    github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 61.167s
FAIL
```