### PR TITLE
chore: update DNS service endpoint

### DIFF
--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -315,16 +315,6 @@ func (c *Config) bmsClient(region string) (*golangsdk.ServiceClient, error) {
 	})
 }
 
-// dnsV2Client is a global client for DNS service, the endpoint is https://dns.{cloud}/v2/
-func (c *Config) dnsV2Client(_ string) (*golangsdk.ServiceClient, error) {
-	sc := new(golangsdk.ServiceClient)
-	sc.ProviderClient = c.HwClient
-	sc.Endpoint = fmt.Sprintf("https://dns.%s", defaultCloud)
-	sc.ResourceBase = fmt.Sprintf("%s/v2/", sc.Endpoint)
-
-	return sc, nil
-}
-
 func (c *Config) identityV3Client(region string) (*golangsdk.ServiceClient, error) {
 	return huaweisdk.NewIdentityV3(c.DomainClient, golangsdk.EndpointOpts{
 		//Region:       c.determineRegion(region),

--- a/flexibleengine/config_test.go
+++ b/flexibleengine/config_test.go
@@ -314,13 +314,13 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	testCheckServiceURL(t, expectedURL, actualURL, "ELB v2.0")
 
 	// test the endpoint of DNS service
-	serviceClient, err = config.dnsV2Client(OS_REGION_NAME)
+	serviceClient, err = config.DnsV2Client(OS_REGION_NAME)
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine DNS client: %s", err)
 	}
 	expectedURL = fmt.Sprintf("https://dns.%s/v2/", defaultCloud)
 	actualURL = serviceClient.ResourceBaseURL()
-	testCheckServiceURL(t, expectedURL, actualURL, "dns")
+	testCheckServiceURL(t, expectedURL, actualURL, "DNS")
 
 	// test the endpoint of VPC endpoint
 	serviceClient, err = config.VPCEPClient(OS_REGION_NAME)

--- a/flexibleengine/data_source_flexibleengine_dns_zone_v2.go
+++ b/flexibleengine/data_source_flexibleengine_dns_zone_v2.go
@@ -79,9 +79,9 @@ func dataSourceDNSZoneV2() *schema.Resource {
 
 func dataSourceDNSZoneV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
+	dnsClient, err := config.DnsV2Client(GetRegion(d, config))
 	if err != nil {
-		return err
+		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 	}
 
 	listOpts := zones.ListOpts{}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -460,6 +460,7 @@ func configureProvider(_ context.Context, d *schema.ResourceData) (interface{}, 
 
 	config.Endpoints = make(map[string]string)
 	config.Endpoints["obs"] = fmt.Sprintf("https://oss.%s.%s/", region, config.Cloud)
+	config.Endpoints["dns"] = fmt.Sprintf("https://dns.%s/", config.Cloud)
 
 	return &config, nil
 }

--- a/flexibleengine/resource_flexibleengine_dns_ptrrecord_v2.go
+++ b/flexibleengine/resource_flexibleengine_dns_ptrrecord_v2.go
@@ -68,7 +68,7 @@ func resourceDNSPtrRecordV2() *schema.Resource {
 func resourceDNSPtrRecordV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	region := GetRegion(d, config)
-	dnsClient, err := config.dnsV2Client(region)
+	dnsClient, err := config.DnsV2Client(region)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 	}
@@ -122,7 +122,7 @@ func resourceDNSPtrRecordV2Create(d *schema.ResourceData, meta interface{}) erro
 
 func resourceDNSPtrRecordV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
+	dnsClient, err := config.DnsV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 	}
@@ -161,7 +161,7 @@ func resourceDNSPtrRecordV2Read(d *schema.ResourceData, meta interface{}) error 
 func resourceDNSPtrRecordV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	region := GetRegion(d, config)
-	dnsClient, err := config.dnsV2Client(region)
+	dnsClient, err := config.DnsV2Client(region)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 	}
@@ -212,7 +212,7 @@ func resourceDNSPtrRecordV2Update(d *schema.ResourceData, meta interface{}) erro
 
 func resourceDNSPtrRecordV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
+	dnsClient, err := config.DnsV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_dns_ptrrecord_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_dns_ptrrecord_v2_test.go
@@ -46,7 +46,7 @@ func TestAccDNSV2PtrRecord_basic(t *testing.T) {
 
 func testAccCheckDNSV2PtrRecordDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	dnsClient, err := config.dnsV2Client(OS_REGION_NAME)
+	dnsClient, err := config.DnsV2Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 	}
@@ -77,7 +77,7 @@ func testAccCheckDNSV2PtrRecordExists(n string, ptrrecord *ptrrecords.Ptr) resou
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		dnsClient, err := config.dnsV2Client(OS_REGION_NAME)
+		dnsClient, err := config.DnsV2Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_dns_recordset_v2.go
+++ b/flexibleengine/resource_flexibleengine_dns_recordset_v2.go
@@ -86,7 +86,7 @@ func resourceDNSRecordSetV2() *schema.Resource {
 
 func resourceDNSRecordSetV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
+	dnsClient, err := config.DnsV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 	}
@@ -161,7 +161,7 @@ func resourceDNSRecordSetV2Create(d *schema.ResourceData, meta interface{}) erro
 
 func resourceDNSRecordSetV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
+	dnsClient, err := config.DnsV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 	}
@@ -211,7 +211,7 @@ func resourceDNSRecordSetV2Read(d *schema.ResourceData, meta interface{}) error 
 
 func resourceDNSRecordSetV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
+	dnsClient, err := config.DnsV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 	}
@@ -286,7 +286,7 @@ func resourceDNSRecordSetV2Update(d *schema.ResourceData, meta interface{}) erro
 
 func resourceDNSRecordSetV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
+	dnsClient, err := config.DnsV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_dns_recordset_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_dns_recordset_v2_test.go
@@ -114,7 +114,7 @@ func TestAccDNSV2RecordSet_private(t *testing.T) {
 
 func testAccCheckDNSV2RecordSetDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	dnsClient, err := config.dnsV2Client(OS_REGION_NAME)
+	dnsClient, err := config.DnsV2Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 	}
@@ -150,7 +150,7 @@ func testAccCheckDNSV2RecordSetExists(n string, recordset *recordsets.RecordSet)
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		dnsClient, err := config.dnsV2Client(OS_REGION_NAME)
+		dnsClient, err := config.DnsV2Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_dns_zone_v2.go
+++ b/flexibleengine/resource_flexibleengine_dns_zone_v2.go
@@ -120,7 +120,7 @@ func resourceDNSRouter(d *schema.ResourceData) map[string]string {
 
 func resourceDNSZoneV2Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
+	dnsClient, err := config.DnsV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 	}
@@ -229,7 +229,7 @@ func resourceDNSZoneV2Create(d *schema.ResourceData, meta interface{}) error {
 
 func resourceDNSZoneV2Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
+	dnsClient, err := config.DnsV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 	}
@@ -267,7 +267,7 @@ func resourceDNSZoneV2Read(d *schema.ResourceData, meta interface{}) error {
 
 func resourceDNSZoneV2Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
+	dnsClient, err := config.DnsV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 	}
@@ -398,7 +398,7 @@ func resourceDNSZoneV2Update(d *schema.ResourceData, meta interface{}) error {
 
 func resourceDNSZoneV2Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dnsClient, err := config.dnsV2Client(GetRegion(d, config))
+	dnsClient, err := config.DnsV2Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_dns_zone_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_dns_zone_v2_test.go
@@ -104,7 +104,7 @@ func TestAccDNSV2Zone_readTTL(t *testing.T) {
 
 func testAccCheckDNSV2ZoneDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	dnsClient, err := config.dnsV2Client(OS_REGION_NAME)
+	dnsClient, err := config.DnsV2Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 	}
@@ -135,7 +135,7 @@ func testAccCheckDNSV2ZoneExists(n string, zone *zones.Zone) resource.TestCheckF
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		dnsClient, err := config.dnsV2Client(OS_REGION_NAME)
+		dnsClient, err := config.DnsV2Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine DNS client: %s", err)
 		}


### PR DESCRIPTION
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDNSV2'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDNSV2 -timeout 720m
=== RUN   TestAccDNSV2PtrRecord_basic
=== PAUSE TestAccDNSV2PtrRecord_basic
=== RUN   TestAccDNSV2RecordSet_basic
=== PAUSE TestAccDNSV2RecordSet_basic
=== RUN   TestAccDNSV2RecordSet_readTTL
=== PAUSE TestAccDNSV2RecordSet_readTTL
=== RUN   TestAccDNSV2RecordSet_private
=== PAUSE TestAccDNSV2RecordSet_private
=== RUN   TestAccDNSV2Zone_basic
=== PAUSE TestAccDNSV2Zone_basic
=== RUN   TestAccDNSV2Zone_private
=== PAUSE TestAccDNSV2Zone_private
=== RUN   TestAccDNSV2Zone_readTTL
=== PAUSE TestAccDNSV2Zone_readTTL
=== CONT  TestAccDNSV2PtrRecord_basic
=== CONT  TestAccDNSV2Zone_basic
=== CONT  TestAccDNSV2RecordSet_readTTL
=== CONT  TestAccDNSV2RecordSet_basic
--- PASS: TestAccDNSV2RecordSet_readTTL (88.06s)
=== CONT  TestAccDNSV2Zone_readTTL
--- PASS: TestAccDNSV2Zone_basic (155.56s)
=== CONT  TestAccDNSV2RecordSet_private
--- PASS: TestAccDNSV2Zone_readTTL (75.39s)
=== CONT  TestAccDNSV2Zone_private
--- PASS: TestAccDNSV2PtrRecord_basic (170.24s)
--- PASS: TestAccDNSV2RecordSet_basic (236.78s)
--- PASS: TestAccDNSV2Zone_private (97.64s)
--- PASS: TestAccDNSV2RecordSet_private (107.77s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 263.375s
```