### PR TITLE
chore: update IAM service endpoint

### DIFF
--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -262,12 +262,12 @@ func (c *Config) determineRegion(region string) string {
 }
 
 func (c *Config) getDomainID() (string, error) {
-	identityClient, err := c.identityV3Client(c.Region)
+	identityClient, err := c.IdentityV3Client(c.Region)
 	if err != nil {
 		return "", fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
 	}
 
-	identityClient.ResourceBase = identityClient.Endpoint + "auth/"
+	identityClient.ResourceBase += "auth/"
 
 	// the List request does not support query options
 	allPages, err := domains.List(identityClient, nil).AllPages()
@@ -289,13 +289,6 @@ func (c *Config) getDomainID() (string, error) {
 	}
 
 	return all[0].ID, nil
-}
-
-func (c *Config) identityV3Client(region string) (*golangsdk.ServiceClient, error) {
-	return huaweisdk.NewIdentityV3(c.DomainClient, golangsdk.EndpointOpts{
-		//Region:       c.determineRegion(region),
-		Availability: c.getHwEndpointType(),
-	})
 }
 
 func (c *Config) getHwEndpointType() golangsdk.Availability {

--- a/flexibleengine/config_test.go
+++ b/flexibleengine/config_test.go
@@ -58,13 +58,21 @@ func TestAccServiceEndpoints_Global(t *testing.T) {
 	config := testProvider.Meta().(*Config)
 
 	// test the endpoint of identity service
-	serviceClient, err = config.identityV3Client(OS_REGION_NAME)
+	serviceClient, err = config.IdentityV3Client(OS_REGION_NAME)
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine identity client: %s", err)
 	}
 	expectedURL = fmt.Sprintf("https://iam.%s.%s/v3/", OS_REGION_NAME, defaultCloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "Identity v3")
+
+	serviceClient, err = config.IAMV3Client(OS_REGION_NAME)
+	if err != nil {
+		t.Fatalf("Error creating FlexibleEngine IAM client: %s", err)
+	}
+	expectedURL = fmt.Sprintf("https://iam.%s.%s/v3.0/", OS_REGION_NAME, defaultCloud)
+	actualURL = serviceClient.ResourceBaseURL()
+	testCheckServiceURL(t, expectedURL, actualURL, "IAM v3.0")
 }
 
 func TestAccServiceEndpoints_Management(t *testing.T) {

--- a/flexibleengine/data_source_flexibleengine_identity_custom_role_v3.go
+++ b/flexibleengine/data_source_flexibleengine_identity_custom_role_v3.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/chnsz/golangsdk/openstack/identity/v3.0/policies"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -53,12 +52,10 @@ func dataSourceIdentityCustomRoleV3() *schema.Resource {
 
 func dataSourceIdentityCustomRoleRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	identityClient, err := config.IAMV3Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine IAM client: %s", err)
 	}
-
-	identityClient.Endpoint = strings.Replace(identityClient.Endpoint, "v3", "v3.0", 1)
 
 	allPages, err := policies.List(identityClient).AllPages()
 	if err != nil {

--- a/flexibleengine/data_source_flexibleengine_identity_project_v3.go
+++ b/flexibleengine/data_source_flexibleengine_identity_project_v3.go
@@ -51,7 +51,7 @@ func dataSourceIdentityProjectV3() *schema.Resource {
 // dataSourceIdentityProjectV3Read performs the project lookup.
 func dataSourceIdentityProjectV3Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack identity client: %s", err)
 	}

--- a/flexibleengine/data_source_flexibleengine_identity_role_v3.go
+++ b/flexibleengine/data_source_flexibleengine_identity_role_v3.go
@@ -51,7 +51,7 @@ func dataSourceIdentityRoleV3() *schema.Resource {
 // dataSourceIdentityRoleV3Read performs the role lookup.
 func dataSourceIdentityRoleV3Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack identity client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_identity_agency_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_identity_agency_v3_test.go
@@ -2,7 +2,6 @@ package flexibleengine
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -97,11 +96,10 @@ func TestAccIdentityV3Agency_domain(t *testing.T) {
 
 func testAccCheckIdentityV3AgencyDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	identityClient, err := config.identityV3Client(OS_REGION_NAME)
+	identityClient, err := config.IAMV3Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine IAM client: %s", err)
 	}
-	identityClient.Endpoint = strings.Replace(identityClient.Endpoint, "v3", "v3.0", 1)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "flexibleengine_identity_agency_v3" {
@@ -129,11 +127,11 @@ func testAccCheckIdentityV3AgencyExists(n string, a *agency.Agency) resource.Tes
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		identityClient, err := config.identityV3Client(OS_REGION_NAME)
+		identityClient, err := config.IAMV3Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
+			return fmt.Errorf("Error creating FlexibleEngine IAM client: %s", err)
 		}
-		identityClient.Endpoint = strings.Replace(identityClient.Endpoint, "v3", "v3.0", 1)
+
 		found, err := agency.Get(identityClient, rs.Primary.ID).Extract()
 		if err != nil {
 			return err

--- a/flexibleengine/resource_flexibleengine_identity_group_membership_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_identity_group_membership_v3_test.go
@@ -48,7 +48,7 @@ func TestAccIdentityV3GroupMembership_basic(t *testing.T) {
 
 func testAccCheckIdentityV3GroupMembershipDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	identityClient, err := config.identityV3Client(OS_REGION_NAME)
+	identityClient, err := config.IdentityV3Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
 	}
@@ -80,7 +80,7 @@ func testAccCheckIdentityV3GroupMembershipExists(n string, us []string) resource
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		identityClient, err := config.identityV3Client(OS_REGION_NAME)
+		identityClient, err := config.IdentityV3Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_identity_group_v3.go
+++ b/flexibleengine/resource_flexibleengine_identity_group_v3.go
@@ -19,12 +19,6 @@ func resourceIdentityGroupV3() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"domain_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -34,13 +28,19 @@ func resourceIdentityGroupV3() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
+			"domain_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 		},
 	}
 }
 
 func resourceIdentityGroupV3Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
 	}
@@ -65,7 +65,7 @@ func resourceIdentityGroupV3Create(d *schema.ResourceData, meta interface{}) err
 
 func resourceIdentityGroupV3Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
 	}
@@ -86,7 +86,7 @@ func resourceIdentityGroupV3Read(d *schema.ResourceData, meta interface{}) error
 
 func resourceIdentityGroupV3Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
 	}
@@ -125,7 +125,7 @@ func resourceIdentityGroupV3Update(d *schema.ResourceData, meta interface{}) err
 
 func resourceIdentityGroupV3Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_identity_group_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_identity_group_v3_test.go
@@ -53,7 +53,7 @@ func TestAccIdentityV3Group_basic(t *testing.T) {
 
 func testAccCheckIdentityV3GroupDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	identityClient, err := config.identityV3Client(OS_REGION_NAME)
+	identityClient, err := config.IdentityV3Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
 	}
@@ -84,7 +84,7 @@ func testAccCheckIdentityV3GroupExists(n string, group *groups.Group) resource.T
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		identityClient, err := config.identityV3Client(OS_REGION_NAME)
+		identityClient, err := config.IdentityV3Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_identity_project_v3.go
+++ b/flexibleengine/resource_flexibleengine_identity_project_v3.go
@@ -57,7 +57,7 @@ func resourceIdentityProjectV3() *schema.Resource {
 
 func resourceIdentityProjectV3Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
 	}
@@ -82,7 +82,7 @@ func resourceIdentityProjectV3Create(d *schema.ResourceData, meta interface{}) e
 
 func resourceIdentityProjectV3Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
 	}
@@ -107,7 +107,7 @@ func resourceIdentityProjectV3Read(d *schema.ResourceData, meta interface{}) err
 
 func resourceIdentityProjectV3Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
 	}
@@ -143,7 +143,7 @@ func resourceIdentityProjectV3Delete(d *schema.ResourceData, meta interface{}) e
 	return nil
 
 	// config := meta.(*Config)
-	// identityClient, err := config.identityV3Client(GetRegion(d, config))
+	// identityClient, err := config.IdentityV3Client(GetRegion(d, config))
 	// if err != nil {
 	// 	return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
 	// }

--- a/flexibleengine/resource_flexibleengine_identity_project_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_identity_project_v3_test.go
@@ -57,7 +57,7 @@ func TestAccIdentityProjectV3_basic(t *testing.T) {
 
 func testAccCheckIdentityProjectV3Destroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	identityClient, err := config.identityV3Client(OS_REGION_NAME)
+	identityClient, err := config.IdentityV3Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
 	}
@@ -88,7 +88,7 @@ func testAccCheckIdentityProjectV3Exists(n string, project *projects.Project) re
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		identityClient, err := config.identityV3Client(OS_REGION_NAME)
+		identityClient, err := config.IdentityV3Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_identity_role_assignment_v3.go
+++ b/flexibleengine/resource_flexibleengine_identity_role_assignment_v3.go
@@ -52,7 +52,7 @@ func resourceIdentityRoleAssignmentV3() *schema.Resource {
 
 func resourceIdentityRoleAssignmentV3Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack identity client: %s", err)
 	}
@@ -79,7 +79,7 @@ func resourceIdentityRoleAssignmentV3Create(d *schema.ResourceData, meta interfa
 
 func resourceIdentityRoleAssignmentV3Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack identity client: %s", err)
 	}
@@ -95,14 +95,13 @@ func resourceIdentityRoleAssignmentV3Read(d *schema.ResourceData, meta interface
 	d.Set("project_id", projectID)
 	d.Set("group_id", groupID)
 	d.Set("role_id", roleAssignment.ID)
-	d.Set("region", GetRegion(d, config))
 
 	return nil
 }
 
 func resourceIdentityRoleAssignmentV3Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	identityClient, err := config.IdentityV3Client(GetRegion(d, config))
 	if err != nil {
 		return fmt.Errorf("Error creating OpenStack identity client: %s", err)
 	}

--- a/flexibleengine/resource_flexibleengine_identity_role_assignment_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_identity_role_assignment_v3_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccIdentityV3RoleAssignment_basic(t *testing.T) {
+func TestAccIdentityRoleAssignment_basic(t *testing.T) {
 	var role roles.Role
 	var group groups.Group
 	var project projects.Project
@@ -43,7 +43,7 @@ func TestAccIdentityV3RoleAssignment_basic(t *testing.T) {
 
 func testAccCheckIdentityV3RoleAssignmentDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	identityClient, err := config.identityV3Client(OS_REGION_NAME)
+	identityClient, err := config.IdentityV3Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating flexibleengine identity client: %s", err)
 	}
@@ -74,7 +74,7 @@ func testAccCheckIdentityV3RoleAssignmentExists(n string, role *roles.Role, grou
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		identityClient, err := config.identityV3Client(OS_REGION_NAME)
+		identityClient, err := config.IdentityV3Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating flexibleengine identity client: %s", err)
 		}
@@ -144,8 +144,8 @@ resource "flexibleengine_identity_group_v3" "group_1" {
 }
 
 resource "flexibleengine_identity_role_assignment_v3" "role_assignment_1" {
-  group_id = flexibleengine_identity_group_v3.group_1.id
+  group_id   = flexibleengine_identity_group_v3.group_1.id
   project_id = data.flexibleengine_identity_project_v3.project_1.id
-  role_id = data.flexibleengine_identity_role_v3.role_1.id
+  role_id    = data.flexibleengine_identity_role_v3.role_1.id
 }
 `

--- a/flexibleengine/resource_flexibleengine_identity_role_v3.go
+++ b/flexibleengine/resource_flexibleengine_identity_role_v3.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/chnsz/golangsdk/openstack/identity/v3.0/policies"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -57,12 +56,10 @@ func resourceIdentityRoleV3() *schema.Resource {
 
 func resourceIdentityRoleCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	identityClient, err := config.IAMV3Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine IAM client: %s", err)
 	}
-
-	identityClient.Endpoint = strings.Replace(identityClient.Endpoint, "v3", "v3.0", 1)
 
 	policy := policies.Policy{}
 	policyDoc := d.Get("policy").(string)
@@ -91,12 +88,10 @@ func resourceIdentityRoleCreate(d *schema.ResourceData, meta interface{}) error 
 
 func resourceIdentityRoleRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	identityClient, err := config.IAMV3Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine IAM client: %s", err)
 	}
-
-	identityClient.Endpoint = strings.Replace(identityClient.Endpoint, "v3", "v3.0", 1)
 
 	role, err := policies.Get(identityClient, d.Id()).Extract()
 	if err != nil {
@@ -122,12 +117,10 @@ func resourceIdentityRoleRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceIdentityRoleUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	identityClient, err := config.IAMV3Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine IAM client: %s", err)
 	}
-
-	identityClient.Endpoint = strings.Replace(identityClient.Endpoint, "v3", "v3.0", 1)
 
 	policy := policies.Policy{}
 	policyDoc := d.Get("policy").(string)
@@ -154,12 +147,10 @@ func resourceIdentityRoleUpdate(d *schema.ResourceData, meta interface{}) error 
 
 func resourceIdentityRoleDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	identityClient, err := config.identityV3Client(GetRegion(d, config))
+	identityClient, err := config.IAMV3Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine IAM client: %s", err)
 	}
-
-	identityClient.Endpoint = strings.Replace(identityClient.Endpoint, "v3", "v3.0", 1)
 
 	err = policies.Delete(identityClient, d.Id()).ExtractErr()
 	if err != nil {

--- a/flexibleengine/resource_flexibleengine_identity_role_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_identity_role_v3_test.go
@@ -2,7 +2,6 @@ package flexibleengine
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -52,12 +51,10 @@ func TestAccIdentityRole_basic(t *testing.T) {
 
 func testAccCheckIdentityRoleDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	identityClient, err := config.identityV3Client(OS_REGION_NAME)
+	identityClient, err := config.IAMV3Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine IAM client: %s", err)
 	}
-
-	identityClient.Endpoint = strings.Replace(identityClient.Endpoint, "v3", "v3.0", 1)
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "flexibleengine_identity_role_v3" {
@@ -85,12 +82,10 @@ func testAccCheckIdentityRoleExists(n string, role *policies.Role) resource.Test
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		identityClient, err := config.identityV3Client(OS_REGION_NAME)
+		identityClient, err := config.IAMV3Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating FlexibleEngine identity client: %s", err)
+			return fmt.Errorf("Error creating FlexibleEngine IAM client: %s", err)
 		}
-
-		identityClient.Endpoint = strings.Replace(identityClient.Endpoint, "v3", "v3.0", 1)
 
 		found, err := policies.Get(identityClient, rs.Primary.ID).Extract()
 		if err != nil {


### PR DESCRIPTION
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccIdentityV3Agency'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccIdentityV3Agency -timeout 720m
=== RUN   TestAccIdentityV3Agency_basic
--- PASS: TestAccIdentityV3Agency_basic (167.10s)
=== RUN   TestAccIdentityV3Agency_domain
--- PASS: TestAccIdentityV3Agency_domain (230.34s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 397.519s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccIdentityRole'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccIdentityRole -timeout 720m
=== RUN   TestAccIdentityRoleAssignment_basic
--- PASS: TestAccIdentityRoleAssignment_basic (56.56s)
=== RUN   TestAccIdentityRole_basic
=== PAUSE TestAccIdentityRole_basic
=== CONT  TestAccIdentityRole_basic
--- PASS: TestAccIdentityRole_basic (97.01s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 153.615s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccIdentityV3Group_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccIdentityV3Group_basic -timeout 720m
=== RUN   TestAccIdentityV3Group_basic
--- PASS: TestAccIdentityV3Group_basic (109.94s)
PASS
ok    github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 109.981s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccIdentityV3GroupMembership_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccIdentityV3GroupMembership_basic -timeout 720m
=== RUN   TestAccIdentityV3GroupMembership_basic
--- PASS: TestAccIdentityV3GroupMembership_basic (150.90s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 150.960s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccIdentityV3ProjectDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccIdentityV3ProjectDataSource_basic -timeout 720m
=== RUN   TestAccIdentityV3ProjectDataSource_basic
--- PASS: TestAccIdentityV3ProjectDataSource_basic (57.81s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 57.849s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccIdentityV3RoleDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccIdentityV3RoleDataSource_basic -timeout 720m
=== RUN   TestAccIdentityV3RoleDataSource_basic
--- PASS: TestAccIdentityV3RoleDataSource_basic (54.41s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 54.455s
```