### PR TITLE
feat(conf): make Config struct as the alias of huaweicloud Config

### DIFF
--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -454,7 +454,7 @@ func configureProvider(_ context.Context, d *schema.ResourceData) (interface{}, 
 	config.RegionProjectIDMap = make(map[string]string)
 	config.RPLock = new(sync.Mutex)
 
-	if err := config.LoadAndValidate(); err != nil {
+	if err := LoadAndValidate(&config); err != nil {
 		return nil, diag.FromErr(err)
 	}
 

--- a/flexibleengine/resource_flexibleengine_dis_stream_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_dis_stream_v2_test.go
@@ -53,7 +53,7 @@ resource flexibleengine_dis_stream "test" {
 
 func testAccCheckDisStreamV2Destroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	client, err := config.Config.DisV2Client(OS_REGION_NAME)
+	client, err := config.DisV2Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("Error creating dis client, err=%s", err)
 	}
@@ -75,7 +75,7 @@ func testAccCheckDisStreamV2Destroy(s *terraform.State) error {
 func testAccCheckDisStreamV2Exists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
-		client, err := config.Config.DisV2Client(OS_REGION_NAME)
+		client, err := config.DisV2Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("Error creating dis client, err=%s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_dli_queue_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_dli_queue_v1_test.go
@@ -71,7 +71,7 @@ resource flexibleengine_dli_queue "test" {
 
 func testAccCheckDliQueueV1Destroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	client, err := config.Config.DliV1Client(OS_REGION_NAME)
+	client, err := config.DliV1Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating dli client, err=%s", err)
 	}
@@ -93,7 +93,7 @@ func testAccCheckDliQueueV1Destroy(s *terraform.State) error {
 func testAccCheckDliQueueV1Exists(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
-		client, err := config.Config.DliV1Client(OS_REGION_NAME)
+		client, err := config.DliV1Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating dli client, err=%s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_dms_kafka_instance_test.go
+++ b/flexibleengine/resource_flexibleengine_dms_kafka_instance_test.go
@@ -55,7 +55,7 @@ func TestAccDmsKafkaInstance_basic(t *testing.T) {
 
 func testAccCheckDmsKafkaInstanceDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	client, err := config.Config.DmsV1Client(OS_REGION_NAME)
+	client, err := config.DmsV1Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating DMS client, err=%s", err)
 	}
@@ -85,7 +85,7 @@ func testAccCheckDmsKafkaInstanceExists(n string) resource.TestCheckFunc {
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		client, err := config.Config.DmsV1Client(OS_REGION_NAME)
+		client, err := config.DmsV1Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating DMS client, err=%s", err)
 		}

--- a/flexibleengine/resource_flexibleengine_dms_kafka_topic_test.go
+++ b/flexibleengine/resource_flexibleengine_dms_kafka_topic_test.go
@@ -45,7 +45,7 @@ func TestAccDmsKafkaTopic_basic(t *testing.T) {
 
 func testAccCheckKafkaTopicDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	client, err := config.Config.DmsV1Client(OS_REGION_NAME)
+	client, err := config.DmsV1Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating DMS client, err=%s", err)
 	}
@@ -86,7 +86,7 @@ func testAccCheckKafkaTopicExists(n string) resource.TestCheckFunc {
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		client, err := config.Config.DmsV1Client(OS_REGION_NAME)
+		client, err := config.DmsV1Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating DMS client, err=%s", err)
 		}


### PR DESCRIPTION
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccServiceEndpoints'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccServiceEndpoints -timeout 720m
=== RUN   TestAccServiceEndpoints_Global
    config_test.go:42: Identity v3 endpoint:     https://iam.eu-west-0.prod-cloud-ocb.orange-business.com/v3/
    config_test.go:42: IAM v3.0 endpoint:        https://iam.eu-west-0.prod-cloud-ocb.orange-business.com/v3.0/
--- PASS: TestAccServiceEndpoints_Global (3.76s)
=== RUN   TestAccServiceEndpoints_Management
    config_test.go:42: CTS endpoint:     https://cts.eu-west-0.prod-cloud-ocb.orange-business.com/v1.0/{{project_id}}/
    config_test.go:42: CES endpoint:     https://ces.eu-west-0.prod-cloud-ocb.orange-business.com/V1.0/{{project_id}}/
--- PASS: TestAccServiceEndpoints_Management (3.66s)
=== RUN   TestAccServiceEndpoints_Compute
    config_test.go:42: ECS v1 endpoint:  https://ecs.eu-west-0.prod-cloud-ocb.orange-business.com/v1/{{project_id}}/
    config_test.go:42: ecs v2 endpoint:  https://ecs.eu-west-0.prod-cloud-ocb.orange-business.com/v2.1/{{project_id}}/
    config_test.go:42: autoscaling v1 endpoint:  https://as.eu-west-0.prod-cloud-ocb.orange-business.com/autoscaling-api/v1/{{project_id}}/
    config_test.go:42: image v2 endpoint:        https://ims.eu-west-0.prod-cloud-ocb.orange-business.com/v2/
    config_test.go:42: cce v3 endpoint:  https://cce.eu-west-0.prod-cloud-ocb.orange-business.com/api/v3/projects/{{project_id}}/
--- PASS: TestAccServiceEndpoints_Compute (6.34s)
=== RUN   TestAccServiceEndpoints_Storage
    config_test.go:42: blockStorage v2 endpoint:         https://evs.eu-west-0.prod-cloud-ocb.orange-business.com/v2/{{project_id}}/
    config_test.go:42: sfsV2 v2 endpoint:        https://sfs.eu-west-0.prod-cloud-ocb.orange-business.com/v2/{{project_id}}/
    config_test.go:42: sfs turbo endpoint:       https://sfs-turbo.eu-west-0.prod-cloud-ocb.orange-business.com/v1/{{project_id}}/
    config_test.go:42: csbs v1 endpoint:         https://csbs.eu-west-0.prod-cloud-ocb.orange-business.com/v1/{{project_id}}/
    config_test.go:42: vbs v2 endpoint:  https://vbs.eu-west-0.prod-cloud-ocb.orange-business.com/v2/{{project_id}}/
--- PASS: TestAccServiceEndpoints_Storage (3.67s)
=== RUN   TestAccServiceEndpoints_Network
    config_test.go:42: vpc v1 endpoint:  https://vpc.eu-west-0.prod-cloud-ocb.orange-business.com/v1/
    config_test.go:42: networking v2.0 endpoint:         https://vpc.eu-west-0.prod-cloud-ocb.orange-business.com/v2.0/
2022/03/17 18:49:18 [DEBUG] FlexibleEngine Region is: eu-west-0
    config_test.go:42: nat gateway v2 endpoint:  https://nat.eu-west-0.prod-cloud-ocb.orange-business.com/v2.0/
2022/03/17 18:49:18 [DEBUG] FlexibleEngine Region is: eu-west-0
    config_test.go:42: elb/otc v1.0 endpoint:    https://elb.eu-west-0.prod-cloud-ocb.orange-business.com/v1.0/{{project_id}}/
    config_test.go:42: ELB v2.0 endpoint:        https://elb.eu-west-0.prod-cloud-ocb.orange-business.com/v2.0/
    config_test.go:42: DNS endpoint:     https://dns.prod-cloud-ocb.orange-business.com/v2/
    config_test.go:42: VPCEP endpoint:   https://vpcep.eu-west-0.prod-cloud-ocb.orange-business.com/v1/{{project_id}}/
--- PASS: TestAccServiceEndpoints_Network (7.31s)
=== RUN   TestAccServiceEndpoints_Database
    config_test.go:42: RDS v1 endpoint:  https://rds.eu-west-0.prod-cloud-ocb.orange-business.com/rds/v1/{{project_id}}/
    config_test.go:42: RDS v3 endpoint:  https://rds.eu-west-0.prod-cloud-ocb.orange-business.com/v3/{{project_id}}/
    config_test.go:42: DDS v3 endpoint:  https://dds.eu-west-0.prod-cloud-ocb.orange-business.com/v3/{{project_id}}/
--- PASS: TestAccServiceEndpoints_Database (3.68s)
=== RUN   TestAccServiceEndpoints_Security
    config_test.go:42: anti-ddos endpoint:       https://antiddos.eu-west-0.prod-cloud-ocb.orange-business.com/v1/{{project_id}}/
    config_test.go:42: KMS endpoint:     https://kms.eu-west-0.prod-cloud-ocb.orange-business.com/v1.0/
--- PASS: TestAccServiceEndpoints_Security (3.68s)
=== RUN   TestAccServiceEndpoints_Application
    config_test.go:42: DCS v1 endpoint:  https://dcs.eu-west-0.prod-cloud-ocb.orange-business.com/v1.0/{{project_id}}/
    config_test.go:42: CSS v1 endpoint:  https://css.eu-west-0.prod-cloud-ocb.orange-business.com/v1.0/{{project_id}}/
--- PASS: TestAccServiceEndpoints_Application (4.63s)
=== RUN   TestAccServiceEndpoints_EnterpriseIntelligence
    config_test.go:42: MRS endpoint:     https://mrs.eu-west-0.prod-cloud-ocb.orange-business.com/v1.1/{{project_id}}/
    config_test.go:42: MLS endpoint:     https://mls.eu-west-0.prod-cloud-ocb.orange-business.com/v1.0/{{project_id}}/
    config_test.go:42: SMN v2 endpoint:  https://smn.eu-west-0.prod-cloud-ocb.orange-business.com/v2/{{project_id}}/notifications/
    config_test.go:42: DWS endpoint:     https://dws.eu-west-0.prod-cloud-ocb.orange-business.com/v1.0/{{project_id}}/
--- PASS: TestAccServiceEndpoints_EnterpriseIntelligence (5.58s)
=== RUN   TestAccServiceEndpoints_Others
2022/03/17 18:49:42 [DEBUG] FlexibleEngine Region is: eu-west-0
    config_test.go:42: DRS endpoint:     https://evs.eu-west-0.prod-cloud-ocb.orange-business.com/v2/{{project_id}}/
2022/03/17 18:49:42 [DEBUG] FlexibleEngine Region is: eu-west-0
    config_test.go:42: SDRS endpoint:    https://sdrs.eu-west-0.prod-cloud-ocb.orange-business.com/v1/{{project_id}}/
2022/03/17 18:49:42 [DEBUG] FlexibleEngine Region is: eu-west-0
    config_test.go:42: RTS endpoint:     https://rts.eu-west-0.prod-cloud-ocb.orange-business.com/v1/{{project_id}}/
--- PASS: TestAccServiceEndpoints_Others (6.97s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 49.328s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccFlexibleEngineVpcSubnetV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccFlexibleEngineVpcSubnetV1_basic -timeout 720m
=== RUN   TestAccFlexibleEngineVpcSubnetV1_basic
--- PASS: TestAccFlexibleEngineVpcSubnetV1_basic (181.58s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 181.653s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDisStreamV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDisStreamV2_basic -timeout 720m
=== RUN   TestAccDisStreamV2_basic
=== PAUSE TestAccDisStreamV2_basic
=== CONT  TestAccDisStreamV2_basic
--- PASS: TestAccDisStreamV2_basic (81.11s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 81.158s
```