### PR TITLE
feat: support cloud parameter in provider

### DIFF
--- a/flexibleengine/config_test.go
+++ b/flexibleengine/config_test.go
@@ -62,7 +62,7 @@ func TestAccServiceEndpoints_Global(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine identity client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://iam.%s.%s/v3/", OS_REGION_NAME, defaultCloud)
+	expectedURL = fmt.Sprintf("https://iam.%s.%s/v3/", OS_REGION_NAME, config.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "Identity v3")
 
@@ -70,7 +70,7 @@ func TestAccServiceEndpoints_Global(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine IAM client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://iam.%s.%s/v3.0/", OS_REGION_NAME, defaultCloud)
+	expectedURL = fmt.Sprintf("https://iam.%s.%s/v3.0/", OS_REGION_NAME, config.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "IAM v3.0")
 }
@@ -95,7 +95,7 @@ func TestAccServiceEndpoints_Management(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine CTS client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://cts.%s.%s/v1.0/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://cts.%s.%s/v1.0/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "CTS")
 
@@ -104,7 +104,7 @@ func TestAccServiceEndpoints_Management(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine CES client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://ces.%s.%s/V1.0/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://ces.%s.%s/V1.0/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "CES")
 }
@@ -132,7 +132,7 @@ func TestAccServiceEndpoints_Compute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine ecs v1 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://ecs.%s.%s/v1/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://ecs.%s.%s/v1/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "ECS v1")
 
@@ -142,7 +142,7 @@ func TestAccServiceEndpoints_Compute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine ecs v2 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://ecs.%s.%s/v2.1/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://ecs.%s.%s/v2.1/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "ecs v2")
 
@@ -152,7 +152,7 @@ func TestAccServiceEndpoints_Compute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine autoscaling v1 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://as.%s.%s/autoscaling-api/v1/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://as.%s.%s/autoscaling-api/v1/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "autoscaling v1")
 
@@ -162,7 +162,7 @@ func TestAccServiceEndpoints_Compute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine image v2 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://ims.%s.%s/v2/", OS_REGION_NAME, defaultCloud)
+	expectedURL = fmt.Sprintf("https://ims.%s.%s/v2/", OS_REGION_NAME, config.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "image v2")
 
@@ -172,7 +172,7 @@ func TestAccServiceEndpoints_Compute(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine cce v3 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://cce.%s.%s/api/v3/projects/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://cce.%s.%s/api/v3/projects/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "cce v3")
 }
@@ -200,7 +200,7 @@ func TestAccServiceEndpoints_Storage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine blockStorage v2 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://evs.%s.%s/v2/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://evs.%s.%s/v2/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "blockStorage v2")
 
@@ -210,7 +210,7 @@ func TestAccServiceEndpoints_Storage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine sfsV2 v2 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://sfs.%s.%s/v2/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://sfs.%s.%s/v2/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "sfsV2 v2")
 
@@ -220,7 +220,7 @@ func TestAccServiceEndpoints_Storage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine sfs turbo client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://sfs-turbo.%s.%s/v1/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://sfs-turbo.%s.%s/v1/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "sfs turbo")
 
@@ -230,7 +230,7 @@ func TestAccServiceEndpoints_Storage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine csbs v1 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://csbs.%s.%s/v1/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://csbs.%s.%s/v1/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "csbs v1")
 
@@ -240,7 +240,7 @@ func TestAccServiceEndpoints_Storage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine vbs v2 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://vbs.%s.%s/v2/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://vbs.%s.%s/v2/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "vbs v2")
 }
@@ -267,7 +267,7 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine networking v1 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://vpc.%s.%s/v1/", OS_REGION_NAME, defaultCloud)
+	expectedURL = fmt.Sprintf("https://vpc.%s.%s/v1/", OS_REGION_NAME, config.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "vpc v1")
 
@@ -277,7 +277,7 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine networking v2 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://vpc.%s.%s/v2.0/", OS_REGION_NAME, defaultCloud)
+	expectedURL = fmt.Sprintf("https://vpc.%s.%s/v2.0/", OS_REGION_NAME, config.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "networking v2.0")
 
@@ -287,7 +287,7 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine nat gateway client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://nat.%s.%s/v2.0/", OS_REGION_NAME, defaultCloud)
+	expectedURL = fmt.Sprintf("https://nat.%s.%s/v2.0/", OS_REGION_NAME, config.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "nat gateway v2")
 
@@ -297,7 +297,7 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine ELB/otc v1.0 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://elb.%s.%s/v1.0/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://elb.%s.%s/v1.0/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "elb/otc v1.0")
 
@@ -307,7 +307,7 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine ELB v2.0 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://elb.%s.%s/v2.0/", OS_REGION_NAME, defaultCloud)
+	expectedURL = fmt.Sprintf("https://elb.%s.%s/v2.0/", OS_REGION_NAME, config.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "ELB v2.0")
 
@@ -316,7 +316,7 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine DNS client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://dns.%s/v2/", defaultCloud)
+	expectedURL = fmt.Sprintf("https://dns.%s/v2/", config.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "DNS")
 
@@ -325,7 +325,7 @@ func TestAccServiceEndpoints_Network(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine VPC endpoint client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://vpcep.%s.%s/v1/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://vpcep.%s.%s/v1/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "VPCEP")
 }
@@ -350,7 +350,7 @@ func TestAccServiceEndpoints_Database(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine RDS v1 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://rds.%s.%s/rds/v1/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://rds.%s.%s/rds/v1/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "RDS v1")
 
@@ -359,7 +359,7 @@ func TestAccServiceEndpoints_Database(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine RDS v3 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://rds.%s.%s/v3/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://rds.%s.%s/v3/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "RDS v3")
 
@@ -368,7 +368,7 @@ func TestAccServiceEndpoints_Database(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine DDS v3 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://dds.%s.%s/v3/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://dds.%s.%s/v3/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "DDS v3")
 }
@@ -393,7 +393,7 @@ func TestAccServiceEndpoints_Security(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine anti-ddos client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://antiddos.%s.%s/v1/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://antiddos.%s.%s/v1/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "anti-ddos")
 
@@ -402,7 +402,7 @@ func TestAccServiceEndpoints_Security(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine KMS client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://kms.%s.%s/v1.0/", OS_REGION_NAME, defaultCloud)
+	expectedURL = fmt.Sprintf("https://kms.%s.%s/v1.0/", OS_REGION_NAME, config.Cloud)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "KMS")
 }
@@ -427,7 +427,7 @@ func TestAccServiceEndpoints_Application(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine DCS v1 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://dcs.%s.%s/v1.0/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://dcs.%s.%s/v1.0/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "DCS v1")
 
@@ -435,7 +435,7 @@ func TestAccServiceEndpoints_Application(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine CSS v1 client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://css.%s.%s/v1.0/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://css.%s.%s/v1.0/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "CSS v1")
 
@@ -461,7 +461,7 @@ func TestAccServiceEndpoints_EnterpriseIntelligence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine MRS client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://mrs.%s.%s/v1.1/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://mrs.%s.%s/v1.1/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "MRS")
 
@@ -469,7 +469,7 @@ func TestAccServiceEndpoints_EnterpriseIntelligence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine MLS client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://mls.%s.%s/v1.0/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://mls.%s.%s/v1.0/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "MLS")
 
@@ -478,7 +478,7 @@ func TestAccServiceEndpoints_EnterpriseIntelligence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine SMN client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://smn.%s.%s/v2/%s/notifications/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://smn.%s.%s/v2/%s/notifications/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "SMN v2")
 
@@ -487,7 +487,7 @@ func TestAccServiceEndpoints_EnterpriseIntelligence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine DWS client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://dws.%s.%s/v1.0/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://dws.%s.%s/v1.0/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "DWS")
 }
@@ -512,7 +512,7 @@ func TestAccServiceEndpoints_Others(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine DRS client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://evs.%s.%s/v2/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://evs.%s.%s/v2/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "DRS")
 
@@ -521,7 +521,7 @@ func TestAccServiceEndpoints_Others(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine SDRS client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://sdrs.%s.%s/v1/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://sdrs.%s.%s/v1/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "SDRS")
 
@@ -530,7 +530,7 @@ func TestAccServiceEndpoints_Others(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating FlexibleEngine RTS client: %s", err)
 	}
-	expectedURL = fmt.Sprintf("https://rts.%s.%s/v1/%s/", OS_REGION_NAME, defaultCloud, config.TenantID)
+	expectedURL = fmt.Sprintf("https://rts.%s.%s/v1/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "RTS")
 }

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -133,6 +133,13 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("OS_AUTH_URL", nil),
 			},
 
+			"cloud": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: descriptions["cloud"],
+				DefaultFunc: schema.EnvDefaultFunc("OS_CLOUD", defaultCloud),
+			},
+
 			"insecure": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -411,6 +418,8 @@ func init() {
 		"cert": "A client certificate to authenticate with.",
 
 		"key": "A client private key to authenticate with.",
+
+		"cloud": "The endpoint of cloud provider, defaults to prod-cloud-ocb.orange-business.com",
 	}
 }
 
@@ -418,6 +427,7 @@ func configureProvider(_ context.Context, d *schema.ResourceData) (interface{}, 
 	config := Config{}
 
 	region := d.Get("region").(string)
+	cloud := d.Get("cloud").(string)
 	config.Region = region
 
 	config.TenantID = d.Get("tenant_id").(string)
@@ -430,7 +440,7 @@ func configureProvider(_ context.Context, d *schema.ResourceData) (interface{}, 
 	if v, ok := d.GetOk("auth_url"); ok {
 		config.IdentityEndpoint = v.(string)
 	} else {
-		config.IdentityEndpoint = fmt.Sprintf("https://iam.%s.%s/v3", region, defaultCloud)
+		config.IdentityEndpoint = fmt.Sprintf("https://iam.%s.%s/v3", region, cloud)
 	}
 
 	config.DomainID = d.Get("domain_id").(string)
@@ -449,7 +459,7 @@ func configureProvider(_ context.Context, d *schema.ResourceData) (interface{}, 
 	config.ClientCertFile = d.Get("cert").(string)
 	config.ClientKeyFile = d.Get("key").(string)
 	config.TerraformVersion = terraformVersion
-	config.Cloud = defaultCloud
+	config.Cloud = cloud
 	config.RegionClient = true
 	config.RegionProjectIDMap = make(map[string]string)
 	config.RPLock = new(sync.Mutex)


### PR DESCRIPTION
`cloud` parameter can specify the endpoint of cloud, and defaults to prod-cloud-ocb.orange-business.com.
usage:
```
provider "flexibleengine" {
  ...
  cloud = "your_cloud_endpoint.com"
}
```