### PR TITLE
fix(cts): check length to avoid index out of range

### DIFF
--- a/docs/data-sources/cts_tracker_v1.md
+++ b/docs/data-sources/cts_tracker_v1.md
@@ -8,29 +8,27 @@ CTS Tracker data source allows access of Cloud Tracker.
 
 ## Example Usage
 
-
 ```hcl
 variable "bucket_name" { }
 
 data "flexibleengine_cts_tracker_v1" "tracker_v1" {
-  bucket_name = "${var.bucket_name}"
+  bucket_name = var.bucket_name
 }
 
 ```
 
 ## Argument Reference
+
 The following arguments are supported:
 
-* `tracker_name` - (Optional) The tracker name. 
+* `tracker_name` - (Optional) The tracker name.
 
 * `bucket_name` - (Optional) The OBS bucket name for a tracker.
 
-* `file_prefix_name` - (Optional) The prefix of a log that needs to be stored in an OBS bucket. 
+* `file_prefix_name` - (Optional) The prefix of a log that needs to be stored in an OBS bucket.
 
-* `status` - (Optional) Status of a tracker. 
-
+* `status` - (Optional) Status of a tracker.
 
 ## Attributes Reference
 
 All above argument parameters can be exported as attribute parameters.
-    

--- a/docs/resources/cts_tracker_v1.md
+++ b/docs/resources/cts_tracker_v1.md
@@ -13,25 +13,27 @@ Allows you to collect, store, and query cloud resource operation records.
  
  resource "flexibleengine_cts_tracker_v1" "tracker_v1" {
   bucket_name      = var.bucket_name
-  file_prefix_name = "yO8Q"
+  file_prefix_name = "tracker"
  }
 
  ```
+
 ## Argument Reference
+
 The following arguments are supported:
 
 * `bucket_name` - (Required) The OBS bucket name for a tracker.
 
-* `file_prefix_name` - (Optional) The prefix of a log that needs to be stored in an OBS bucket. 
+* `file_prefix_name` - (Optional) The prefix of a log that needs to be stored in an OBS bucket.
 
-* `status` - The status of a tracker. The value should be **enabled** when creating a tracker, and when updating the value can be enabled or disabled.
-
+* `status` - The status of a tracker. The value should be **enabled** when creating a tracker,
+  and can be enabled or disabled when updating it.
 
 ## Attributes Reference
+
 In addition to all arguments above, the following attributes are exported:
 
 * `tracker_name` - The tracker name. Currently, only tracker **system** is available.
-
 
 ## Import
 
@@ -40,7 +42,3 @@ CTS tracker can be imported using  `tracker_name`, e.g.
 ```
 $ terraform import flexibleengine_cts_tracker_v1.tracker system
 ```
-
-
-
-

--- a/flexibleengine/data_source_flexibleengine_cts_tracker_v1.go
+++ b/flexibleengine/data_source_flexibleengine_cts_tracker_v1.go
@@ -45,7 +45,8 @@ func dataSourceCTSTrackerV1() *schema.Resource {
 
 func dataSourceCTSTrackerV1Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	trackerClient, err := config.CtsV1Client(GetRegion(d, config))
+	region := GetRegion(d, config)
+	trackerClient, err := config.CtsV1Client(region)
 	if err != nil {
 		return fmt.Errorf("Error creating CTS client: %s", err)
 	}
@@ -58,7 +59,6 @@ func dataSourceCTSTrackerV1Read(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	refinedTrackers, err := tracker.List(trackerClient, listOpts)
-
 	if err != nil {
 		return fmt.Errorf("Unable to retrieve cts tracker: %s", err)
 	}
@@ -74,17 +74,15 @@ func dataSourceCTSTrackerV1Read(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	trackers := refinedTrackers[0]
-
 	log.Printf("[INFO] Retrieved cts tracker %s using given filter", trackers.TrackerName)
 
 	d.SetId(trackers.TrackerName)
 
+	d.Set("region", region)
 	d.Set("tracker_name", trackers.TrackerName)
 	d.Set("bucket_name", trackers.BucketName)
 	d.Set("file_prefix_name", trackers.FilePrefixName)
 	d.Set("status", trackers.Status)
-
-	d.Set("region", GetRegion(d, config))
 
 	return nil
 }

--- a/flexibleengine/data_source_flexibleengine_cts_tracker_v1_test.go
+++ b/flexibleengine/data_source_flexibleengine_cts_tracker_v1_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccCTSTrackerV1DataSource_basic(t *testing.T) {
-	var bucketName = fmt.Sprintf("terra-test-%s", acctest.RandString(5))
+	var bucketName = fmt.Sprintf("acc-test-%s", acctest.RandString(5))
 	dataName := "data.flexibleengine_cts_tracker_v1.tracker_v1"
 
 	resource.Test(t, resource.TestCase{
@@ -54,7 +54,6 @@ resource "flexibleengine_obs_bucket" "bucket" {
 
 resource "flexibleengine_cts_tracker_v1" "tracker_v1" {
   bucket_name      = flexibleengine_obs_bucket.bucket.bucket
-  file_prefix_name = "yO8Q"
 }
 
 data "flexibleengine_cts_tracker_v1" "tracker_v1" {  

--- a/flexibleengine/resource_flexibleengine_cts_tracker_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_cts_tracker_v1_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/cts/v1/tracker"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -13,7 +12,7 @@ import (
 
 func TestAccCTSTrackerV1_basic(t *testing.T) {
 	var tracker tracker.Tracker
-	var bucketName = fmt.Sprintf("terra-test-%s", acctest.RandString(5))
+	var bucketName = fmt.Sprintf("acc-test-%s", acctest.RandString(5))
 	resourceName := "flexibleengine_cts_tracker_v1.tracker_v1"
 
 	resource.Test(t, resource.TestCase{
@@ -26,7 +25,7 @@ func TestAccCTSTrackerV1_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCTSTrackerV1Exists(resourceName, &tracker),
 					resource.TestCheckResourceAttr(resourceName, "bucket_name", bucketName),
-					resource.TestCheckResourceAttr(resourceName, "file_prefix_name", "yO8Q"),
+					resource.TestCheckResourceAttr(resourceName, "file_prefix_name", "tracker"),
 				),
 			},
 			{
@@ -50,12 +49,9 @@ func testAccCheckCTSTrackerV1Destroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := tracker.List(ctsClient, tracker.ListOpts{TrackerName: rs.Primary.ID})
-		if err != nil {
+		trackerList, _ := tracker.List(ctsClient, tracker.ListOpts{TrackerName: rs.Primary.ID})
+		if len(trackerList) != 0 {
 			return fmt.Errorf("cts tracker still exists")
-		}
-		if _, ok := err.(golangsdk.ErrDefault404); !ok {
-			return err
 		}
 	}
 
@@ -83,6 +79,11 @@ func testAccCheckCTSTrackerV1Exists(n string, trackers *tracker.Tracker) resourc
 		if err != nil {
 			return err
 		}
+
+		if len(trackerList) == 0 {
+			return fmt.Errorf("can not find cts tracker %s", rs.Primary.ID)
+		}
+
 		found := trackerList[0]
 		if found.TrackerName != rs.Primary.ID {
 			return fmt.Errorf("cts tracker not found")
@@ -104,7 +105,7 @@ resource "flexibleengine_obs_bucket" "bucket" {
 
 resource "flexibleengine_cts_tracker_v1" "tracker_v1" {
   bucket_name      = flexibleengine_obs_bucket.bucket.bucket
-  file_prefix_name = "yO8Q"
+  file_prefix_name = "tracker"
 }
 `, bucketName)
 }

--- a/flexibleengine/resource_flexibleengine_obs_bucket.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket.go
@@ -1170,15 +1170,17 @@ func deleteAllBucketObjects(obsClient *obs.ObsClient, bucket string) error {
 	}
 
 	objects := make([]obs.ObjectToDelete, len(resp.Contents))
+	allKeys := make([]string, len(resp.Contents))
 	for i, content := range resp.Contents {
 		objects[i].Key = content.Key
+		allKeys[i] = content.Key
 	}
 
 	deleteOpts := &obs.DeleteObjectsInput{
 		Bucket:  bucket,
 		Objects: objects,
 	}
-	log.Printf("[DEBUG] objects of %s will be deleted: %v", bucket, objects)
+	log.Printf("[DEBUG] objects of %s will be deleted: %v", bucket, allKeys)
 	output, err := obsClient.DeleteObjects(deleteOpts)
 	if err != nil {
 		return getObsError("Error deleting all objects of OBS bucket", bucket, err)


### PR DESCRIPTION
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCTSTrackerV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCTSTrackerV1_basic -timeout 720m
=== RUN   TestAccCTSTrackerV1_basic
--- PASS: TestAccCTSTrackerV1_basic (108.28s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 108.338s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCTSTrackerV1DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCTSTrackerV1DataSource_basic -timeout 720m
=== RUN   TestAccCTSTrackerV1DataSource_basic
--- PASS: TestAccCTSTrackerV1DataSource_basic (93.52s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 93.566s
```