### PR TITLE
feat: support FunctionGraph service

### DIFF
--- a/docs/data-sources/fgs_dependencies.md
+++ b/docs/data-sources/fgs_dependencies.md
@@ -1,0 +1,70 @@
+---
+subcategory: "FunctionGraph"
+---
+
+# flexibleengine_fgs_dependencies
+
+Use this data source to filter dependent packages of FGS from FlexibleEngine.
+
+## Example Usage
+
+### Obtain all public dependent packages
+
+```hcl
+data "flexibleengine_fgs_dependencies" "test" {}
+```
+
+### Obtain specific public dependent package by name
+
+```hcl
+data "flexibleengine_fgs_dependencies" "test" {
+  type = "public"
+  name = "obssdk"
+}
+```
+
+### Obtain all public Python2.7 dependent packages
+
+```hcl
+data "flexibleengine_fgs_dependencies" "test" {
+  type    = "public"
+  runtime = "Python2.7"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region in which to obtain the dependent packages. If omitted, the
+  provider-level region will be used.
+
+* `type` - (Optional, String) Specifies the dependent package type to match. Valid values: **public** and **private**.
+
+* `runtime` - (Optional, String) Specifies the dependent package runtime to match. Valid values: **Java8**,
+  **Node.js6.10**, **Node.js8.10**, **Node.js10.16**, **Node.js12.13**, **Python2.7**, **Python3.6**, **Go1.8**,
+  **Go1.x**, **C#(.NET Core 2.0)**, **C#(.NET Core 2.1)**, **C#(.NET Core 3.1)** and **PHP7.3**.
+
+* `name` - (Optional, String) Specifies the dependent package runtime to match.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A data source ID.
+
+* `packages` - All dependent packages that match.
+
+  + `id` - Dependent package ID.
+
+  + `name` - Dependent package name.
+
+  + `owner` - Dependent package owner.
+
+  + `link` - URL of the dependent package in the OBS console.
+
+  + `etag` - Unique ID of the dependent package.
+
+  + `size` - Dependent package size.
+
+  + `file_name` - File name of the Dependent package.
+
+  + `runtime` - Dependent package runtime.

--- a/docs/resources/fgs_dependency.md
+++ b/docs/resources/fgs_dependency.md
@@ -1,0 +1,75 @@
+---
+subcategory: "FunctionGraph"
+---
+
+# flexibleengine_fgs_dependency
+
+Manages a custom dependency package within FlexibleEngine FunctionGraph.
+
+## Example Usage
+
+### Create a custom dependency package using a OBS bucket path where the zip file is located
+
+```hcl
+variable "package_name"
+variable "package_location"
+variable "dependency_name"
+
+resource "flexibleengine_obs_bucket" "test" {
+  ...
+}
+
+resource "flexibleengine_obs_bucket_object" "test" {
+  bucket = flexibleengine_obs_bucket.test.bucket
+  key    = format("terraform_dependencies/%s", var.package_name)
+  source = var.package_location
+}
+
+resource "flexibleengine_fgs_dependency" "test" {
+  name    = var.dependency_name
+  runtime = "Python3.6"
+  link    = format("https://%s/%s", flexibleengine_obs_bucket.test.bucket_domain_name, flexibleengine_obs_bucket_object.test.key)
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create a custom dependency package.
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `runtime` - (Required, String) Specifies the dependency package runtime.
+  The valid values are **Java8**, **Node.js6.10**, **Node.js8.10**, **Node.js10.16**, **Node.js12.13**, **Python2.7**,
+  **Python3.6**, **Go1.8**, **Go1.x**, **C#(.NET Core 2.0)**, **C#(.NET Core 2.1)**, **C#(.NET Core 3.1)** and
+  **PHP7.3**.
+
+* `name` - (Required, String) Specifies the dependeny name.
+  The name can contain a maximum of 96 characters and must start with a letter and end with a letter or digit.
+  Only letters, digits, underscores (_), periods (.), and hyphens (-) are allowed.
+
+* `link` - (Required, String) Specifies the OBS bucket path where the dependency package is located. The OBS object URL
+  must be in zip format, such as 'https://obs-terraform.oss.eu-west-0.prod-cloud-ocb.orange-business.com/dependencies/sdkcore.zip'.
+
+-> A link can only be used to create at most one dependency package.
+
+* `description` - (Optional, String) Specifies the dependency description.
+  The description can contain a maximum of 512 characters.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The dependency ID in UUID format.
+
+* `owner` - The base64 encoded digest of the dependency after encryption by MD5.
+
+* `etag` - The unique ID of the dependency package.
+
+* `size` - The dependency package size in bytes.
+
+## Import
+
+Dependencies can be imported using the `id`, e.g.:
+
+```
+$ terraform import flexibleengine_fgs_dependency.test 795e722f-0c23-41b6-a189-dcd56f889cf6
+```

--- a/docs/resources/fgs_function.md
+++ b/docs/resources/fgs_function.md
@@ -1,0 +1,252 @@
+---
+subcategory: "FunctionGraph"
+---
+
+# flexibleengine_fgs_function
+
+Manages a Function resource within FlexibleEngine.
+
+## Example Usage
+
+### With base64 func code
+
+```hcl
+resource "flexibleengine_fgs_function" "f_1" {
+  name        = "func_1"
+  app         = "default"
+  agency      = "test"
+  description = "fuction test"
+  handler     = "test.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGV2ZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
+}
+```
+
+### With text code
+
+```hcl
+resource "flexibleengine_fgs_function" "f_1" {
+  name        = "func_1"
+  app         = "default"
+  agency      = "test"
+  description = "fuction test"
+  handler     = "test.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = <<EOF
+# -*- coding:utf-8 -*-
+import json
+def handler (event, context):
+    return {
+        "statusCode": 200,
+        "isBase64Encoded": False,
+        "body": json.dumps(event),
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+EOF
+}
+```
+
+### With agency, vpc, subnet and func_mounts
+
+```hcl
+resource "flexibleengine_vpc_v1" "test" {
+  name = vpc_1
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test" {
+  name       = "subnet_1"
+  cidr       = "192.168.1.0/24"
+  gateway_ip = "192.168.1.1"
+  vpc_id     = flexibleengine_vpc_v1.test.id
+}
+
+resource "flexibleengine_sfs_file_system_v2" "test" {
+  share_proto = "NFS"
+  size        = 10
+  name        = "sfs_1"
+  description = "test sfs for fgs"
+}
+
+resource "flexibleengine_identity_agency_v3" "test" {
+  name                   = "agency_1"
+  description            = "test agency for fgs"
+  delegated_service_name = "op_svc_cff"
+
+  project_role {
+    project = "eu-west-0"
+    roles   = [
+      "VPC Administrator",
+      "SFS Administrator",
+    ]
+  }
+}
+
+resource "flexibleengine_fgs_function" "test" {
+  name        = "func_1"
+  package     = "default"
+  description = "fuction test"
+  handler     = "test.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGV2ZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
+  agency      = flexibleengine_identity_agency_v3.test.name
+  vpc_id      = flexibleengine_vpc_v1.test.id
+  network_id  = flexibleengine_vpc_subnet_v1.test.id
+
+  func_mounts {
+    mount_type       = "sfs"
+    mount_resource   = flexibleengine_sfs_file_system_v2.test.id
+    mount_share_path = flexibleengine_sfs_file_system_v2.test.export_location
+    local_mount_path = "/mnt"
+  }
+}
+```
+
+### With agency, user_data for environment variables and OBS for code storage
+
+```hcl
+variable code_url {}
+
+resource "flexibleengine_identity_agency_v3" "agency" {
+  name                   = "fgs_obs_agency"
+  description            = "Delegate OBS access to FGS"
+  delegated_service_name = "op_svc_cff"
+  domain_roles           = ["OBS OperateAccess"]
+}
+
+resource "flexibleengine_fgs_function" "function" {
+  name        = "test_function"
+  app         = "default"
+  description = "test function"
+  handler     = "index.handler"
+  agency      = flexibleengine_identity_agency_v3.agency.name
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Node.js6.10"
+  code_type   = "obs"
+  code_url    = var.code_url
+
+  user_data = jsonencode({
+    environmentVariable1 = "someValue"
+    environmentVariable2 = "5"
+  })
+
+  encrypted_user_data = jsonencode({
+    secret_key = "xxxxxxx"
+  })
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the Function resource. If omitted, the
+  provider-level region will be used. Changing this creates a new Function resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the function.
+
+* `app` - (Required, String) Specifies the group to which the function belongs.
+
+* `handler` - (Required, String) Specifies the entry point of the function.
+
+* `memory_size` - (Required, Int) Specifies the memory size(MB) allocated to the function.
+
+* `runtime` - (Required, String, ForceNew) Specifies the environment for executing the function. Changing this creates a
+  new Function resource.
+
+* `timeout` - (Required, Int) Specifies the timeout interval of the function, ranges from 3s to 900s.
+
+* `code_type` - (Required, String) Specifies the function code type, which can be inline: inline code, zip: ZIP file,
+  jar: JAR file or java functions, obs: function code stored in an OBS bucket.
+
+* `func_code` - (Optional, String) Specifies the function code. When code_type is set to inline, zip, or jar, this
+  parameter is mandatory, and the code can be encoded using Base64 or just with the text code.
+
+* `code_url` - (Optional, String) Specifies the code url. This parameter is mandatory when code_type is set to obs.
+
+* `code_filename` - (Optional, String) Specifies the name of a function file, This field is mandatory only when coe_type
+  is set to jar or zip.
+
+* `depend_list` - (Optional, String) Specifies the ID list of the dependencies.
+
+* `user_data` - (Optional, String) Specifies the Key/Value information defined for the function. Key/value data might be
+  parsed with [Terraform `jsonencode()` function]('https://www.terraform.io/docs/language/functions/jsonencode.html').
+
+* `encrypted_user_data` - (Optional, String) Specifies the key/value information defined to be encrypted for the
+  function. The format is the same as `user_data`.
+
+* `agency` - (Optional, String) Specifies the agency. This parameter is mandatory if the function needs to access other
+  cloud services.
+
+* `app_agency` - (Optional, String) Specifies An execution agency enables you to obtain a token or an AK/SK for
+  accessing other cloud services.
+
+* `description` - (Optional, String) Specifies the description of the function.
+
+* `initializer_handler` - (Optional, String) Specifies the initializer of the function.
+
+* `initializer_timeout` - (Optional, Int) Specifies the maximum duration the function can be initialized. Value range:
+  1s to 300s.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the function. Changing
+  this creates a new function.
+
+* `vpc_id`  - (Optional, String) Specifies the ID of VPC.
+
+* `network_id`  - (Optional, String) Specifies the network ID of subnet.
+
+-> **NOTE:** An agency with VPC management permissions must be specified for the function.
+
+* `mount_user_id` - (Optional, String) Specifies the user ID, a non-0 integer from –1 to 65534. Default to -1.
+
+* `mount_user_group_id` - (Optional, String) Specifies the user group ID, a non-0 integer from –1 to 65534. Default to
+  -1.
+
+* `func_mounts` - (Optional, List) Specifies the file system list. The `func_mounts` object structure is documented
+  below.
+
+The `func_mounts` block supports:
+
+* `mount_type` - (Required, String) Specifies the mount type. Options: sfs, sfsTurbo, and ecs.
+
+* `mount_resource` - (Required, String) Specifies the ID of the mounted resource (corresponding cloud service).
+
+* `mount_share_path` - (Required, String) Specifies the remote mount path. Example: 192.168.0.12:/data.
+
+* `local_mount_path` - (Required, String) Specifies the function access path.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+* `func_mounts/status` - The status of file system.
+* `urn` - Uniform Resource Name
+* `version` - The version of the function
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `delete` - Default is 10 minute.
+
+## Import
+
+Functions can be imported using the `id`, e.g.
+
+```
+$ terraform import flexibleengine_fgs_function.my-func 7117d38e-4c8f-4624-a505-bd96b97d024c
+```

--- a/docs/resources/fgs_trigger.md
+++ b/docs/resources/fgs_trigger.md
@@ -1,0 +1,275 @@
+---
+subcategory: "FunctionGraph"
+---
+
+# flexibleengine_fgs_trigger
+
+Manages a trigger resource within FlexibleEngine FunctionGraph.
+
+## Example Usage
+
+### Create a Timing Trigger with rate schedule type
+
+```hcl
+variable "function_urn" {}
+variable "trigger_name" {}
+
+resource "flexibleengine_fgs_trigger" "test" {
+  function_urn = var.function_urn
+  type         = "TIMER"
+
+  timer {
+    name          = var.trigger_name
+    schedule_type = "Rate"
+    schedule      = "1d"
+  }
+}
+```
+
+### Create a Timing Trigger with cron schedule type
+
+```hcl
+variable "function_urn" {}
+variable "trigger_name" {}
+
+resource "flexibleengine_fgs_trigger" "test" {
+  function_urn = var.function_urn
+  type         = "TIMER"
+
+  timer {
+    name          = var.trigger_name
+    schedule_type = "Cron"
+    schedule      = "@every 1h30m"
+  }
+}
+```
+
+### Create an OBS trigger
+
+```hcl
+variable "function_urn" {}
+variable "bucket_name" {}
+variable "trigger_name" {}
+
+resource "flexibleengine_fgs_trigger" "test" {
+  function_urn = var.function_urn
+  type         = "OBS"
+  status       = "ACTIVE"
+
+  obs {
+    bucket_name             = var.bucket_name
+    event_notification_name = var.trigger_name
+    suffix                  = ".json"
+
+    events = ["ObjectCreated"]
+  }
+}
+```
+
+### Create an SMN trigger
+
+```hcl
+variable "function_urn" {}
+variable "topic_urn" {}
+
+resource "flexibleengine_fgs_trigger" "test" {
+  function_urn = var.function_urn
+  type         = "SMN"
+  status       = "ACTIVE"
+
+  smn {
+    topic_urn = var.topic_urn
+  }
+}
+```
+
+### Create a DIS trigger
+
+```hcl
+variable "function_urn" {}
+variable "stream_name" {}
+
+resource "flexibleengine_fgs_trigger" "test" {
+  function_urn = var.function_urn
+  type         = "DIS"
+  status       = "ACTIVE"
+
+  dis {
+    stream_name       = var.stream_name
+    starting_position = "TRIM_HORIZON"
+    max_fetch_bytes   = 2097152
+    pull_period       = 30000
+    serial_enable     = true
+  }
+}
+```
+
+### Create a Shared APIG trigger
+
+```hcl
+variable "function_urn" {}
+variable "group_id" {}
+variable "api_name" {}
+
+resource "flexibleengine_fgs_trigger" "test" {
+  function_urn = var.function_urn
+  type         = "APIG"
+  status       = "ACTIVE"
+
+  apig {
+    group_id = var.group_id
+    api_name = var.api_name
+    env_name = "RELEASE"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the trigger resource.
+  If omitted, the provider-level region will be used.
+  Changing this will create a new trigger resource.
+
+* `function_urn` - (Required, String, ForceNew) Specifies the Uniform Resource Name (URN) of the function.
+  Changing this will create a new trigger resource.
+
+* `type` - (Required, String, ForceNew) Specifies the type of the function.
+  The valid values currently only support **TIMER**, **OBS**, **SMN**, **DIS**, and **APIG**.
+  Changing this will create a new trigger resource.
+
+* `status` - (Optional, String) Specifies whether trigger is enabled. The valid values are **ACTIVE** and **DISABLED**.
+
+  -> **NOTE:** Currently, SMN triggers do not support `status`, and OBS triggers do not support updating `status`.
+
+* `timer` - (Optional, List, ForceNew) Specifies the configuration of the timing trigger.
+  Changing this will create a new trigger resource.
+  The [object](#fgs_trigger_timer) structure is documented below.
+
+* `obs` - (Optional, List, ForceNew) Specifies the configuration of the OBS trigger.
+  Changing this will create a new trigger resource.
+  The [object](#fgs_trigger_obs) structure is documented below.
+
+* `smn` - (Optional, List, ForceNew) Specifies the configuration of the SMN trigger.
+  Changing this will create a new trigger resource.
+  The [object](#fgs_trigger_smn) structure is documented below.
+
+* `dis` - (Optional, List, ForceNew) Specifies the configuration of the DIS trigger.
+  Changing this will create a new trigger resource.
+  The [object](#fgs_trigger_dis) structure is documented below.
+
+  -> **NOTE:** Specify an agency with DIS access permissions for the function version before you can create a DIS
+  trigger.
+
+* `apig` - (Optional, List, ForceNew) Specifies the configuration of the shared APIG trigger.
+  Changing this will create a new trigger resource.
+  The [object](#fgs_trigger_apig) structure is documented below.
+
+<a name="fgs_trigger_timer"></a>
+The `timer` block supports:
+
+* `name` - (Required, String, ForceNew) Specifies the trigger name, which can contains of 1 to 64 characters.
+  The name must start with a letter, only letters, digits, hyphens (-) and underscores (_) are allowed.
+  Changing this will create a new trigger resource.
+
+* `schedule_type` - (Required, String, ForceNew) Specifies the type of the time schedule.
+  The valid values are **Rate** and **Cron**.
+  Changing this will create a new trigger resource.
+
+* `schedule` - (Required, String, ForceNew) Specifies the time schedule.
+  For the rate type, schedule is composed of time and time unit.
+  The time unit supports minutes (m), hours (h) and days (d).
+  For the corn expression, please refer to the
+  [User Guide](https://docs.prod-cloud-ocb.orange-business.com/usermanual/functiongraph/functiongraph_01_0908.html).
+  Changing this will create a new trigger resource.
+
+* `additional_information` - (Optional, String, ForceNew) Specifies the event used by the timer to trigger the function.
+  Changing this will create a new trigger resource.
+
+<a name="fgs_trigger_obs"></a>
+The `obs` block supports:
+
+* `bucket_name` - (Required, String, ForceNew) Specifies the OBS bucket name.
+  Changing this will create a new trigger resource.
+
+* `events` - (Required, List, ForceNew) Specifies the events that can trigger functions.
+  Changing this will create a new trigger resource.
+  The valid values are as follows:
+  + **ObjectCreated**, **Put**, **Post**, **Copy** and **CompleteMultipartUpload**.
+  + **ObjectRemoved**, **Delete** and **DeleteMarkerCreated**.
+
+  -> **NOTE:** If **ObjectCreated** is configured, **Put**, **Post**, **Copy** and **CompleteMultipartUpload** cannot
+  be configured. If **ObjectRemoved** is configured, **Delete** and **DeleteMarkerCreated** cannot be configured.
+
+* `event_notification_name` - (Required, String, ForceNew) Specifies the event notification name.
+  Changing this will create a new trigger resource.
+
+* `prefix` - (Optional, String, ForceNew) Specifies the prefix to limit notifications to objects beginning with this keyword.
+  Changing this will create a new trigger resource.
+
+* `suffix` - (Optional, String, ForceNew) Specifies the suffix to limit notifications to objects ending with this keyword.
+  Changing this will create a new trigger resource.
+
+<a name="fgs_trigger_smn"></a>
+The `smn` block supports:
+
+* `topic_urn` - (Required, String, ForceNew) Specifies the Uniform Resource Name (URN) for SMN topic.
+  Changing this will create a new trigger resource.
+
+<a name="fgs_trigger_dis"></a>
+The `dis` block supports:
+
+* `stream_name` - (Required, String, ForceNew) Specifies the name of the DIS stream resource.
+  Changing this will create a new trigger resource.
+
+* `starting_position` - (Required, String, ForceNew) Specifies the type of starting position for DIS queue.
+  The valid values are as follows:
+  + **TRIM_HORIZON**: Starts reading from the earliest data stored in the partitions.
+  + **LATEST**: Starts reading from the latest data stored in the partitions.
+  Changing this will create a new trigger resource.
+
+* `max_fetch_bytes` - (Required, Int, ForceNew) Specifies the maximum volume of data that can be obtained for a single
+  request, in Byte. Only the records with a size smaller than this value can be obtained.
+  The valid value is range from `1,024` to `4,194,304`.
+  Changing this will create a new trigger resource.
+
+* `pull_period` - (Required, Int, ForceNew) Specifies the interval at which data is pulled from the specified stream.
+  The valid value is range from `2` to `60,000`.
+  Changing this will create a new trigger resource.
+
+* `serial_enable` - (Required, Bool, ForceNew) Specifies the determines whether to pull data only after the data pulled
+  in the last period has been processed.
+  Changing this will create a new trigger resource.
+
+<a name="fgs_trigger_apig"></a>
+The `apig` block supports:
+
+* `group_id` - (Required, String, ForceNew) Specifies the ID of the APIG group to which the API belongs.
+  Changing this will create a new trigger resource.
+
+* `env_name` - (Required, String, ForceNew) Specifies the API environment name.
+  Changing this will create a new trigger resource.
+
+* `api_name` - (Required, String, ForceNew) Specifies the API name. Changing this will create a new trigger resource.
+
+* `security_authentication` - (Optional, String, ForceNew) Specifies the security authentication mode. The valid values
+  are **NONE**, **APP** and **IAM**, default to **IAM**. Changing this will create a new trigger resource.
+
+* `request_protocol` - (Optional, String, ForceNew) Specifies the request protocol of the API. The valid value are
+  **HTTP** and **HTTPS**. Default to **HTTPS**. Changing this will create a new trigger resource.
+
+* `timeout` - (Optional, Int, ForceNew) Specifies the timeout for request sending. The valid value is range form
+  `1` to `60,000`, default to `5,000`. Changing this will create a new trigger resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - resource ID in UUID format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `update` - Default is 2 minute.

--- a/flexibleengine/data_source_flexibleengine_fgs_dependencies_test.go
+++ b/flexibleengine/data_source_flexibleengine_fgs_dependencies_test.go
@@ -1,0 +1,88 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccFunctionGraphDependencies_basic(t *testing.T) {
+	dataSourceName := "data.flexibleengine_fgs_dependencies.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionGraphDependencies_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(dataSourceName, "packages.#", regexp.MustCompile(`[1-9][0-9]*`)),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFunctionGraphDependencies_name(t *testing.T) {
+	dataSourceName := "data.flexibleengine_fgs_dependencies.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionGraphDependencies_name(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "type", "public"),
+					resource.TestCheckResourceAttr(dataSourceName, "name", "obssdk"),
+					resource.TestCheckResourceAttr(dataSourceName, "packages.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFunctionGraphDependencies_runtime(t *testing.T) {
+	dataSourceName := "data.flexibleengine_fgs_dependencies.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionGraphDependencies_runtime(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dataSourceName, "type", "public"),
+					resource.TestCheckResourceAttr(dataSourceName, "runtime", "Python2.7"),
+					resource.TestMatchResourceAttr(dataSourceName, "packages.#", regexp.MustCompile(`[1-9][0-9]*`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccFunctionGraphDependencies_basic() string {
+	return fmt.Sprintf(`
+data "flexibleengine_fgs_dependencies" "test" {}
+`)
+}
+
+func testAccFunctionGraphDependencies_name() string {
+	return fmt.Sprintf(`
+data "flexibleengine_fgs_dependencies" "test" {
+  type = "public"
+  name = "obssdk"
+}
+`)
+}
+
+func testAccFunctionGraphDependencies_runtime() string {
+	return fmt.Sprintf(`
+data "flexibleengine_fgs_dependencies" "test" {
+  type    = "public"
+  runtime = "Python2.7"
+}
+`)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -7,7 +7,10 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 const (
@@ -17,6 +20,10 @@ const (
 
 // This is a global MutexKV for use within this plugin.
 var osMutexKV = mutexkv.NewMutexKV()
+
+func init() {
+	utils.PackageName = "FlexibleEngine"
+}
 
 // Provider returns a schema.Provider for FlexibleEngine.
 func Provider() *schema.Provider {
@@ -229,6 +236,9 @@ func Provider() *schema.Provider {
 			"flexibleengine_vpcep_public_services":              dataSourceVPCEPPublicServices(),
 			"flexibleengine_vpcep_endpoints":                    dataSourceVPCEPEndpoints(),
 
+			// importing data source
+			"flexibleengine_fgs_dependencies": fgs.DataSourceFunctionGraphDependencies(),
+
 			// Deprecated data source
 			"flexibleengine_dcs_az_v1":      dataSourceDcsAZV1(),
 			"flexibleengine_dds_flavor_v3":  dataSourceDDSFlavorV3(),
@@ -363,6 +373,11 @@ func Provider() *schema.Provider {
 			"flexibleengine_waf_rule_web_tamper_protection":     resourceWafRuleWebTamperProtection(),
 			"flexibleengine_dli_queue":                          ResourceDliQueueV1(),
 
+			// importing resource
+			"flexibleengine_fgs_dependency": fgs.ResourceFgsDependency(),
+			"flexibleengine_fgs_function":   fgs.ResourceFgsFunctionV2(),
+			"flexibleengine_fgs_trigger":    fgs.ResourceFunctionGraphTrigger(),
+
 			// Deprecated resource
 			"flexibleengine_elb_loadbalancer": resourceELoadBalancer(),
 			"flexibleengine_elb_listener":     resourceEListener(),
@@ -470,6 +485,7 @@ func configureProvider(_ context.Context, d *schema.ResourceData) (interface{}, 
 
 	config.Endpoints = make(map[string]string)
 	config.Endpoints["obs"] = fmt.Sprintf("https://oss.%s.%s/", region, config.Cloud)
+	config.Endpoints["fgs"] = fmt.Sprintf("https://fgs.%s.%s/", region, config.Cloud)
 	config.Endpoints["dns"] = fmt.Sprintf("https://dns.%s/", config.Cloud)
 
 	return &config, nil

--- a/flexibleengine/provider_test.go
+++ b/flexibleengine/provider_test.go
@@ -33,6 +33,7 @@ var (
 	OS_SDRS_ENVIRONMENT       = os.Getenv("OS_SDRS_ENVIRONMENT")
 	OS_DELEGATED_DOMAIN_NAME  = os.Getenv("OS_DELEGATED_DOMAIN_NAME")
 	OS_DESTINATION_BUCKET     = os.Getenv("OS_DESTINATION_BUCKET")
+	OS_FGS_BUCKET             = os.Getenv("OS_FGS_BUCKET")
 	OS_TENANT_NAME            = getTenantName()
 )
 

--- a/flexibleengine/resource_flexibleengine_fgs_dependency_test.go
+++ b/flexibleengine/resource_flexibleengine_fgs_dependency_test.go
@@ -1,0 +1,83 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/fgs/v2/dependencies"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getDependencyResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.FgsV2Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating FunctionGraph v2 client: %s", err)
+	}
+	return dependencies.Get(c, state.Primary.ID)
+}
+
+func TestAccFunctionGraphResourceDependency_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_fgs_dependency.test"
+	pkgLocation := fmt.Sprintf("https://%s.oss.%s.prod-cloud-ocb.orange-business.com/dependencies/sdkcore.zip",
+		OS_FGS_BUCKET, OS_REGION_NAME)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckS3(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionGraphResourceDependency_basic(rName, pkgLocation),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by terraform script"),
+					resource.TestCheckResourceAttr(resourceName, "runtime", "Python2.7"),
+					resource.TestCheckResourceAttr(resourceName, "link", pkgLocation),
+				),
+			},
+			{
+				Config: testAccFunctionGraphResourceDependency_update(rName, pkgLocation),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by terraform script"),
+					resource.TestCheckResourceAttr(resourceName, "runtime", "Python3.6"),
+					resource.TestCheckResourceAttr(resourceName, "link", pkgLocation),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccFunctionGraphResourceDependency_basic(rName, pkgLocation string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_fgs_dependency" "test" {
+  name        = "%s"
+  description = "Created by terraform script"
+  runtime     = "Python2.7"
+  link        = "%s"
+}
+`, rName, pkgLocation)
+}
+
+func testAccFunctionGraphResourceDependency_update(rName, pkgLocation string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_fgs_dependency" "test" {
+  name        = "%s_update"
+  description = "Updated by terraform script"
+  runtime     = "Python3.6"
+  link        = "%s"
+}
+`, rName, pkgLocation)
+}

--- a/flexibleengine/resource_flexibleengine_fgs_function_test.go
+++ b/flexibleengine/resource_flexibleengine_fgs_function_test.go
@@ -1,0 +1,239 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/fgs/v2/function"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getResourceObj(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.FgsV2Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating FunctionGraph client: %s", err)
+	}
+	return function.GetMetadata(c, state.Primary.ID).Extract()
+}
+
+func TestAccFgsV2Function_basic(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_fgs_function.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFgsV2Function_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "fuction test"),
+					resource.TestCheckResourceAttrSet(resourceName, "urn"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
+				),
+			},
+			{
+				Config: testAccFgsV2Function_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "fuction test update"),
+					resource.TestCheckResourceAttrSet(resourceName, "urn"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"app",
+					"package",
+					"func_code",
+				},
+			},
+		},
+	})
+}
+
+func TestAccFgsV2Function_text(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_fgs_function.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFgsV2Function_text(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "fuction test"),
+					resource.TestCheckResourceAttrSet(resourceName, "urn"),
+					resource.TestCheckResourceAttrSet(resourceName, "version"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"app",
+					"package",
+					"func_code",
+				},
+			},
+		},
+	})
+}
+
+func TestAccFgsV2Function_agency(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_fgs_function.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFgsV2Function_agency(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "agency", randName),
+					resource.TestCheckResourceAttr(resourceName, "func_mounts.0.mount_type", "sfs"),
+					resource.TestCheckResourceAttr(resourceName, "func_mounts.0.status", "active"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"xrole",
+					"agency",
+					"func_code",
+				},
+			},
+		},
+	})
+}
+
+func testAccFgsV2Function_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_fgs_function" "test" {
+  name        = "%s"
+  app         = "default"
+  description = "fuction test"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGV2ZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
+}
+`, rName)
+}
+
+func testAccFgsV2Function_update(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_fgs_function" "test" {
+  name        = "%s"
+  app         = "default"
+  description = "fuction test update"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGV2ZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
+}
+`, rName)
+}
+
+func testAccFgsV2Function_text(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_fgs_function" "test" {
+  name        = "%s"
+  app         = "default"
+  description = "fuction test"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+
+  func_code = <<EOF
+# -*- coding:utf-8 -*-
+import json
+def handler (event, context):
+    return {
+        "statusCode": 200,
+        "isBase64Encoded": False,
+        "body": json.dumps(event),
+        "headers": {
+            "Content-Type": "application/json"
+        }
+    }
+EOF
+}
+`, rName)
+}
+
+func testAccFgsV2Function_agency(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc_v1" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test" {
+  name       = "%s"
+  cidr       = "192.168.1.0/24"
+  gateway_ip = "192.168.1.1"
+  vpc_id     = flexibleengine_vpc_v1.test.id
+}
+
+resource "flexibleengine_sfs_file_system_v2" "test" {
+  share_proto = "NFS"
+  size        = 10
+  name        = "%s"
+  description = "test sfs for fgs"
+}
+
+resource "flexibleengine_identity_agency_v3" "test" {
+  name                   = "%s"
+  description            = "test agency for fgs"
+  delegated_service_name = "op_svc_cff"
+
+  project_role {
+    project = "%s"
+    roles = [
+      "VPC Administrator",
+      "SFS Administrator",
+    ]
+  }
+}
+
+resource "flexibleengine_fgs_function" "test" {
+  name        = "%s"
+  package     = "default"
+  description = "fuction test"
+  handler     = "test.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGV2ZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
+  agency      = flexibleengine_identity_agency_v3.test.name
+  vpc_id      = flexibleengine_vpc_v1.test.id
+  network_id  = flexibleengine_vpc_subnet_v1.test.id
+
+  func_mounts {
+    mount_type       = "sfs"
+    mount_resource   = flexibleengine_sfs_file_system_v2.test.id
+    mount_share_path = flexibleengine_sfs_file_system_v2.test.export_location
+    local_mount_path = "/mnt"
+  }
+}
+`, rName, rName, rName, rName, OS_REGION_NAME, rName)
+}

--- a/flexibleengine/resource_flexibleengine_fgs_trigger_test.go
+++ b/flexibleengine/resource_flexibleengine_fgs_trigger_test.go
@@ -1,0 +1,617 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/fgs/v2/trigger"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getTriggerResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.FgsV2Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating FunctionGraph v2 client: %s", err)
+	}
+	return trigger.Get(c, state.Primary.Attributes["function_urn"], state.Primary.Attributes["type"],
+		state.Primary.ID).Extract()
+}
+
+func TestAccFunctionGraphTrigger_basic(t *testing.T) {
+	var (
+		randName     = acceptance.RandomAccResourceName()
+		resourceName = "flexibleengine_fgs_trigger.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionGraphTimingTrigger_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "TIMER"),
+					resource.TestCheckResourceAttr(resourceName, "timer.0.name", randName),
+					resource.TestCheckResourceAttr(resourceName, "timer.0.schedule_type", "Rate"),
+					resource.TestCheckResourceAttr(resourceName, "timer.0.schedule", "3d"),
+					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_urn",
+						"flexibleengine_fgs_function.test", "urn"),
+				),
+			},
+			{
+				Config: testAccFunctionGraphTimingTrigger_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "TIMER"),
+					resource.TestCheckResourceAttr(resourceName, "timer.0.name", randName),
+					resource.TestCheckResourceAttr(resourceName, "timer.0.schedule_type", "Rate"),
+					resource.TestCheckResourceAttr(resourceName, "timer.0.schedule", "3d"),
+					resource.TestCheckResourceAttr(resourceName, "status", "DISABLED"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_urn",
+						"flexibleengine_fgs_function.test", "urn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFunctionGraphTrigger_cronTimer(t *testing.T) {
+	var (
+		randName     = acceptance.RandomAccResourceName()
+		resourceName = "flexibleengine_fgs_trigger.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionGraphTimingTrigger_cron(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "TIMER"),
+					resource.TestCheckResourceAttr(resourceName, "timer.0.name", randName),
+					resource.TestCheckResourceAttr(resourceName, "timer.0.schedule_type", "Cron"),
+					resource.TestCheckResourceAttr(resourceName, "timer.0.schedule", "@every 1h30m"),
+					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_urn",
+						"flexibleengine_fgs_function.test", "urn"),
+				),
+			},
+			{
+				Config: testAccFunctionGraphTimingTrigger_cronUpdate(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "TIMER"),
+					resource.TestCheckResourceAttr(resourceName, "timer.0.name", randName),
+					resource.TestCheckResourceAttr(resourceName, "timer.0.schedule_type", "Cron"),
+					resource.TestCheckResourceAttr(resourceName, "timer.0.schedule", "@every 1h30m"),
+					resource.TestCheckResourceAttr(resourceName, "status", "DISABLED"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_urn",
+						"flexibleengine_fgs_function.test", "urn"),
+				),
+			},
+		},
+	})
+}
+
+// OBS trigger does not suppport status updation.
+func TestAccFunctionGraphTrigger_obs(t *testing.T) {
+	var (
+		// The underscores (_) are not allowed.
+		randName     = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+		resourceName = "flexibleengine_fgs_trigger.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckS3(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionGraphObsTrigger_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "OBS"),
+					resource.TestCheckResourceAttr(resourceName, "obs.0.bucket_name", randName),
+					resource.TestCheckResourceAttr(resourceName, "obs.0.event_notification_name", randName),
+					resource.TestCheckResourceAttr(resourceName, "obs.0.suffix", ".json"),
+					resource.TestCheckResourceAttr(resourceName, "obs.0.events.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_urn",
+						"flexibleengine_fgs_function.test", "urn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFunctionGraphTrigger_dis(t *testing.T) {
+	var (
+		randName     = acceptance.RandomAccResourceName()
+		resourceName = "flexibleengine_fgs_trigger.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionGraphDisTrigger_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "DIS"),
+					resource.TestCheckResourceAttr(resourceName, "dis.0.stream_name", randName),
+					resource.TestCheckResourceAttr(resourceName, "dis.0.starting_position", "TRIM_HORIZON"),
+					resource.TestCheckResourceAttr(resourceName, "dis.0.max_fetch_bytes", "2097152"),
+					resource.TestCheckResourceAttr(resourceName, "dis.0.pull_period", "30000"),
+					resource.TestCheckResourceAttr(resourceName, "dis.0.serial_enable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_urn",
+						"flexibleengine_fgs_function.test", "urn"),
+				),
+			},
+			{
+				Config: testAccFunctionGraphDisTrigger_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "DIS"),
+					resource.TestCheckResourceAttr(resourceName, "dis.0.stream_name", randName),
+					resource.TestCheckResourceAttr(resourceName, "dis.0.starting_position", "TRIM_HORIZON"),
+					resource.TestCheckResourceAttr(resourceName, "dis.0.max_fetch_bytes", "2097152"),
+					resource.TestCheckResourceAttr(resourceName, "dis.0.pull_period", "30000"),
+					resource.TestCheckResourceAttr(resourceName, "dis.0.serial_enable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "status", "DISABLED"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_urn",
+						"flexibleengine_fgs_function.test", "urn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFunctionGraphTrigger_smn(t *testing.T) {
+	var (
+		randName     = acceptance.RandomAccResourceName()
+		resourceName = "flexibleengine_fgs_trigger.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionGraphSmnTrigger_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "SMN"),
+					resource.TestCheckResourceAttrSet(resourceName, "smn.0.topic_urn"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_urn",
+						"flexibleengine_fgs_function.test", "urn"),
+				),
+			},
+		},
+	})
+}
+
+/*
+func TestAccFunctionGraphTrigger_kafka(t *testing.T) {
+	var (
+		randName  = acceptance.RandomAccResourceName()
+		adminPass = fmt.Sprintf("%s%s%d", acctest.RandString(5), acctest.RandStringFromCharSet(2, "#$"),
+			acctest.RandIntRange(100, 999))
+		resourceName = "flexibleengine_fgs_trigger.test"
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    acceptance.TestAccProviders,
+		//CheckDestroy: rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFunctionGraphKafkaTrigger_basic(randName, adminPass),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "KAFKA"),
+					resource.TestCheckResourceAttr(resourceName, "kafka.0.batch_size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "kafka.0.topic_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_urn",
+						"flexibleengine_fgs_function.test", "urn"),
+					resource.TestCheckResourceAttrPair(resourceName, "kafka.0.instance_id",
+						"flexibleengine_dms_kafka_instance.test", "id"),
+				),
+			},
+			{
+				Config: testAccFunctionGraphKafkaTrigger_update(randName, adminPass),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "type", "KAFKA"),
+					resource.TestCheckResourceAttr(resourceName, "kafka.0.batch_size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "kafka.0.topic_ids.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "status", "DISABLED"),
+					resource.TestCheckResourceAttrPair(resourceName, "function_urn",
+						"flexibleengine_fgs_function.test", "urn"),
+					resource.TestCheckResourceAttrPair(resourceName, "kafka.0.instance_id",
+						"flexibleengine_dms_kafka_instance.test", "id"),
+				),
+			},
+		},
+	})
+}
+*/
+
+func testAccFunctionGraphTimingTrigger_base(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_fgs_function" "test" {
+  name        = "%s"
+  app         = "default"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 10
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
+}`, rName)
+}
+
+func testAccFunctionGraphTimingTrigger_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_fgs_trigger" "test" {
+  function_urn = flexibleengine_fgs_function.test.urn
+  type         = "TIMER"
+
+  timer {
+    name          = "%s"
+    schedule_type = "Rate"
+    schedule      = "3d"
+  }
+}
+`, testAccFunctionGraphTimingTrigger_base(rName), rName)
+}
+
+func testAccFunctionGraphTimingTrigger_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_fgs_trigger" "test" {
+  function_urn = flexibleengine_fgs_function.test.urn
+  type         = "TIMER"
+  status       = "DISABLED"
+
+  timer {
+	name          = "%s"
+	schedule_type = "Rate"
+	schedule      = "3d"
+  }
+}
+`, testAccFunctionGraphTimingTrigger_base(rName), rName)
+}
+
+func testAccFunctionGraphTimingTrigger_cron(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_fgs_trigger" "test" {
+  function_urn = flexibleengine_fgs_function.test.urn
+  type         = "TIMER"
+
+  timer {
+    name          = "%s"
+    schedule_type = "Cron"
+    schedule      = "@every 1h30m"
+  }
+}
+`, testAccFunctionGraphTimingTrigger_base(rName), rName)
+}
+
+func testAccFunctionGraphTimingTrigger_cronUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_fgs_trigger" "test" {
+  function_urn = flexibleengine_fgs_function.test.urn
+  type         = "TIMER"
+  status       = "DISABLED"
+
+  timer {
+	name          = "%s"
+	schedule_type = "Cron"
+	schedule      = "@every 1h30m"
+  }
+}
+`, testAccFunctionGraphTimingTrigger_base(rName), rName)
+}
+
+func testAccFunctionGraphObsTrigger_base(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_obs_bucket" "test" {
+  bucket = "%s"
+  acl    = "private"
+}
+
+resource "flexibleengine_identity_agency_v3" "test" {
+  name                   = "%s"
+  delegated_service_name = "op_svc_cff"
+
+  project_role {
+    project = "MOS"
+
+    roles = [
+      "OBS OperateAccess",
+    ]
+  }
+
+  domain_roles = [
+    "OBS OperateAccess",
+  ]
+}
+
+data "flexibleengine_fgs_dependencies" "test" {
+  runtime = "Python2.7"
+  name    = "esdk_obs_python-3x"
+}
+
+resource "flexibleengine_fgs_function" "test" {
+  name        = "%s"
+  app         = "default"
+  agency      = flexibleengine_identity_agency_v3.test.name
+  handler     = "index.handler"
+  memory_size = 256
+  timeout     = 15
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
+  depend_list = [data.flexibleengine_fgs_dependencies.test.packages[0].id]
+}`, rName, rName, rName)
+}
+
+func testAccFunctionGraphObsTrigger_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_fgs_trigger" "test" {
+  function_urn = flexibleengine_fgs_function.test.urn
+  type         = "OBS"
+  status       = "ACTIVE"
+
+  obs {
+    bucket_name             = flexibleengine_obs_bucket.test.bucket
+    event_notification_name = "%s"
+    suffix                  = ".json"
+
+    events = ["ObjectCreated"]
+  }
+}`, testAccFunctionGraphObsTrigger_base(rName), rName)
+}
+
+func testAccFunctionGraphDisTrigger_base(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_dis_stream" "test" {
+  name            = "%s"
+  type            = "COMMON"
+  partition_count = 3
+}
+
+resource "flexibleengine_identity_agency_v3" "test" {
+  name                   = "%s"
+  delegated_service_name = "op_svc_cff"
+
+  project_role {
+    project = "%s"
+
+    roles = [
+      "DIS Administrator",
+    ]
+  }
+}
+
+resource "flexibleengine_fgs_function" "test" {
+  name        = "%s"
+  app         = "default"
+  agency      = flexibleengine_identity_agency_v3.test.name
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 10
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  func_code   = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
+}`, rName, rName, OS_REGION_NAME, rName)
+}
+
+func testAccFunctionGraphDisTrigger_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_fgs_trigger" "test" {
+  function_urn = flexibleengine_fgs_function.test.urn
+  type         = "DIS"
+  status       = "ACTIVE"
+
+  dis {
+    stream_name       = flexibleengine_dis_stream.test.name
+    starting_position = "TRIM_HORIZON"
+	max_fetch_bytes   = 2097152
+    pull_period       = 30000
+    serial_enable     = true
+  }
+}`, testAccFunctionGraphDisTrigger_base(rName))
+}
+
+func testAccFunctionGraphDisTrigger_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_fgs_trigger" "test" {
+  function_urn = flexibleengine_fgs_function.test.urn
+  type         = "DIS"
+  status       = "DISABLED"
+
+  dis {
+    stream_name       = flexibleengine_dis_stream.test.name
+    starting_position = "TRIM_HORIZON"
+	max_fetch_bytes   = 2097152
+    pull_period       = 30000
+    serial_enable     = true
+  }
+}`, testAccFunctionGraphDisTrigger_base(rName))
+}
+
+func testAccFunctionGraphSmnTrigger_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_smn_topic_v2" "test" {
+  name = "%s"
+}
+
+resource "flexibleengine_fgs_trigger" "test" {
+  function_urn = flexibleengine_fgs_function.test.urn
+  type         = "SMN"
+
+  smn {
+    topic_urn = flexibleengine_smn_topic_v2.test.topic_urn
+  }
+}`, testAccFunctionGraphTimingTrigger_base(rName), rName)
+}
+
+func testAccNetwork_config(rName string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_availability_zones" "test" {}
+
+resource "flexibleengine_vpc_v1" "test" {
+  name = "%s"
+  cidr = "192.168.128.0/20"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test" {
+  name       = "%s"
+  vpc_id     = flexibleengine_vpc_v1.test.id
+  cidr       = "192.168.128.0/24"
+  gateway_ip = "192.168.128.1"
+}
+
+resource "flexibleengine_networking_secgroup_v2" "test" {
+  name = "%s"
+}
+
+resource "flexibleengine_networking_secgroup_rule" "test" {
+  security_group_id = flexibleengine_networking_secgroup_v2.test.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 9092
+  port_range_max    = 9092
+  remote_ip_prefix  = "0.0.0.0/0"
+}`, rName, rName, rName)
+}
+
+func testAccDmsKafka_config(rName, password string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_dms_az" "test" {}
+
+data "flexibleengine_dms_product" "test" {
+  engine            = "kafka"
+  version           = "1.1.0"
+  instance_type     = "cluster"
+  partition_num     = 300
+  storage           = 600
+  storage_spec_code = "dms.physical.storage.high"
+}
+
+resource "flexibleengine_dms_kafka_instance" "test" {
+  name              = "%s"
+  vpc_id            = flexibleengine_vpc_v1.test.id
+  network_id        = flexibleengine_vpc_subnet_v1.test.id
+  security_group_id = flexibleengine_networking_secgroup_v2.test.id
+  available_zones   = [data.flexibleengine_dms_az.test.id]
+  product_id        = data.flexibleengine_dms_product.test.id
+  engine_version    = data.flexibleengine_dms_product.test.version
+  bandwidth         = data.flexibleengine_dms_product.test.bandwidth
+  storage_space     = data.flexibleengine_dms_product.test.storage
+  storage_spec_code = data.flexibleengine_dms_product.test.storage_spec_code
+  manager_user      = "%s"
+  manager_password  = "%s"
+}
+
+resource "flexibleengine_dms_kafka_topic" "test" {
+  instance_id = flexibleengine_dms_kafka_instance.test.id
+  name        = "%s"
+  partitions  = 20
+}`, testAccNetwork_config(rName), rName, rName, password, rName)
+}
+
+func testAccFunctionGraphKafkaTrigger_base(rName, password string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_identity_agency_v3" "test" {
+  name                   = "%s"
+  delegated_service_name = "op_svc_cff"
+
+  project_role {
+	project = "%s"
+
+    roles = [
+      "DMS Administrator",
+      "VPC FullAccess",
+    ]
+  }
+}
+
+resource "flexibleengine_fgs_function" "test" {
+  name        = "%s"
+  app         = "default"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 10
+  runtime     = "Python2.7"
+  code_type   = "inline"
+  agency      = flexibleengine_identity_agency_v3.test.name
+  vpc_id      = flexibleengine_vpc_v1.test.id
+  network_id  = flexibleengine_vpc_subnet_v1.test.id
+  func_code   = "aW1wb3J0IGpzb24KZGVmIGhhbmRsZXIgKGZW50LCBjb250ZXh0KToKICAgIG91dHB1dCA9ICdIZWxsbyBtZXNzYWdlOiAnICsganNvbi5kdW1wcyhldmVudCkKICAgIHJldHVybiBvdXRwdXQ="
+}`, testAccDmsKafka_config(rName, password), rName, OS_REGION_NAME, rName)
+}
+
+func testAccFunctionGraphKafkaTrigger_basic(rName, password string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_fgs_trigger" "test" {
+  function_urn = flexibleengine_fgs_function.test.urn
+  type         = "KAFKA"
+
+  kafka {
+    instance_id = flexibleengine_dms_kafka_instance.test.id
+    batch_size  = 100
+
+    topic_ids = [
+      flexibleengine_dms_kafka_topic.test.id
+    ]
+  }
+}`, testAccFunctionGraphKafkaTrigger_base(rName, password))
+}
+
+func testAccFunctionGraphKafkaTrigger_update(rName, password string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_fgs_trigger" "test" {
+  function_urn = flexibleengine_fgs_function.test.urn
+  type         = "KAFKA"
+  status       = "DISABLED"
+	
+  kafka {
+    instance_id = flexibleengine_dms_kafka_instance.test.id
+    batch_size  = 100
+  
+    topic_ids = [
+      flexibleengine_dms_kafka_topic.test.id
+    ]
+  }
+}`, testAccFunctionGraphKafkaTrigger_base(rName, password))
+}


### PR DESCRIPTION
fixes #691 

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccFgsV2Function_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccFgsV2Function_basic -timeout 720m
=== RUN   TestAccFgsV2Function_basic
=== PAUSE TestAccFgsV2Function_basic
=== CONT  TestAccFgsV2Function_basic
--- PASS: TestAccFgsV2Function_basic (73.44s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 73.514s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccFgsV2Function_text'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccFgsV2Function_text -timeout 720m
=== RUN   TestAccFgsV2Function_text
=== PAUSE TestAccFgsV2Function_text
=== CONT  TestAccFgsV2Function_text
--- PASS: TestAccFgsV2Function_text (45.00s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 45.088s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccFunctionGraphDependencies'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccFunctionGraphDependencies -timeout 720m
=== RUN   TestAccFunctionGraphDependencies_basic
=== PAUSE TestAccFunctionGraphDependencies_basic
=== RUN   TestAccFunctionGraphDependencies_name
=== PAUSE TestAccFunctionGraphDependencies_name
=== RUN   TestAccFunctionGraphDependencies_runtime
=== PAUSE TestAccFunctionGraphDependencies_runtime
=== CONT  TestAccFunctionGraphDependencies_basic
=== CONT  TestAccFunctionGraphDependencies_runtime
=== CONT  TestAccFunctionGraphDependencies_name
--- PASS: TestAccFunctionGraphDependencies_name (38.93s)
--- PASS: TestAccFunctionGraphDependencies_runtime (38.96s)
--- PASS: TestAccFunctionGraphDependencies_basic (38.98s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 39.067s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccFunctionGraphResourceDependency_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccFunctionGraphResourceDependency_basic -timeout 720m
=== RUN   TestAccFunctionGraphResourceDependency_basic
=== PAUSE TestAccFunctionGraphResourceDependency_basic
=== CONT  TestAccFunctionGraphResourceDependency_basic
--- PASS: TestAccFunctionGraphResourceDependency_basic (74.16s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 74.236s

make testacc TEST='./flexibleengine' TESTARGS='-run TestAccFunctionGraphTrigger'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccFunctionGraphTrigger -timeout 720m
=== RUN   TestAccFunctionGraphTrigger_basic
=== PAUSE TestAccFunctionGraphTrigger_basic
=== RUN   TestAccFunctionGraphTrigger_cronTimer
=== PAUSE TestAccFunctionGraphTrigger_cronTimer
=== RUN   TestAccFunctionGraphTrigger_smn
=== PAUSE TestAccFunctionGraphTrigger_smn
=== CONT  TestAccFunctionGraphTrigger_basic
=== CONT  TestAccFunctionGraphTrigger_cronTimer
=== CONT  TestAccFunctionGraphTrigger_smn
--- PASS: TestAccFunctionGraphTrigger_smn (34.93s)
--- PASS: TestAccFunctionGraphTrigger_basic (69.73s)
--- PASS: TestAccFunctionGraphTrigger_cronTimer (69.95s)
PASS
ok    github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 70.025s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccFunctionGraphTrigger_obs'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccFunctionGraphTrigger_obs -timeout 720m
=== RUN   TestAccFunctionGraphTrigger_obs
=== PAUSE TestAccFunctionGraphTrigger_obs
=== CONT  TestAccFunctionGraphTrigger_obs
--- PASS: TestAccFunctionGraphTrigger_obs (50.65s)
PASS
ok      github.com/terraform-providers/terraform-provider-flexibleengine/flexibleengine 50.735s
```