### PR TITLE
chore: add acceptance package

### DIFF
--- a/flexibleengine/acceptance/acceptance.go
+++ b/flexibleengine/acceptance/acceptance.go
@@ -1,0 +1,85 @@
+/*
+Package acceptance includes all test cases of resources and data sources that
+imported directly from huaweicloud.
+*/
+package acceptance
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine"
+)
+
+var (
+	OS_DEPRECATED_ENVIRONMENT = os.Getenv("OS_DEPRECATED_ENVIRONMENT")
+	OS_AVAILABILITY_ZONE      = os.Getenv("OS_AVAILABILITY_ZONE")
+	OS_REGION_NAME            = os.Getenv("OS_REGION_NAME")
+	OS_ACCESS_KEY             = os.Getenv("OS_ACCESS_KEY")
+	OS_SECRET_KEY             = os.Getenv("OS_SECRET_KEY")
+
+	OS_VPC_ID     = os.Getenv("OS_VPC_ID")
+	OS_NETWORK_ID = os.Getenv("OS_NETWORK_ID")
+	OS_SUBNET_ID  = os.Getenv("OS_SUBNET_ID")
+
+	OS_FLAVOR_ID    = os.Getenv("OS_FLAVOR_ID")
+	OS_IMAGE_ID     = os.Getenv("OS_IMAGE_ID")
+	OS_KEYPAIR_NAME = os.Getenv("OS_KEYPAIR_NAME")
+	OS_FGS_BUCKET   = os.Getenv("OS_FGS_BUCKET")
+)
+
+// TestAccProviderFactories is a static map containing only the main provider instance
+var TestAccProviderFactories map[string]func() (*schema.Provider, error)
+
+// testAccProvider is the "main" provider instance
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = flexibleengine.Provider()
+
+	TestAccProviderFactories = map[string]func() (*schema.Provider, error){
+		"flexibleengine": func() (*schema.Provider, error) {
+			return testAccProvider, nil
+		},
+	}
+}
+
+func testAccPreCheckRequiredEnvVars(t *testing.T) {
+	if OS_REGION_NAME == "" {
+		t.Fatal("OS_REGION_NAME must be set for acceptance tests")
+	}
+}
+
+func testAccPreCheck(t *testing.T) {
+	testAccPreCheckRequiredEnvVars(t)
+
+	// Do not run the test if this is a deprecated testing environment.
+	if OS_DEPRECATED_ENVIRONMENT != "" {
+		t.Skip("This environment only runs deprecated tests")
+	}
+}
+
+func testAccPreCheckDeprecated(t *testing.T) {
+	testAccPreCheckRequiredEnvVars(t)
+
+	if OS_DEPRECATED_ENVIRONMENT == "" {
+		t.Skip("This environment does not support deprecated tests")
+	}
+}
+
+func testAccPreCheckAdminOnly(t *testing.T) {
+	v := os.Getenv("OS_ADMIN")
+	if v != "admin" {
+		t.Skip("Skipping test because it requires the admin user")
+	}
+}
+
+func testAccPreCheckOBS(t *testing.T) {
+	testAccPreCheckRequiredEnvVars(t)
+
+	if OS_ACCESS_KEY == "" || OS_SECRET_KEY == "" {
+		t.Skip("OS_ACCESS_KEY and OS_SECRET_KEY must be set for OBS acceptance tests")
+	}
+}

--- a/flexibleengine/acceptance/data_source_flexibleengine_fgs_dependencies_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_fgs_dependencies_test.go
@@ -1,4 +1,4 @@
-package flexibleengine
+package acceptance
 
 import (
 	"fmt"
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccFunctionGraphDependencies_basic(t *testing.T) {
+func TestAccDataFGSDependencies_basic(t *testing.T) {
 	dataSourceName := "data.flexibleengine_fgs_dependencies.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -16,7 +16,7 @@ func TestAccFunctionGraphDependencies_basic(t *testing.T) {
 		ProviderFactories: TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFunctionGraphDependencies_basic(),
+				Config: testAccDataFGSDependencies_basic(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(dataSourceName, "packages.#", regexp.MustCompile(`[1-9][0-9]*`)),
 				),
@@ -25,7 +25,7 @@ func TestAccFunctionGraphDependencies_basic(t *testing.T) {
 	})
 }
 
-func TestAccFunctionGraphDependencies_name(t *testing.T) {
+func TestAccDataFGSDependencies_name(t *testing.T) {
 	dataSourceName := "data.flexibleengine_fgs_dependencies.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -33,7 +33,7 @@ func TestAccFunctionGraphDependencies_name(t *testing.T) {
 		ProviderFactories: TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFunctionGraphDependencies_name(),
+				Config: testAccDataFGSDependencies_name(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "type", "public"),
 					resource.TestCheckResourceAttr(dataSourceName, "name", "obssdk"),
@@ -44,7 +44,7 @@ func TestAccFunctionGraphDependencies_name(t *testing.T) {
 	})
 }
 
-func TestAccFunctionGraphDependencies_runtime(t *testing.T) {
+func TestAccDataFGSDependencies_runtime(t *testing.T) {
 	dataSourceName := "data.flexibleengine_fgs_dependencies.test"
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -52,7 +52,7 @@ func TestAccFunctionGraphDependencies_runtime(t *testing.T) {
 		ProviderFactories: TestAccProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccFunctionGraphDependencies_runtime(),
+				Config: testAccDataFGSDependencies_runtime(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(dataSourceName, "type", "public"),
 					resource.TestCheckResourceAttr(dataSourceName, "runtime", "Python2.7"),
@@ -63,13 +63,13 @@ func TestAccFunctionGraphDependencies_runtime(t *testing.T) {
 	})
 }
 
-func testAccFunctionGraphDependencies_basic() string {
+func testAccDataFGSDependencies_basic() string {
 	return fmt.Sprintf(`
 data "flexibleengine_fgs_dependencies" "test" {}
 `)
 }
 
-func testAccFunctionGraphDependencies_name() string {
+func testAccDataFGSDependencies_name() string {
 	return fmt.Sprintf(`
 data "flexibleengine_fgs_dependencies" "test" {
   type = "public"
@@ -78,7 +78,7 @@ data "flexibleengine_fgs_dependencies" "test" {
 `)
 }
 
-func testAccFunctionGraphDependencies_runtime() string {
+func testAccDataFGSDependencies_runtime() string {
 	return fmt.Sprintf(`
 data "flexibleengine_fgs_dependencies" "test" {
   type    = "public"

--- a/flexibleengine/acceptance/resource_flexibleengine_fgs_dependency_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_fgs_dependency_test.go
@@ -1,4 +1,4 @@
-package flexibleengine
+package acceptance
 
 import (
 	"fmt"
@@ -29,7 +29,7 @@ func TestAccFunctionGraphResourceDependency_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckS3(t)
+			testAccPreCheckOBS(t)
 		},
 		ProviderFactories: TestAccProviderFactories,
 		Steps: []resource.TestStep{

--- a/flexibleengine/acceptance/resource_flexibleengine_fgs_function_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_fgs_function_test.go
@@ -1,4 +1,4 @@
-package flexibleengine
+package acceptance
 
 import (
 	"fmt"

--- a/flexibleengine/acceptance/resource_flexibleengine_fgs_trigger_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_fgs_trigger_test.go
@@ -1,4 +1,4 @@
-package flexibleengine
+package acceptance
 
 import (
 	"fmt"
@@ -109,7 +109,7 @@ func TestAccFunctionGraphTrigger_obs(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckS3(t)
+			testAccPreCheckOBS(t)
 		},
 		ProviderFactories: TestAccProviderFactories,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
```
$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccFgsV2Function_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccFgsV2Function_basic -timeout 720m
=== RUN   TestAccFgsV2Function_basic
=== PAUSE TestAccFgsV2Function_basic
=== CONT  TestAccFgsV2Function_basic
--- PASS: TestAccFgsV2Function_basic (77.56s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      77.646s
$
$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccFunctionGraphTrigger_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccFunctionGraphTrigger_basic -timeout 720m
=== RUN   TestAccFunctionGraphTrigger_basic
=== PAUSE TestAccFunctionGraphTrigger_basic
=== CONT  TestAccFunctionGraphTrigger_basic
--- PASS: TestAccFunctionGraphTrigger_basic (73.71s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      73.841s
$
$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccDataFGSDependencies_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccDataFGSDependencies_basic -timeout 720m
=== RUN   TestAccDataFGSDependencies_basic
=== PAUSE TestAccDataFGSDependencies_basic
=== CONT  TestAccDataFGSDependencies_basic
--- PASS: TestAccDataFGSDependencies_basic (43.13s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      43.220s
```