### PR TITLE
feat(vpc): support description and secondary_cidr arguments

### DIFF
--- a/docs/resources/vpc_v1.md
+++ b/docs/resources/vpc_v1.md
@@ -38,29 +38,33 @@ resource "flexibleengine_vpc_v1" "vpc_with_tags" {
 
 The following arguments are supported:
 
-* `cidr` - (Required) The range of available subnets in the VPC. The value ranges from 10.0.0.0/8 to 10.255.255.0/24, 172.16.0.0/12 to 172.31.255.0/24, or 192.168.0.0/16 to 192.168.255.0/24.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the VPC. If omitted, the
+  provider-level region will be used. Changing this creates a new VPC resource.
 
-* `region` - (Optional) The region in which to obtain the V1 VPC client. A VPC client is needed to create a VPC. If omitted, the region argument of the provider is used. Changing this creates a new VPC.
+* `name` - (Required, String) Specifies the name of the VPC. The name must be unique for a tenant. The value is a string
+  of no more than 64 characters and can contain digits, letters, underscores (_), and hyphens (-).
 
-* `name` - (Required) The name of the VPC. The name must be unique for a tenant. The value is a string of no more than 64 characters and can contain digits, letters, underscores (_), and hyphens (-). Changing this updates the name of the existing VPC.
+* `cidr` - (Required, String) Specifies the range of available subnets in the VPC. The value ranges from 10.0.0.0/8 to
+  10.255.255.0/24, 172.16.0.0/12 to 172.31.255.0/24, or 192.168.0.0/16 to 192.168.255.0/24.
 
-* `tags` - (Optional) The key/value pairs to associate with the VPC.
+* `description` - (Optional, String) Specifies supplementary information about the VPC. The value is a string of
+  no more than 255 characters and cannot contain angle brackets (< or >).
+
+* `secondary_cidr` - (Optional, String) Specifies the secondary CIDR block of the VPC.
+
+  -> The argument cannot be imported into your Terraform state. And the following secondary CIDR blocks cannot be added
+  to a VPC: 10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16.
+  [View the complete list of unsupported CIDR blocks](https://docs.prod-cloud-ocb.orange-business.com/usermanual/vpc/vpc_vpc_0007.html).
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the VPC.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
-* `id` -  ID of the VPC.
+* `id` - The VPC ID in UUID format.
 
-* `name` -  See Argument Reference above.
-
-* `cidr` - See Argument Reference above.
-
-* `status` - The current status of the desired VPC. Can be either CREATING, OK, DOWN, PENDING_UPDATE, PENDING_DELETE, or ERROR.
-
-* `shared` - Specifies whether the cross-tenant sharing is supported.
-
-* `region` - See Argument Reference above.
+* `status` - The current status of the VPC. Possible values are as follows: CREATING, OK or ERROR.
 
 ## Import
 

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -11,6 +11,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -327,7 +328,6 @@ func Provider() *schema.Provider {
 			"flexibleengine_nat_gateway_v2":                     resourceNatGatewayV2(),
 			"flexibleengine_nat_snat_rule_v2":                   resourceNatSnatRuleV2(),
 			"flexibleengine_vpc_eip_v1":                         resourceVpcEIPV1(),
-			"flexibleengine_vpc_v1":                             resourceVirtualPrivateCloudV1(),
 			"flexibleengine_vpc_subnet_v1":                      resourceVpcSubnetV1(),
 			"flexibleengine_vpc_flow_log_v1":                    resourceVpcFlowLogV1(),
 			"flexibleengine_vpc_route_v2":                       resourceVPCRouteV2(),
@@ -378,6 +378,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_fgs_function":    fgs.ResourceFgsFunctionV2(),
 			"flexibleengine_fgs_trigger":     fgs.ResourceFunctionGraphTrigger(),
 			"flexibleengine_rds_instance_v3": rds.ResourceRdsInstance(),
+			"flexibleengine_vpc_v1":          vpc.ResourceVirtualPrivateCloudV1(),
 
 			// Deprecated resource
 			"flexibleengine_elb_loadbalancer": resourceELoadBalancer(),

--- a/flexibleengine/resource_flexibleengine_vpc_v1.go
+++ b/flexibleengine/resource_flexibleengine_vpc_v1.go
@@ -15,6 +15,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
+// resourceVirtualPrivateCloudV1 is not used any more since v1.29.0
+// flexibleengine_vpc_v1 can be imported directly
 func resourceVirtualPrivateCloudV1() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceVirtualPrivateCloudV1Create,


### PR DESCRIPTION
fixes #700 

```
$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccFlexibleEngineVpcV1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccFlexibleEngineVpcV1 -timeout 720m
=== RUN   TestAccFlexibleEngineVpcV1_basic
=== PAUSE TestAccFlexibleEngineVpcV1_basic
=== RUN   TestAccFlexibleEngineVpcV1_secondaryCIDR
=== PAUSE TestAccFlexibleEngineVpcV1_secondaryCIDR
=== CONT  TestAccFlexibleEngineVpcV1_basic
=== CONT  TestAccFlexibleEngineVpcV1_secondaryCIDR
--- PASS: TestAccFlexibleEngineVpcV1_basic (111.79s)
--- PASS: TestAccFlexibleEngineVpcV1_secondaryCIDR (115.43s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      115.687s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccFlexibleEngineVpcSubnetV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccFlexibleEngineVpcSubnetV1_basic -timeout 720m
=== RUN   TestAccFlexibleEngineVpcSubnetV1_basic
--- PASS: TestAccFlexibleEngineVpcSubnetV1_basic (130.85s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 130.915s
```