### PR TITLE
feat: support to forcibly delete an AS group

### DIFF
--- a/docs/resources/as_group_v1.md
+++ b/docs/resources/as_group_v1.md
@@ -156,6 +156,9 @@ The following arguments are supported:
 * `delete_instances` - (Optional) Whether to delete the instances in the AS group
     when deleting the AS group. The options are `yes` and `no`.
 
+* `force_delete` - (Optional) Whether to forcibly delete the AS group, remove the ECS instances and release them.
+  The default value is `false`.
+
 The `networks` block supports:
 
 * `id` - (Required) The network UUID.

--- a/flexibleengine/resource_flexibleengine_as_group_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_as_group_v1_test.go
@@ -17,7 +17,7 @@ func TestAccASV1Group_basic(t *testing.T) {
 	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
 	resourceName := "flexibleengine_as_group_v1.as_group"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckASV1GroupDestroy,
@@ -26,10 +26,38 @@ func TestAccASV1Group_basic(t *testing.T) {
 				Config: testASV1Group_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckASV1GroupExists(resourceName, &asGroup),
+					resource.TestCheckResourceAttr(resourceName, "desire_instance_number", "0"),
+					resource.TestCheckResourceAttr(resourceName, "min_instance_number", "0"),
+					resource.TestCheckResourceAttr(resourceName, "max_instance_number", "0"),
 					resource.TestCheckResourceAttr(resourceName, "lbaas_listeners.0.protocol_port", "8080"),
 					resource.TestCheckResourceAttr(resourceName, "status", "INSERVICE"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccASV1Group_forceDelete(t *testing.T) {
+	var asGroup groups.Group
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "flexibleengine_as_group_v1.as_group"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckASV1GroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testASGroup_forceDelete(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckASV1GroupExists(resourceName, &asGroup),
+					resource.TestCheckResourceAttr(resourceName, "desire_instance_number", "2"),
+					resource.TestCheckResourceAttr(resourceName, "min_instance_number", "2"),
+					resource.TestCheckResourceAttr(resourceName, "max_instance_number", "5"),
+					resource.TestCheckResourceAttr(resourceName, "instances.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "status", "INSERVICE"),
 				),
 			},
 		},
@@ -94,14 +122,38 @@ func testAccCheckASV1GroupExists(n string, group *groups.Group) resource.TestChe
 func testASV1Group_base(rName string) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_networking_secgroup_v2" "secgroup" {
-  name        = "sg-%s"
+  name        = "sg-%[1]s"
   description = "This is a terraform test security group"
 }
 
 resource "flexibleengine_compute_keypair_v2" "test_key" {
-  name       = "key-%s"
+  name       = "key-%[1]s"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
 }
+
+data "flexibleengine_images_image_v2" "ubuntu" {
+  name = "OBS Ubuntu 18.04"
+}
+
+resource "flexibleengine_as_configuration_v1" "test_as_config"{
+  scaling_configuration_name = "cfg-%[1]s"
+  instance_config {
+    flavor   = "%s"
+    image    = data.flexibleengine_images_image_v2.ubuntu.id
+    key_name = flexibleengine_compute_keypair_v2.test_key.id
+    disk {
+      size        = 40
+      volume_type = "SATA"
+      disk_type   = "SYS"
+    }
+  }
+}
+`, rName, OS_FLAVOR_NAME)
+}
+
+func testASV1Group_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
 
 resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
   name          = "lb-%s"
@@ -120,29 +172,6 @@ resource "flexibleengine_lb_pool_v2" "pool_1" {
   protocol    = "HTTP"
   lb_method   = "ROUND_ROBIN"
   listener_id = flexibleengine_lb_listener_v2.listener_1.id
-}
-`, rName, rName, rName, OS_SUBNET_ID)
-}
-
-func testASV1Group_basic(rName string) string {
-	return fmt.Sprintf(`
-%s
-
-data "flexibleengine_images_image_v2" "ubuntu" {
-  name = "OBS Ubuntu 18.04"
-}
-
-resource "flexibleengine_as_configuration_v1" "test_as_config"{
-  scaling_configuration_name = "cfg-%s"
-  instance_config {
-	image    = data.flexibleengine_images_image_v2.ubuntu.id
-	key_name = flexibleengine_compute_keypair_v2.test_key.id
-    disk {
-      size        = 40
-      volume_type = "SATA"
-      disk_type   = "SYS"
-    }
-  }
 }
 
 resource "flexibleengine_as_group_v1" "as_group"{
@@ -165,5 +194,32 @@ resource "flexibleengine_as_group_v1" "as_group"{
     key = "value"
   }
 }
-`, testASV1Group_base(rName), rName, rName, OS_VPC_ID, OS_NETWORK_ID)
+`, testASV1Group_base(rName), rName, OS_SUBNET_ID, rName, OS_VPC_ID, OS_NETWORK_ID)
+}
+
+func testASGroup_forceDelete(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_as_group_v1" "as_group"{
+  scaling_group_name       = "as-%s"
+  scaling_configuration_id = flexibleengine_as_configuration_v1.test_as_config.id
+  vpc_id                   = "%s"
+  min_instance_number      = 2
+  desire_instance_number   = 2
+  max_instance_number      = 5
+  force_delete             = true
+
+  networks {
+    id = "%s"
+  }
+  security_groups {
+    id = flexibleengine_networking_secgroup_v2.secgroup.id
+  }
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testASV1Group_base(rName), rName, OS_VPC_ID, OS_NETWORK_ID)
 }


### PR DESCRIPTION
fixes #701 
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccASV1Group_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccASV1Group_basic -timeout 720m
=== RUN   TestAccASV1Group_basic
=== PAUSE TestAccASV1Group_basic
=== CONT  TestAccASV1Group_basic
--- PASS: TestAccASV1Group_basic (113.94s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 114.002s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccASGroup_forceDelete'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccASGroup_forceDelete -timeout 720m
=== RUN   TestAccASGroup_forceDelete
=== PAUSE TestAccASGroup_forceDelete
=== CONT  TestAccASGroup_forceDelete
--- PASS: TestAccASGroup_forceDelete (225.36s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 225.428s
```