### PR TITLE
fix: add validation for secgroup rule remote_ip_prefix

### DIFF
--- a/docs/resources/networking_secgroup_rule_v2.md
+++ b/docs/resources/networking_secgroup_rule_v2.md
@@ -4,9 +4,7 @@ subcategory: "Virtual Private Cloud (VPC)"
 
 # flexibleengine_networking_secgroup_rule_v2
 
-Manages a V2 neutron security group rule resource within FlexibleEngine.
-Unlike Nova security groups, neutron separates the group from the rules
-and also allows an admin to target a specific tenant_id.
+Manages a Security Group Rule resource within FlexibleEngine.
 
 ## Example Usage
 
@@ -36,13 +34,17 @@ The following arguments are supported:
     `region` argument of the provider is used. Changing this creates a new
     security group rule.
 
+* `security_group_id` - (Required) The security group ID the rule should belong
+    to. Changing this creates a new security group rule.
+
 * `direction` - (Required) The direction of the rule, valid values are __ingress__
     or __egress__. Changing this creates a new security group rule.
 
 * `ethertype` - (Required) The layer 3 protocol type, valid values are __IPv4__
     or __IPv6__. Changing this creates a new security group rule.
 
-* `protocol` - (Optional) The layer 4 protocol type, valid values are following. Changing this creates a new security group rule. This is required if you want to specify a port range.
+* `protocol` - (Optional) The layer 4 protocol type, valid values are following.
+    Changing this creates a new security group rule. This is required if you want to specify a port range.
   * __tcp__
   * __udp__
   * __icmp__
@@ -80,28 +82,11 @@ The following arguments are supported:
     FlexibleEngine ID of a security group in the same tenant. Changing this creates
     a new security group rule.
 
-* `security_group_id` - (Required) The security group id the rule should belong
-    to, the value needs to be an FlexibleEngine ID of a security group in the same
-    tenant. Changing this creates a new security group rule.
-
-* `tenant_id` - (Optional) The owner of the security group. Required if admin
-    wants to create a port for another tenant. Changing this creates a new
-    security group rule.
-
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
-* `region` - See Argument Reference above.
-* `direction` - See Argument Reference above.
-* `ethertype` - See Argument Reference above.
-* `protocol` - See Argument Reference above.
-* `port_range_min` - See Argument Reference above.
-* `port_range_max` - See Argument Reference above.
-* `remote_ip_prefix` - See Argument Reference above.
-* `remote_group_id` - See Argument Reference above.
-* `security_group_id` - See Argument Reference above.
-* `tenant_id` - See Argument Reference above.
+* `id` - The resource ID in UUID format.
 
 ## Import
 

--- a/flexibleengine/resource_flexibleengine_networking_secgroup_rule_v2.go
+++ b/flexibleengine/resource_flexibleengine_networking_secgroup_rule_v2.go
@@ -34,6 +34,11 @@ func resourceNetworkingSecGroupRuleV2() *schema.Resource {
 				Computed: true,
 				ForceNew: true,
 			},
+			"security_group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
 			"direction": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -69,24 +74,22 @@ func resourceNetworkingSecGroupRuleV2() *schema.Resource {
 				Computed: true,
 			},
 			"remote_ip_prefix": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: validateCIDR,
 				StateFunc: func(v interface{}) string {
 					return strings.ToLower(v.(string))
 				},
 			},
-			"security_group_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 		},
 	}
@@ -171,7 +174,6 @@ func resourceNetworkingSecGroupRuleV2Read(d *schema.ResourceData, meta interface
 	d.Set("remote_group_id", security_group_rule.RemoteGroupID)
 	d.Set("remote_ip_prefix", security_group_rule.RemoteIPPrefix)
 	d.Set("security_group_id", security_group_rule.SecGroupID)
-	d.Set("tenant_id", security_group_rule.TenantID)
 	d.Set("region", GetRegion(d, config))
 
 	return nil

--- a/flexibleengine/validators.go
+++ b/flexibleengine/validators.go
@@ -129,7 +129,7 @@ func validateCIDR(v interface{}, k string) (ws []string, errors []error) {
 		return
 	}
 
-	if ipnet == nil || value != ipnet.String() {
+	if ipnet == nil || strings.ToLower(value) != ipnet.String() {
 		errors = append(errors, fmt.Errorf(
 			"%q must contain a valid network CIDR, got %q", k, value))
 	}


### PR DESCRIPTION
fixes #747 

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccNetworkingV2SecGroupRule'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccNetworkingV2SecGroupRule -timeout 720m
=== RUN   TestAccNetworkingV2SecGroupRule_basic
=== PAUSE TestAccNetworkingV2SecGroupRule_basic
=== RUN   TestAccNetworkingV2SecGroupRule_remoteGroup
=== PAUSE TestAccNetworkingV2SecGroupRule_remoteGroup
=== RUN   TestAccNetworkingV2SecGroupRule_ipv6
=== PAUSE TestAccNetworkingV2SecGroupRule_ipv6
=== RUN   TestAccNetworkingV2SecGroupRule_numericProtocol
=== PAUSE TestAccNetworkingV2SecGroupRule_numericProtocol
=== CONT  TestAccNetworkingV2SecGroupRule_basic
=== CONT  TestAccNetworkingV2SecGroupRule_numericProtocol
=== CONT  TestAccNetworkingV2SecGroupRule_ipv6
=== CONT  TestAccNetworkingV2SecGroupRule_remoteGroup
--- PASS: TestAccNetworkingV2SecGroupRule_ipv6 (68.62s)
--- PASS: TestAccNetworkingV2SecGroupRule_remoteGroup (68.75s)
--- PASS: TestAccNetworkingV2SecGroupRule_numericProtocol (68.81s)
--- PASS: TestAccNetworkingV2SecGroupRule_basic (69.49s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 69.559s
```