### PR TITLE
feat: support description field of SG rule

### DIFF
--- a/docs/resources/networking_secgroup_rule_v2.md
+++ b/docs/resources/networking_secgroup_rule_v2.md
@@ -82,6 +82,10 @@ The following arguments are supported:
     FlexibleEngine ID of a security group in the same tenant. Changing this creates
     a new security group rule.
 
+* `description` - (Optional) Specifies the supplementary information about the security group rule.
+  This parameter can contain a maximum of 255 characters and cannot contain angle brackets (< or >).
+  Changing this creates a new security group rule.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/docs/resources/networking_secgroup_v2.md
+++ b/docs/resources/networking_secgroup_v2.md
@@ -4,9 +4,7 @@ subcategory: "Virtual Private Cloud (VPC)"
 
 # flexibleengine_networking_secgroup_v2
 
-Manages a V2 neutron security group resource within FlexibleEngine.
-Unlike Nova security groups, neutron separates the group from the rules
-and also allows an admin to target a specific tenant_id.
+Manages a Security Group resource within FlexibleEngine.
 
 ## Example Usage
 
@@ -30,22 +28,15 @@ The following arguments are supported:
 
 * `description` - (Optional) A unique name for the security group.
 
-* `tenant_id` - (Optional) The owner of the security group. Required if admin
-    wants to create a port for another tenant. Changing this creates a new
-    security group.
-
 * `delete_default_rules` - (Optional) Whether or not to delete the default
     egress security rules. This is `false` by default. See the below note
     for more information.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
-* `region` - See Argument Reference above.
-* `name` - See Argument Reference above.
-* `description` - See Argument Reference above.
-* `tenant_id` - See Argument Reference above.
+* `id` - The resource ID in UUID format.
 
 ## Default Security Group Rules
 

--- a/flexibleengine/resource_flexibleengine_networking_secgroup_rule_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_networking_secgroup_rule_v2_test.go
@@ -36,6 +36,7 @@ func TestAccNetworkingV2SecGroupRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ethertype", "IPv4"),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "tcp"),
 					resource.TestCheckResourceAttr(resourceName, "remote_ip_prefix", "0.0.0.0/0"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
 				),
 			},
 			{
@@ -189,7 +190,7 @@ func testAccCheckNetworkingV2SecGroupRuleExists(n string, sgRule *rules.SecGroup
 func testAccNetworkingV2SecGroupRule_base(rName string) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_networking_secgroup_v2" "secgroup_1" {
-  name        = "secgroup-%s"
+  name        = "sg-%s"
   description = "terraform security group rule acceptance test"
 }
 `, rName)
@@ -207,6 +208,7 @@ resource "flexibleengine_networking_secgroup_rule_v2" "secgroup_rule_1" {
   protocol          = "tcp"
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = flexibleengine_networking_secgroup_v2.secgroup_1.id
+  description       = "allow SSH"
 }
 `, testAccNetworkingV2SecGroupRule_base(rName))
 }


### PR DESCRIPTION
fixes #749 

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccNetworkingV2SecGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccNetworkingV2SecGroup -timeout 720m
=== RUN   TestAccNetworkingV2SecGroupRule_basic
=== PAUSE TestAccNetworkingV2SecGroupRule_basic
=== RUN   TestAccNetworkingV2SecGroupRule_remoteGroup
=== PAUSE TestAccNetworkingV2SecGroupRule_remoteGroup
=== RUN   TestAccNetworkingV2SecGroupRule_ipv6
=== PAUSE TestAccNetworkingV2SecGroupRule_ipv6
=== RUN   TestAccNetworkingV2SecGroupRule_numericProtocol
=== PAUSE TestAccNetworkingV2SecGroupRule_numericProtocol
=== RUN   TestAccNetworkingV2SecGroup_basic
--- PASS: TestAccNetworkingV2SecGroup_basic (86.76s)
=== RUN   TestAccNetworkingV2SecGroup_noDefaultRules
--- PASS: TestAccNetworkingV2SecGroup_noDefaultRules (47.61s)
=== CONT  TestAccNetworkingV2SecGroupRule_basic
=== CONT  TestAccNetworkingV2SecGroupRule_numericProtocol
=== CONT  TestAccNetworkingV2SecGroupRule_ipv6
=== CONT  TestAccNetworkingV2SecGroupRule_remoteGroup
--- PASS: TestAccNetworkingV2SecGroupRule_remoteGroup (68.01s)
--- PASS: TestAccNetworkingV2SecGroupRule_numericProtocol (68.50s)
--- PASS: TestAccNetworkingV2SecGroupRule_basic (68.76s)
--- PASS: TestAccNetworkingV2SecGroupRule_ipv6 (68.98s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 203.420s
```