### PR TITLE
feat: support description field of DNAT rule

### DIFF
--- a/docs/resources/nat_dnat_rule_v2.md
+++ b/docs/resources/nat_dnat_rule_v2.md
@@ -62,6 +62,10 @@ The following arguments are supported:
   the IP address of a VPC for dedicated connection. This parameter is mandatory in
   Direct Connect scenario. Changing this creates a new dnat rule.
 
+* `description` - (Optional) Specifies the description of the dnat rule.
+  The value is a string of no more than 255 characters, and angle brackets (<>) are not allowed.
+  Changing this creates a new dnat rule.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are exported:

--- a/flexibleengine/resource_flexibleengine_nat_dnat_rule_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_nat_dnat_rule_v2_test.go
@@ -39,6 +39,7 @@ func TestAccNatDnat_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNatDnatExists(),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "tcp"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by terraform acc test"),
 					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
 				),
 			},
@@ -65,6 +66,7 @@ func TestAccNatDnat_protocol(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNatDnatExists(),
 					resource.TestCheckResourceAttr(resourceName, "protocol", "any"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by terraform acc test"),
 					resource.TestCheckResourceAttr(resourceName, "status", "ACTIVE"),
 				),
 			},
@@ -186,6 +188,7 @@ resource "flexibleengine_nat_dnat_rule_v2" "dnat" {
   floating_ip_id = flexibleengine_networking_floatingip_v2.fip_1.id
   private_ip     = flexibleengine_compute_instance_v2.instance_1.network.0.fixed_ip_v4
   protocol       = "tcp"
+  description    = "created by terraform acc test"
   internal_service_port = 80
   external_service_port = 8080
 }
@@ -203,6 +206,7 @@ resource "flexibleengine_nat_dnat_rule_v2" "dnat" {
   floating_ip_id = flexibleengine_networking_floatingip_v2.fip_1.id
   private_ip     = flexibleengine_compute_instance_v2.instance_1.network.0.fixed_ip_v4
   protocol       = "any"
+  description    = "created by terraform acc test"
   internal_service_port = 0
   external_service_port = 0
 }


### PR DESCRIPTION
fixes #750 

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccNatDnat'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccNatDnat -timeout 720m
=== RUN   TestAccNatDnat_basic
=== PAUSE TestAccNatDnat_basic
=== RUN   TestAccNatDnat_protocol
=== PAUSE TestAccNatDnat_protocol
=== CONT  TestAccNatDnat_basic
=== CONT  TestAccNatDnat_protocol
--- PASS: TestAccNatDnat_basic (158.75s)
--- PASS: TestAccNatDnat_protocol (159.98s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 160.072s
```