### PR TITLE
feat: add CBR vault and policy resource

### DIFF
--- a/docs/data-sources/cbr_vaults.md
+++ b/docs/data-sources/cbr_vaults.md
@@ -1,0 +1,92 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+---
+
+# flexibleengine_cbr_vaults
+
+Use this data source to get available CBR vaults within FlexibleEngine.
+
+## Example Usage
+
+### Get vaults for all server type
+
+```hcl
+data "flexibleengine_cbr_vaults" "test" {
+  type = "server"
+}
+```
+
+## Argument reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the CBR vaults.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies a unique name of the CBR vault. This parameter can contain a maximum of 64
+  characters, which may consist of letters, digits, underscores(_) and hyphens (-).
+
+* `type` - (Optional, String) Specifies the object type of the CBR vault. The vaild values are as follows:
+  + **server** (Cloud Servers)
+  + **disk** (EVS Disks)
+  + **turbo** (SFS Turbo file systems)
+
+* `protection_type` - (Optional, String) Specifies the protection type of the CBR vault.
+  The valid values are **backup** and **replication**. Vaults of type **disk** don't support **replication**.
+
+* `size` - (Optional, Int) Specifies the vault sapacity, in GB. The valid value range is `1` to `10,485,760`.
+
+* `auto_expand_enabled` - (Optional, Bool) Specifies whether to enable automatic expansion of the backup protection
+  type vault. Default to **false**.
+
+* `policy_id` - (Optional, String) Specifies a policy to associate with the CBR vault.
+  The `policy_id` cannot be used with the vault of replicate protection type.
+
+* `status` - (Optional, String) Specifies the CBR vault status, including **available**, **lock**, **frozen** and **error**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in hashcode format.
+
+* `vaults` - List of CBR vault details. The object structure of each CBR vault is documented below.
+
+The `vaults` block supports:
+
+* `id` - The vault ID in UUID format.
+
+* `name` - The CBR vault name.
+
+* `type` - The object type of the CBR vault.
+
+* `consistent_level` - The backup specifications. The valid value is **crash_consistent**.
+
+* `protection_type` - The protection type of the CBR vault.
+
+* `size` - The vault capacity, in GB.
+
+* `auto_expand_enabled` - Whether to enable automatic expansion of the backup protection type vault.
+
+* `policy_id` - The policy associated with the CBR vault.
+
+* `allocated` - The allocated capacity of the vault, in GB.
+
+* `used` - The used capacity, in GB.
+
+* `spec_code` - The specification code.
+
+* `status` - The vault status.
+
+* `storage` - The name of the bucket for the vault.
+
+* `tags` - The key/value pairs to associate with the CBR vault.
+
+* `resources` - An array of one or more resources to attach to the CBR vault.
+  The object structure is documented below.
+
+The `resources` block supports:
+
+* `server_id` - The ID of the ECS instance to be backed up.
+
+* `includes` - An array of disk or SFS file system IDs which will be included in the backup.

--- a/docs/resources/cbr_policy.md
+++ b/docs/resources/cbr_policy.md
@@ -1,0 +1,134 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+---
+
+# flexibleengine_cbr_policy
+
+Manages a CBR Policy resource within FlexibleEngine.
+
+## Example Usage
+
+### create a backup policy
+
+```hcl
+variable "policy_name" {}
+
+resource "flexibleengine_cbr_policy" "test" {
+  name        = var.policy_name
+  type        = "backup"
+  time_period = 20
+
+  backup_cycle {
+    frequency       = "WEEKLY"
+    days            = "MO,TH"
+    execution_times = ["06:00"]
+  }
+}
+```
+
+### create a replication policy
+
+```hcl
+variable "policy_name" {}
+variable "dest_region" {}
+variable "dest_project_id" {}
+
+resource "flexibleengine_cbr_policy" "test" {
+  name                   = var.policy_name
+  type                   = "replication"
+  destination_region     = var.dest_region
+  destination_project_id = var.dest_project_id
+  backup_quantity        = 20
+
+  backup_cycle {
+    frequency       = "DAILY"
+    interval        = 5
+    execution_times = ["21:00"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the CBR policy. If omitted, the
+  provider-level region will be used. Changing this will create a new policy.
+
+* `name` - (Required, String) Specifies a unique name of the CBR policy. This parameter can contain a maximum of 64
+  characters, which may consist of chinese charactors, letters, digits, underscores(_) and hyphens (-).
+
+* `type` - (Required, String, ForceNew) Specifies the protection type of the CBR policy.
+  Valid values are **backup** and **replication**.
+  Changing this will create a new policy.
+
+* `backup_cycle` - (Required, List) Specifies the scheduling rule for the CBR policy backup execution.
+  The [object](#cbr_policy_backup_cycle) structure is documented below.
+
+* `enabled` - (Optional, Bool) Specifies whether to enable the CBR policy. Default to **true**.
+
+* `destination_region` - (Optional, String) Specifies the name of the replication destination region, which is mandatory
+  for cross-region replication. Required if `protection_type` is **replication**.
+
+* `destination_project_id` - (Optional, String) Specifies the ID of the replication destination project, which is
+  mandatory for cross-region replication. Required if `protection_type` is **replication**.
+
+* `backup_quantity` - (Optional, Int) Specifies the maximum number of retained backups. The value ranges from `2` to
+  `99,999`. This parameter and `time_period` are alternative.
+
+* `time_period` - (Optional, Int) Specifies the duration (in days) for retained backups. The value ranges from `2` to
+  `99,999`.
+
+-> **NOTE:** If this `backup_quantity` and `time_period` are both left blank, the backups will be retained permanently.
+
+* `long_term_retention` - (Optional, List) Specifies the long-term retention rules, which is an advanced options of
+  the `backup_quantity`. The [object](#cbr_policy_long_term_retention) structure is documented below.
+
+-> The configuration of `long_term_retention` and `backup_quantity` will take effect together.
+  When the number of retained backups exceeds the preset value (number of `backup_quantity`), the system automatically
+  deletes the earliest backups. By default, the system automatically clears data every other day.
+
+* `time_zone` - (Optional, String) Specifies the UTC time zone, e.g.: `UTC+08:00`.
+  Required if `long_term_retention` is set.
+
+<a name="cbr_policy_backup_cycle"></a>
+The `backup_cycle` block supports:
+
+* `days` - (Optional, String) Specifies the weekly backup day of backup schedule. It supports seven days a week (MO, TU,
+  WE, TH, FR, SA, SU) and this parameter is separated by a comma (,) without spaces, between date and date during the
+  configuration.
+
+* `interval` - (Optional, Int) Specifies the interval (in days) of backup schedule. The value range is `1` to `30`. This
+  parameter and `days` are alternative.
+
+* `execution_times` - (Required, List) Specifies the backup time. Automated backups will be triggered at the backup
+  time. The current time is in the UTC format (HH:MM). The minutes in the list must be set to **00** and the hours
+  cannot be repeated. In the replication policy, you are advised to set one time point for one day.
+
+<a name="cbr_policy_long_term_retention"></a>
+The `long_term_retention` block supports:
+
+* `daily` - (Optional, Int) - Specifies the latest backup of each day is saved in the long term.
+
+* `weekly` - (Optional, Int) - Specifies the latest backup of each week is saved in the long term.
+
+* `monthly` - (Optional, Int) - Specifies the latest backup of each month is saved in the long term.
+
+* `yearly` - (Optional, Int) - Specifies the latest backup of each year is saved in the long term.
+
+-> A maximum of 10 backups are retained for failed periodic backup tasks. They are retained for one month and can be
+  manually deleted on the web console.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A resource ID in UUID format.
+
+## Import
+
+Policies can be imported by their `id`. For example,
+
+```
+terraform import flexibleengine_cbr_policy.test 4d2c2939-774f-42ef-ab15-e5b126b11ace
+```

--- a/docs/resources/cbr_vault.md
+++ b/docs/resources/cbr_vault.md
@@ -1,0 +1,162 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+---
+
+# flexibleengine_cbr_vault
+
+Manages a CBR Vault resource within FlexibleEngine.
+
+## Example Usage
+
+### Create a server type vault
+
+```hcl
+variable "vault_name" {}
+variable "ecs_instance_id" {}
+
+resource "flexibleengine_cbr_vault" "test" {
+  name            = var.vault_name
+  type            = "server"
+  protection_type = "backup"
+  size            = 100
+
+  resources {
+    server_id = var.ecs_instance_id
+  }
+
+  tags = {
+    foo = "bar"
+  }
+}
+```
+
+### Create a disk type vault
+
+```hcl
+variable "vault_name" {}
+variable "evs_volume_id" {}
+
+resource "flexibleengine_cbr_vault" "test" {
+  name             = var.vault_name
+  type             = "disk"
+  protection_type  = "backup"
+  size             = 50
+  auto_expand      = true
+
+  resources {
+    includes = [
+      var.evs_volume_id
+    ]
+  }
+
+  tags = {
+    foo = "bar"
+  }
+}
+```
+
+### Create an SFS turbo type vault
+
+```hcl
+variable "vault_name" {}
+variable "sfs_turbo_id" {}
+
+resource "flexibleengine_cbr_vault" "test" {
+  name             = var.vault_name
+  type             = "turbo"
+  protection_type  = "backup"
+  size             = 1000
+
+  resources {
+    includes = [
+      var.sfs_turbo_id
+    ]
+  }
+
+  tags = {
+    foo = "bar"
+  }
+}
+```
+
+### Create an SFS turbo type vault with replicate protection type
+
+```hcl
+variable "vault_name" {}
+
+resource "flexibleengine_cbr_vault" "test" {
+  name             = var.vault_name
+  type             = "turbo"
+  protection_type  = "replication"
+  size             = 1000
+}
+```
+
+## Argument reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the CBR vault. If omitted, the
+  provider-level region will be used. Changing this will create a new vault.
+
+* `name` - (Required, String) Specifies a unique name of the CBR vault. This parameter can contain a maximum of 64
+  characters, which may consist of letters, digits, underscores(_) and hyphens (-).
+
+* `type` - (Required, String, ForceNew) Specifies the object type of the CBR vault.
+  Changing this will create a new vault. Vaild values are as follows:
+  + **server** (Cloud Servers)
+  + **disk** (EVS Disks)
+  + **turbo** (SFS Turbo file systems)
+
+* `protection_type` - (Required, String, ForceNew) Specifies the protection type of the CBR vault.
+  The valid values are **backup** and **replication**. Vaults of type **disk** don't support **replication**.
+  Changing this will create a new vault.
+
+* `size` - (Required, Int) Specifies the vault sapacity, in GB. The valid value range is `1` to `10,485,760`.
+
+* `auto_expand` - (Optional, Bool) Specifies to enable auto capacity expansion for the backup protection type vault.
+  Defaults to **false**.
+
+* `policy_id` - (Optional, String) Specifies a policy to associate with the CBR vault.
+  `policy_id` cannot be used with the vault of replicate protection type.
+
+* `consistent_level` - (Optional, String, ForceNew) Specifies the backup specifications.
+  Currently, Only **server** type vaults support application consistent and only **crash_consistent** is valid.
+  Changing this will create a new vault.
+
+* `resources` - (Optional, List) Specifies an array of one or more resources to attach to the CBR vault.
+  The [object](#cbr_vault_resources) structure is documented below.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the CBR vault.
+
+<a name="cbr_vault_resources"></a>
+The `resources` block supports:
+
+* `server_id` - (Optional, String) Specifies the ID of the ECS instance to be backed up.
+
+* `includes` - (Optional, List) Specifies the array of disk or SFS file system IDs which will be included in the backup.
+  Only **disk** and **turbo** vault support this parameter.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A resource ID in UUID format.
+
+* `allocated` - The allocated capacity of the vault, in GB.
+
+* `used` - The used capacity, in GB.
+
+* `spec_code` - The specification code.
+
+* `status` - The vault status.
+
+* `storage` - The name of the bucket for the vault.
+
+## Import
+
+Vaults can be imported by their `id`. For example,
+
+```
+terraform import flexibleengine_cbr_vault.test 01c33779-7c83-4182-8b6b-24a671fcedf8
+```

--- a/flexibleengine/acceptance/acceptance.go
+++ b/flexibleengine/acceptance/acceptance.go
@@ -28,6 +28,9 @@ var (
 	OS_IMAGE_ID     = os.Getenv("OS_IMAGE_ID")
 	OS_KEYPAIR_NAME = os.Getenv("OS_KEYPAIR_NAME")
 	OS_FGS_BUCKET   = os.Getenv("OS_FGS_BUCKET")
+
+	OS_DEST_REGION     = os.Getenv("OS_DEST_REGION")
+	OS_DEST_PROJECT_ID = os.Getenv("OS_DEST_PROJECT_ID")
 )
 
 // TestAccProviderFactories is a static map containing only the main provider instance
@@ -85,5 +88,11 @@ func testAccPreCheckOBS(t *testing.T) {
 
 	if OS_ACCESS_KEY == "" || OS_SECRET_KEY == "" {
 		t.Skip("OS_ACCESS_KEY and OS_SECRET_KEY must be set for OBS acceptance tests")
+	}
+}
+
+func testAccPreCheckReplication(t *testing.T) {
+	if OS_DEST_REGION == "" || OS_DEST_PROJECT_ID == "" {
+		t.Skip("Skipping the replication policy acceptance tests.")
 	}
 }

--- a/flexibleengine/acceptance/data_source_flexibleengine_cbr_vaults_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_cbr_vaults_test.go
@@ -1,0 +1,197 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
+)
+
+func TestAccDataCBRVaults_BasicServer(t *testing.T) {
+	randName := acceptance.RandomAccResourceNameWithDash()
+	dataSourceName := "data.flexibleengine_cbr_vaults.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCBRVaults_serverBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeServer),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "backup"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "200"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.resources.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.tags.foo", "bar"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.tags.key", "value"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataCBRVaults_ReplicaServer(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.flexibleengine_cbr_vaults.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCBRVaults_serverReplication(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeServer),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "replication"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "200"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataCBRVaults_BasicVolume(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.flexibleengine_cbr_vaults.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCBRVaults_volumeBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeDisk),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "backup"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "50"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.resources.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataCBRVaults_BasicTurbo(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.flexibleengine_cbr_vaults.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCBRVaults_turboBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeTurbo),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "backup"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "800"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.resources.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataCBRVaults_ReplicaTurbo(t *testing.T) {
+	randName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.flexibleengine_cbr_vaults.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      dc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataCBRVaults_turboReplication(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", randName),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.#", "1"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.type", cbr.VaultTypeTurbo),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.protection_type", "replication"),
+					resource.TestCheckResourceAttr(dataSourceName, "vaults.0.size", "1000"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataCBRVaults_serverBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_cbr_vaults" "test" {
+  name = flexibleengine_cbr_vault.test.name
+}
+`, testAccCBRV3Vault_serverBasic(rName))
+}
+
+func testAccDataCBRVaults_serverReplication(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_cbr_vaults" "test" {
+  name = flexibleengine_cbr_vault.test.name
+}
+`, testAccCBRV3Vault_serverReplication(rName))
+}
+
+func testAccDataCBRVaults_volumeBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_cbr_vaults" "test" {
+  name = flexibleengine_cbr_vault.test.name
+}
+`, testAccCBRV3Vault_volumeBasic(rName))
+}
+
+func testAccDataCBRVaults_turboBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_cbr_vaults" "test" {
+  name = flexibleengine_cbr_vault.test.name
+}
+`, testAccCBRV3Vault_turboBasic(rName))
+}
+
+func testAccDataCBRVaults_turboReplication(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_cbr_vaults" "test" {
+  name = flexibleengine_cbr_vault.test.name
+}
+`, testAccCBRV3Vault_turboReplication(rName))
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_cbr_policy_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_cbr_policy_test.go
@@ -1,0 +1,292 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/cbr/v3/policies"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccCBRV3Policy_basic(t *testing.T) {
+	var cbrPolicy policies.Policy
+	randName := fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+	resourceName := "flexibleengine_cbr_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCBRPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCBRV3Policy_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCBRPolicyExists(resourceName, &cbrPolicy),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "time_period", "20"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.days", "MO,TU"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.0", "06:00"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.1", "18:00"),
+				),
+			},
+			{
+				Config: testCBRV3Policy_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "backup_quantity", "5"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.days", "SA,SU"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.0", "08:00"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.1", "20:00"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCBRV3Policy_retention(t *testing.T) {
+	var cbrPolicy policies.Policy
+	randName := fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+	resourceName := "flexibleengine_cbr_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCBRPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCBRV3Policy_retention(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCBRPolicyExists(resourceName, &cbrPolicy),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "backup_quantity", "15"),
+					resource.TestCheckResourceAttr(resourceName, "time_zone", "UTC+08:00"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.daily", "10"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.weekly", "10"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.monthly", "1"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.days", "SA,SU"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.0", "08:00"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.1", "20:00"),
+				),
+			},
+			{
+				Config: testCBRV3Policy_retention_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "backup_quantity", "35"),
+					resource.TestCheckResourceAttr(resourceName, "time_zone", "UTC+08:00"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.daily", "20"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.weekly", "20"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.monthly", "6"),
+					resource.TestCheckResourceAttr(resourceName, "long_term_retention.0.yearly", "1"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.days", "SA,SU"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.0", "08:00"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.1", "20:00"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCBRV3Policy_replication(t *testing.T) {
+	var cbrPolicy policies.Policy
+	randName := fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+	resourceName := "flexibleengine_cbr_policy.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckReplication(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCBRPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testCBRV3Policy_replication(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCBRPolicyExists(resourceName, &cbrPolicy),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "type", "replication"),
+					resource.TestCheckResourceAttr(resourceName, "destination_region", OS_DEST_REGION),
+					resource.TestCheckResourceAttr(resourceName, "destination_project_id", OS_DEST_PROJECT_ID),
+					resource.TestCheckResourceAttr(resourceName, "time_period", "20"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.interval", "5"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.0", "06:00"),
+					resource.TestCheckResourceAttr(resourceName, "backup_cycle.0.execution_times.1", "18:00"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckCBRPolicyDestroy(s *terraform.State) error {
+	conf := testAccProvider.Meta().(*config.Config)
+	client, err := conf.CbrV3Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine CBR client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_cbr_policy" {
+			continue
+		}
+
+		_, err := policies.Get(client, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("CBR policy still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCBRPolicyExists(n string, policy *policies.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conf := testAccProvider.Meta().(*config.Config)
+		client, err := conf.CbrV3Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating FlexibleEngine CBR client: %s", err)
+		}
+
+		found, err := policies.Get(client, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("CBR policy not found")
+		}
+
+		*policy = *found
+
+		return nil
+	}
+}
+
+func testCBRV3Policy_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_cbr_policy" "test" {
+  name        = "%s"
+  type        = "backup"
+  time_period = 20
+
+  backup_cycle {
+    days            = "MO,TU"
+    execution_times = ["06:00", "18:00"]
+  }
+}
+`, rName)
+}
+
+func testCBRV3Policy_update(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_cbr_policy" "test" {
+  name            = "%s-update"
+  type            = "backup"
+  backup_quantity = 5
+
+  backup_cycle {
+    days            = "SA,SU"
+    execution_times = ["08:00", "20:00"]
+  }
+}
+`, rName)
+}
+
+func testCBRV3Policy_retention(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_cbr_policy" "test" {
+  name            = "%s"
+  type            = "backup"
+  backup_quantity = 15
+
+  time_zone       = "UTC+08:00"
+  long_term_retention {
+    daily   = 10
+    weekly  = 10
+    monthly = 1
+  }
+
+  backup_cycle {
+    days            = "SA,SU"
+    execution_times = ["08:00", "20:00"]
+  }
+}
+`, rName)
+}
+
+func testCBRV3Policy_retention_update(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_cbr_policy" "test" {
+  name            = "%s"
+  type            = "backup"
+  backup_quantity = 35
+
+  time_zone       = "UTC+08:00"
+  long_term_retention {
+    daily   = 20
+    weekly  = 20
+    monthly = 6
+    yearly  = 1
+  }
+
+  backup_cycle {
+    days            = "SA,SU"
+    execution_times = ["08:00", "20:00"]
+  }
+}
+`, rName)
+}
+
+func testCBRV3Policy_replication(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_cbr_policy" "test" {
+  name                   = "%s"
+  type                   = "replication"
+  destination_region     = "%s"
+  destination_project_id = "%s"
+  time_period            = 20
+
+  backup_cycle {
+    interval        = 5
+    execution_times = ["06:00", "18:00"]
+  }
+}
+`, rName, OS_DEST_REGION, OS_DEST_PROJECT_ID)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_cbr_vault_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_cbr_vault_test.go
@@ -1,0 +1,591 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/cbr/v3/vaults"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
+)
+
+func TestAccCBRV3Vault_BasicServer(t *testing.T) {
+	var vault vaults.Vault
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_cbr_vault.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCBRVaultDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCBRV3Vault_serverBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCBRVaultExists(resourceName, &vault),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeServer),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "200"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttrPair(resourceName, "resources.0.server_id", "flexibleengine_compute_instance_v2.test", "id"),
+				),
+			},
+			{
+				Config: testAccCBRV3Vault_serverUpdate(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeServer),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "300"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo1", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
+					resource.TestCheckResourceAttrPair(resourceName, "policy_id", "flexibleengine_cbr_policy.test", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCBRV3Vault_ReplicaServer(t *testing.T) {
+	var vault vaults.Vault
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_cbr_vault.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCBRVaultDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCBRV3Vault_serverReplication(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCBRVaultExists(resourceName, &vault),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeServer),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "replication"),
+					resource.TestCheckResourceAttr(resourceName, "size", "200"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCBRV3Vault_BasicVolume(t *testing.T) {
+	var vault vaults.Vault
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_cbr_vault.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCBRVaultDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCBRV3Vault_volumeBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCBRVaultExists(resourceName, &vault),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeDisk),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "50"),
+					resource.TestCheckResourceAttr(resourceName, "auto_expand", "false"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "resources.0.includes.#", "2"),
+				),
+			},
+			{
+				Config: testAccCBRV3Vault_volumeUpdate(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeDisk),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "auto_expand", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "resources.0.includes.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCBRV3Vault_BasicTurbo(t *testing.T) {
+	var vault vaults.Vault
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_cbr_vault.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCBRVaultDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCBRV3Vault_turboBasic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCBRVaultExists(resourceName, &vault),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeTurbo),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "800"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+				),
+			},
+			{
+				Config: testAccCBRV3Vault_turboUpdate(randName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", randName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeTurbo),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
+					resource.TestCheckResourceAttr(resourceName, "size", "1000"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCBRV3Vault_ReplicaTurbo(t *testing.T) {
+	var vault vaults.Vault
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_cbr_vault.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckCBRVaultDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCBRV3Vault_turboReplication(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCBRVaultExists(resourceName, &vault),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "consistent_level", "crash_consistent"),
+					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeTurbo),
+					resource.TestCheckResourceAttr(resourceName, "protection_type", "replication"),
+					resource.TestCheckResourceAttr(resourceName, "size", "1000"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckCBRVaultDestroy(s *terraform.State) error {
+	conf := testAccProvider.Meta().(*config.Config)
+	client, err := conf.CbrV3Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating FlexibleEngine CBR client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_cbr_vault" {
+			continue
+		}
+
+		_, err := vaults.Get(client, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("CBR vault still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckCBRVaultExists(n string, vault *vaults.Vault) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conf := testAccProvider.Meta().(*config.Config)
+		client, err := conf.CbrV3Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating FlexibleEngine CBR client: %s", err)
+		}
+
+		found, err := vaults.Get(client, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("CBR vault not found")
+		}
+
+		*vault = *found
+
+		return nil
+	}
+}
+
+func testAccCBRV3Vault_policy(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_cbr_policy" "test" {
+  name        = "%s"
+  type        = "backup"
+  time_period = 20
+
+  backup_cycle {
+    days            = "MO,TU"
+    execution_times = ["06:00", "18:00"]
+  }
+}
+`, rName)
+}
+
+func testAccEvsVolumeConfiguration_basic() string {
+	return fmt.Sprintf(`
+variable "volume_configuration" {
+  type = list(object({
+    volume_type = string
+    size        = number
+  }))
+  default = [
+    {volume_type = "SSD", size = 100},
+    {volume_type = "SSD", size = 100},
+  ]
+}`)
+}
+
+func testAccEvsVolumeConfiguration_update() string {
+	return fmt.Sprintf(`
+variable "volume_configuration" {
+  type = list(object({
+    volume_type = string
+    size        = number
+  }))
+  default = [
+    {volume_type = "SAS", size = 100},
+    {volume_type = "SAS", size = 100},
+  ]
+}`)
+}
+
+func testAccCBRV3VaultBasicConfiguration(config, rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_compute_availability_zones_v2" "test" {}
+
+data "flexibleengine_compute_flavors_v2" "test" {
+  performance_type = "normal"
+  cpu_core         = 2
+  memory_size      = 4
+}
+
+data "flexibleengine_images_image_v2" "test" {
+  name        = "OBS Ubuntu 18.04"
+  most_recent = true
+}
+
+resource "flexibleengine_vpc_v1" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/20"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test" {
+  name       = "%s"
+  cidr       = "192.168.0.0/24"
+  vpc_id     = flexibleengine_vpc_v1.test.id
+  gateway_ip = "192.168.0.1"
+}
+
+resource "flexibleengine_networking_secgroup_v2" "test" {
+  name = "%s"
+}
+
+resource "flexibleengine_compute_keypair_v2" "test" {
+  name = "%s"
+  lifecycle {
+    ignore_changes = [
+      public_key,
+    ]
+  }
+}
+
+resource "flexibleengine_compute_instance_v2" "test" {
+  availability_zone = data.flexibleengine_compute_availability_zones_v2.test.names[0]
+  name              = "%s"
+  image_id          = data.flexibleengine_images_image_v2.test.id
+  flavor_id         = data.flexibleengine_compute_flavors_v2.test.flavors[0]
+  key_pair          = flexibleengine_compute_keypair_v2.test.name
+
+  security_groups = [
+    flexibleengine_networking_secgroup_v2.test.name
+  ]
+
+  network {
+    uuid = flexibleengine_vpc_subnet_v1.test.id
+  }
+}
+
+resource "flexibleengine_blockstorage_volume_v2" "test" {
+  count = length(var.volume_configuration)
+
+  availability_zone = data.flexibleengine_compute_availability_zones_v2.test.names[0]
+  volume_type       = var.volume_configuration[count.index].volume_type
+  name              = "%s_${tostring(count.index)}"
+  size              = var.volume_configuration[count.index].size
+}
+
+resource "flexibleengine_compute_volume_attach_v2" "test" {
+  count = length(flexibleengine_blockstorage_volume_v2.test)
+
+  instance_id = flexibleengine_compute_instance_v2.test.id
+  volume_id   = flexibleengine_blockstorage_volume_v2.test[count.index].id
+}`, config, rName, rName, rName, rName, rName, rName)
+}
+
+func testAccCBRV3Vault_serverBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_cbr_vault" "test" {
+  name             = "%s"
+  type             = "server"
+  consistent_level = "crash_consistent"
+  protection_type  = "backup"
+  size             = 200
+
+  resources {
+    server_id = flexibleengine_compute_instance_v2.test.id
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testAccCBRV3VaultBasicConfiguration(testAccEvsVolumeConfiguration_basic(), rName),
+		rName)
+}
+
+func testAccCBRV3Vault_serverUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "flexibleengine_cbr_vault" "test" {
+  name             = "%s-update"
+  type             = "server"
+  consistent_level = "crash_consistent"
+  protection_type  = "backup"
+  size             = 300
+  policy_id        = flexibleengine_cbr_policy.test.id
+
+  resources {
+    server_id = flexibleengine_compute_instance_v2.test.id
+  }
+
+  tags = {
+    foo1 = "bar"
+    key  = "value_update"
+  }
+}
+`, testAccCBRV3VaultBasicConfiguration(testAccEvsVolumeConfiguration_update(), rName), testAccCBRV3Vault_policy(rName),
+		rName)
+}
+
+func testAccCBRV3Vault_serverReplication(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_cbr_vault" "test" {
+  name             = "%s"
+  type             = "server"
+  consistent_level = "crash_consistent"
+  protection_type  = "replication"
+  size             = 200
+}
+`, rName)
+}
+
+func testAccCBRV3Vault_volumeBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_cbr_vault" "test" {
+  name            = "%s"
+  type            = "disk"
+  protection_type = "backup"
+  size            = 50
+
+  resources {
+    includes = flexibleengine_compute_volume_attach_v2.test[*].volume_id
+  }
+}
+`, testAccCBRV3VaultBasicConfiguration(testAccEvsVolumeConfiguration_basic(), rName),
+		rName)
+}
+
+func testAccCBRV3Vault_volumeUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "flexibleengine_cbr_vault" "test" {
+  name            = "%s-update"
+  type            = "disk"
+  protection_type = "backup"
+  size            = 100
+  auto_expand     = true
+  policy_id       = flexibleengine_cbr_policy.test.id
+
+  resources {
+    includes = flexibleengine_compute_volume_attach_v2.test[*].volume_id
+  }
+}
+`, testAccCBRV3VaultBasicConfiguration(testAccEvsVolumeConfiguration_basic(), rName),
+		testAccCBRV3Vault_policy(rName), rName)
+}
+
+// Vaults of type 'turbo'
+func testAccCBRV3Vault_turboBase(rName string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_compute_availability_zones_v2" "test" {}
+
+resource "flexibleengine_vpc_v1" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/20"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test" {
+  name       = "%s"
+  cidr       = "192.168.0.0/22"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = flexibleengine_vpc_v1.test.id
+}
+
+resource "flexibleengine_networking_secgroup_v2" "test" {
+  name = "%s"
+}
+
+resource "flexibleengine_sfs_turbo" "test1" {
+  name              = "%s-1"
+  size              = 500
+  share_proto       = "NFS"
+  vpc_id            = flexibleengine_vpc_v1.test.id
+  subnet_id         = flexibleengine_vpc_subnet_v1.test.id
+  security_group_id = flexibleengine_networking_secgroup_v2.test.id
+  availability_zone = data.flexibleengine_compute_availability_zones_v2.test.names[0]
+}`, rName, rName, rName, rName)
+}
+
+func testAccCBRV3Vault_turboBasic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_cbr_vault" "test" {
+  name            = "%s"
+  type            = "turbo"
+  protection_type = "backup"
+  size            = 800
+
+  resources {
+    includes = [
+      flexibleengine_sfs_turbo.test1.id
+    ]
+  }
+}
+`, testAccCBRV3Vault_turboBase(rName), rName)
+}
+
+func testAccCBRV3Vault_turboUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "flexibleengine_sfs_turbo" "test2" {
+  name              = "%s-2"
+  size              = 500
+  share_proto       = "NFS"
+  vpc_id            = flexibleengine_vpc_v1.test.id
+  subnet_id         = flexibleengine_vpc_subnet_v1.test.id
+  security_group_id = flexibleengine_networking_secgroup_v2.test.id
+  availability_zone = data.flexibleengine_compute_availability_zones_v2.test.names[0]
+}
+
+resource "flexibleengine_cbr_vault" "test" {
+  name            = "%s-update"
+  type            = "turbo"
+  protection_type = "backup"
+  size            = 1000
+  policy_id       = flexibleengine_cbr_policy.test.id
+
+  resources {
+    includes = [
+      flexibleengine_sfs_turbo.test1.id,
+      flexibleengine_sfs_turbo.test2.id
+    ]
+  }
+}
+`, testAccCBRV3Vault_turboBase(rName), testAccCBRV3Vault_policy(rName), rName, rName)
+}
+
+func testAccCBRV3Vault_turboReplication(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_cbr_vault" "test" {
+  name            = "%s"
+  type            = "turbo"
+  protection_type = "replication"
+  size            = 1000
+}
+`, rName)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpc"
@@ -249,6 +250,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_vpcep_endpoints":                    dataSourceVPCEPEndpoints(),
 
 			// importing data source
+			"flexibleengine_cbr_vaults":       cbr.DataSourceCbrVaultsV3(),
 			"flexibleengine_fgs_dependencies": fgs.DataSourceFunctionGraphDependencies(),
 
 			// Deprecated data source
@@ -384,6 +386,8 @@ func Provider() *schema.Provider {
 			"flexibleengine_dli_queue":                          ResourceDliQueueV1(),
 
 			// importing resource
+			"flexibleengine_cbr_policy":      cbr.ResourceCBRPolicyV3(),
+			"flexibleengine_cbr_vault":       cbr.ResourceCBRVaultV3(),
 			"flexibleengine_fgs_dependency":  fgs.ResourceFgsDependency(),
 			"flexibleengine_fgs_function":    fgs.ResourceFgsFunctionV2(),
 			"flexibleengine_fgs_trigger":     fgs.ResourceFunctionGraphTrigger(),

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,12 @@ go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.25.3
-	github.com/chnsz/golangsdk v0.0.0-20220418073727-5999a3ef059d
+	github.com/chnsz/golangsdk v0.0.0-20220505073229-48c9a216b801
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
-	github.com/huaweicloud/terraform-provider-huaweicloud v1.35.2
+	github.com/huaweicloud/terraform-provider-huaweicloud v1.36.0
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chnsz/golangsdk v0.0.0-20220418073727-5999a3ef059d h1:Y8iTlZ2tfSTw7EDTKHKU2uxzqmhqFU9HQB0/7PHZ2Mk=
 github.com/chnsz/golangsdk v0.0.0-20220418073727-5999a3ef059d/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220505073229-48c9a216b801 h1:or1ZuyiSrt/k9QO0n9KA3NmAK+KmjBvg2wD+rq4DzSA=
+github.com/chnsz/golangsdk v0.0.0-20220505073229-48c9a216b801/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -220,8 +222,12 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.82 h1:KcQEgjoH1WL56Xl+mDhw+0R+6NgO7yKy1vGisLxWiNs=
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.82/go.mod h1:IvF+Pe06JMUivVgN6B4wcsPEoFvVa40IYaOPZyUt5HE=
+github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.86 h1:5PF/3bNfAarOXKDPheq3mJlkxYnwNvq5WOVmowveMtA=
+github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.86/go.mod h1:IvF+Pe06JMUivVgN6B4wcsPEoFvVa40IYaOPZyUt5HE=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.35.2 h1:HJ+EjSX2CX9v5Z508s7zcFsz2KZP6gNrnkBZIr91RLE=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.35.2/go.mod h1:VZXp2WPxG4W08+RP998r26fxYQSvNdQwYfnJ7u6OjMw=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.36.0 h1:YgR/B+FN5Kdnh+0tZfDgWzpzyjQGUgTXBBBlrDVD/00=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.36.0/go.mod h1:8SsyT+UF2EbkSeCK6JdB8U/ljVZXsiM4AGF2pVf5bUM=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=


### PR DESCRIPTION
fixes #754 

```
$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccCBRV3Vault_BasicServer'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccCBRV3Vault_BasicServer -timeout 720m
=== RUN   TestAccCBRV3Vault_BasicServer
=== PAUSE TestAccCBRV3Vault_BasicServer
=== CONT  TestAccCBRV3Vault_BasicServer
--- PASS: TestAccCBRV3Vault_BasicServer (341.52s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      341.610s

$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccCBRV3Policy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccCBRV3Policy -timeout 720m
=== RUN   TestAccCBRV3Policy_basic
=== PAUSE TestAccCBRV3Policy_basic
=== RUN   TestAccCBRV3Policy_retention
=== PAUSE TestAccCBRV3Policy_retention
=== RUN   TestAccCBRV3Policy_replication
=== PAUSE TestAccCBRV3Policy_replication
=== CONT  TestAccCBRV3Policy_basic
=== CONT  TestAccCBRV3Policy_replication
=== CONT  TestAccCBRV3Policy_retention
--- PASS: TestAccCBRV3Policy_replication (54.07s)
--- PASS: TestAccCBRV3Policy_basic (81.19s)
--- PASS: TestAccCBRV3Policy_retention (81.62s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      81.738s

$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccDataCBRVaults_BasicVolume'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccDataCBRVaults_BasicVolume -timeout 720m
=== RUN   TestAccDataCBRVaults_BasicVolume
=== PAUSE TestAccDataCBRVaults_BasicVolume
=== CONT  TestAccDataCBRVaults_BasicVolume
--- PASS: TestAccDataCBRVaults_BasicVolume (202.56s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      202.656s
```