### PR TITLE
lts: fix an issue caused by API

### DIFF
--- a/flexibleengine/resource_flexibleengine_lts_group.go
+++ b/flexibleengine/resource_flexibleengine_lts_group.go
@@ -48,6 +48,7 @@ func resourceLTSGroupV2Create(d *schema.ResourceData, meta interface{}) error {
 
 	createOpts := &loggroups.CreateOpts{
 		LogGroupName: d.Get("group_name").(string),
+		TTL:          7, // fixed to 7days
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.25.3
-	github.com/chnsz/golangsdk v0.0.0-20220615020710-87cd9b9a3040
+	github.com/chnsz/golangsdk v0.0.0-20220616110846-5f3079766b1d
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/chnsz/golangsdk v0.0.0-20220505073229-48c9a216b801/go.mod h1:j6UR2TfA
 github.com/chnsz/golangsdk v0.0.0-20220610082705-21055906aa25/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chnsz/golangsdk v0.0.0-20220615020710-87cd9b9a3040 h1:9rkxND2IVrOzVpCfkWx8bxE4340D/Nqytro8S4iFu2s=
 github.com/chnsz/golangsdk v0.0.0-20220615020710-87cd9b9a3040/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220616110846-5f3079766b1d h1:M85HGOcnm9JzozP4Ce6jsMKnTxXScxQySPp7YbNTG5s=
+github.com/chnsz/golangsdk v0.0.0-20220616110846-5f3079766b1d/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=


### PR DESCRIPTION
fixes #764 

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLTSGroupV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLTSGroupV2_basic -timeout 720m
=== RUN   TestAccLTSGroupV2_basic
=== PAUSE TestAccLTSGroupV2_basic
=== CONT  TestAccLTSGroupV2_basic
--- PASS: TestAccLTSGroupV2_basic (49.11s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 49.167s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLTSTopicV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLTSTopicV2_basic -timeout 720m
=== RUN   TestAccLTSTopicV2_basic
=== PAUSE TestAccLTSTopicV2_basic
=== CONT  TestAccLTSTopicV2_basic
--- PASS: TestAccLTSTopicV2_basic (73.95s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 74.030s
```