### PR TITLE
feat(elb): support to create dedicated load balancer

### DIFF
--- a/docs/data-sources/elb_flavors.md
+++ b/docs/data-sources/elb_flavors.md
@@ -1,0 +1,57 @@
+---
+subcategory: "Elastic Load Balance (ELB)"
+---
+
+# flexibleengine_elb_flavors
+
+Use this data source to get the available **Dedicated** ELB Flavors.
+
+## Example Usage
+
+```hcl
+data "flexibleengine_elb_flavors" "flavors" {
+  type            = "L7"
+  max_connections = 200000
+  cps             = 2000
+  bandwidth       = 50
+}
+
+# Create Dedicated Load Balancer with the first matched flavor
+resource "flexibleengine_lb_loadbalancer_v3" "lb" {
+  l7_flavor_id = data.flexibleengine_elb_flavors.flavors.ids[0]
+
+  # Other properties...
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the flavors. If omitted, the provider-level region will be
+  used.
+
+* `type` - (Optional, String) Specifies the flavor type. Valid values are **L4** and **L7**.
+
+* `max_connections` - (Optional, Int) Specifies the maximum connections in the flavor.
+
+* `bandwidth` - (Optional, Int) Specifies the bandwidth size(Mbit/s) in the flavor.
+
+* `cps` - (Optional, Int) Specifies the cps in the flavor.
+
+* `qps` - (Optional, Int) Specifies the qps in the L7 flavor.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `ids` - A list of flavor IDs.
+
+* `flavors` - A list of flavors. Each element contains the following attributes:
+  + `id` - ID of the flavor.
+  + `name` - Name of the flavor.
+  + `type` - Type of the flavor.
+  + `max_connections` - Maximum connections of the flavor.
+  + `cps` - Cps of the flavor.
+  + `qps` - Qps of the L7 flavor.
+  + `bandwidth` - Bandwidth size(Mbit/s) of the flavor.

--- a/docs/resources/lb_loadbalancer_v3.md
+++ b/docs/resources/lb_loadbalancer_v3.md
@@ -1,0 +1,174 @@
+---
+subcategory: "Elastic Load Balance (ELB)"
+---
+
+# flexibleengine_lb_loadbalancer_v3
+
+Manages a **Dedicated** Load Balancer resource within FlexibleEngine.
+
+## Example Usage
+
+### Basic Loadbalancer
+
+```hcl
+resource "flexibleengine_lb_loadbalancer_v3" "basic" {
+  name              = "basic"
+  description       = "basic example"
+  cross_vpc_backend = true
+
+  vpc_id         = "{{ vpc_id }}"
+  ipv4_subnet_id = "{{ subnet_id }}"
+
+  l4_flavor_id = "{{ l4_flavor_id }}"
+  l7_flavor_id = "{{ l7_flavor_id }}"
+
+  availability_zone = [
+    "eu-west-0a",
+    "eu-west-0b",
+  ]
+}
+```
+
+### Loadbalancer With Existing EIP
+
+```hcl
+resource "flexibleengine_lb_loadbalancer_v3" "basic" {
+  name              = "basic"
+  description       = "basic example"
+  cross_vpc_backend = true
+
+  vpc_id            = "{{ vpc_id }}"
+  ipv6_network_id   = "{{ ipv6_network_id }}"
+  ipv6_bandwidth_id = "{{ ipv6_bandwidth_id }}"
+  ipv4_subnet_id    = "{{ subnet_id }}"
+
+  l4_flavor_id = "{{ l4_flavor_id }}"
+  l7_flavor_id = "{{ l7_flavor_id }}"
+
+  availability_zone = [
+    "eu-west-0a",
+    "eu-west-0b",
+  ]
+
+  ipv4_eip_id = "{{ eip_id }}"
+}
+```
+
+### Loadbalancer With EIP
+
+```hcl
+resource "flexibleengine_lb_loadbalancer_v3" "basic" {
+  name              = "basic"
+  description       = "basic example"
+  cross_vpc_backend = true
+
+  vpc_id            = "{{ vpc_id }}"
+  ipv6_network_id   = "{{ ipv6_network_id }}"
+  ipv6_bandwidth_id = "{{ ipv6_bandwidth_id }}"
+  ipv4_subnet_id    = "{{ subnet_id }}"
+
+  l4_flavor_id = "{{ l4_flavor_id }}"
+  l7_flavor_id = "{{ l7_flavor_id }}"
+
+  availability_zone = [
+    "eu-west-0a",
+    "eu-west-0b",
+  ]
+
+  iptype                = "5_bgp"
+  bandwidth_charge_mode = "traffic"
+  sharetype             = "PER"
+  bandwidth_size        = 10
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the loadbalancer resource. If omitted, the
+  provider-level region will be used. Changing this creates a new loadbalancer.
+
+* `availability_zone` - (Required, List, ForceNew) Specifies the list of AZ names. Changing this parameter will create a
+  new resource.
+
+* `name` - (Required, String) Human-readable name for the loadbalancer.
+
+* `description` - (Optional, String) Human-readable description for the loadbalancer.
+
+* `cross_vpc_backend` - (Optional, Bool) Enable this if you want to associate the IP addresses of backend servers with
+  your load balancer. Can only be true when updating.
+
+* `vpc_id` - (Optional, String, ForceNew) The vpc on which to create the loadbalancer. Changing this creates a new
+  loadbalancer.
+
+* `ipv4_subnet_id` - (Optional, String) The subnet on which to allocate the loadbalancer's ipv4 address.
+
+* `ipv6_network_id` - (Optional, String) The network on which to allocate the loadbalancer's ipv6 address.
+
+* `ipv6_bandwidth_id` - (Optional, String) The ipv6 bandwidth id. Only support shared bandwidth.
+
+* `ipv4_address` - (Optional, String) The ipv4 address of the load balancer.
+
+* `ipv4_eip_id` - (Optional, String, ForceNew) The ID of the EIP. Changing this parameter will create a new resource.
+
+-> **NOTE:** If the ipv4_eip_id parameter is configured, you do not need to configure the bandwidth parameters:
+`iptype`, `bandwidth_charge_mode`, `bandwidth_size` and `share_type`.
+
+* `iptype` - (Optional, String, ForceNew) Elastic IP type. Changing this parameter will create a new resource.
+
+* `bandwidth_charge_mode` - (Optional, String, ForceNew) Bandwidth billing type. Changing this parameter will create a
+  new resource.
+
+* `sharetype` - (Optional, String, ForceNew) Bandwidth sharing type. Changing this parameter will create a new resource.
+
+* `bandwidth_size` - (Optional, Int, ForceNew) Bandwidth size. Changing this parameter will create a new resource.
+
+* `l4_flavor_id` - (Optional, String) The L4 flavor id of the load balancer.
+
+* `l7_flavor_id` - (Optional, String) The L7 flavor id of the load balancer.
+
+* `tags` - (Optional, Map) The key/value pairs to associate with the loadbalancer.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `ipv4_eip` - The ipv4 eip address of the Load Balancer.
+* `ipv6_eip` - The ipv6 eip address of the Load Balancer.
+* `ipv6_eip_id` - The ipv6 eip id of the Load Balancer.
+* `ipv6_address` - The ipv6 address of the Load Balancer.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `update` - Default is 10 minute.
+* `delete` - Default is 5 minute.
+
+## Import
+
+ELB loadbalancer can be imported using the loadbalancer ID, e.g.
+
+```
+$ terraform import flexibleengine_lb_loadbalancer_v3.loadbalancer_1 5c20fdad-7288-11eb-b817-0255ac10158b
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attrubutes missing from the
+API response, security or some other reason. The missing attributes include: `ipv6_bandwidth_id`, `iptype`,
+`bandwidth_charge_mode`, `sharetype` and `bandwidth_size`.
+It is generally recommended running `terraform plan` after importing a loadbalancer.
+You can then decide if changes should be applied to the loadbalancer, or the resource
+definition should be updated to align with the loadbalancer. Also you can ignore changes as below.
+
+```
+resource "flexibleengine_lb_loadbalancer_v3" "loadbalancer_1" {
+    ...
+  lifecycle {
+    ignore_changes = [
+      ipv6_bandwidth_id, iptype, bandwidth_charge_mode, sharetype, bandwidth_size,
+    ]
+  }
+}
+```

--- a/flexibleengine/acceptance/resource_flexibleengine_lb_loadbalancer_v3_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_lb_loadbalancer_v3_test.go
@@ -1,0 +1,189 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/elb/v3/loadbalancers"
+	"github.com/chnsz/golangsdk/openstack/networking/v1/eips"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getELBResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.ElbV3Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating ELB v3 client: %s", err)
+	}
+
+	eipID := state.Primary.Attributes["ipv4_eip_id"]
+	eipType := state.Primary.Attributes["iptype"]
+	if eipType != "" && eipID != "" {
+		eipClient, err := c.NetworkingV1Client(OS_REGION_NAME)
+		if err != nil {
+			return nil, fmt.Errorf("Error creating VPC v1 client: %s", err)
+		}
+
+		if _, err := eips.Get(eipClient, eipID).Extract(); err != nil {
+			return nil, err
+		}
+	}
+
+	return loadbalancers.Get(client, state.Primary.ID).Extract()
+}
+
+func TestAccElbV3LoadBalancer_basic(t *testing.T) {
+	var lb loadbalancers.LoadBalancer
+	rName := acceptance.RandomAccResourceNameWithDash()
+	rNameUpdate := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "flexibleengine_lb_loadbalancer_v3.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&lb,
+		getELBResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccElbV3LoadBalancerConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "cross_vpc_backend", "false"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
+				),
+			},
+			{
+				Config: testAccElbV3LoadBalancerConfig_update(rName, rNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "cross_vpc_backend", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform_update"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccElbV3LoadBalancer_withEIP(t *testing.T) {
+	var lb loadbalancers.LoadBalancer
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "flexibleengine_lb_loadbalancer_v3.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&lb,
+		getELBResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccElbV3LoadBalancerConfig_withEIP(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "iptype", "5_bgp"),
+					resource.TestCheckResourceAttrSet(resourceName, "ipv4_eip_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccElbV3Config_base(rName string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_availability_zones" "test" {}
+
+resource "flexibleengine_vpc_v1" "test" {
+  name = "vpc_%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test" {
+  name        = "subnet_%s"
+  cidr        = "192.168.0.0/24"
+  gateway_ip  = "192.168.0.1"
+  vpc_id      = flexibleengine_vpc_v1.test.id
+  ipv6_enable = true
+}
+`, rName, rName)
+}
+
+func testAccElbV3LoadBalancerConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_lb_loadbalancer_v3" "test" {
+  name            = "%s"
+  ipv4_subnet_id  = flexibleengine_vpc_subnet_v1.test.subnet_id
+  ipv6_network_id = flexibleengine_vpc_subnet_v1.test.id
+
+  availability_zone = [
+    data.flexibleengine_availability_zones.test.names[0]
+  ]
+
+  tags = {
+    key   = "value"
+    owner = "terraform"
+  }
+}
+`, testAccElbV3Config_base(rName), rName)
+}
+
+func testAccElbV3LoadBalancerConfig_update(rName, rNameUpdate string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_lb_loadbalancer_v3" "test" {
+  name              = "%s"
+  cross_vpc_backend = true
+  ipv4_subnet_id    = flexibleengine_vpc_subnet_v1.test.subnet_id
+  ipv6_network_id   = flexibleengine_vpc_subnet_v1.test.id
+
+  availability_zone = [
+    data.flexibleengine_availability_zones.test.names[0]
+  ]
+
+  tags = {
+    key1  = "value1"
+    owner = "terraform_update"
+  }
+}
+`, testAccElbV3Config_base(rName), rNameUpdate)
+}
+
+func testAccElbV3LoadBalancerConfig_withEIP(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_lb_loadbalancer_v3" "test" {
+  name              = "%s"
+  ipv4_subnet_id    = flexibleengine_vpc_subnet_v1.test.subnet_id
+  availability_zone = [data.flexibleengine_availability_zones.test.names[0]]
+
+  iptype                = "5_bgp"
+  bandwidth_charge_mode = "traffic"
+  sharetype             = "PER"
+  bandwidth_size        = 5
+}
+`, testAccElbV3Config_base(rName), rName)
+}

--- a/flexibleengine/data_source_flexibleengine_elb_flavors.go
+++ b/flexibleengine/data_source_flexibleengine_elb_flavors.go
@@ -1,0 +1,166 @@
+package flexibleengine
+
+import (
+	"fmt"
+
+	"github.com/chnsz/golangsdk/openstack/elb/v3/flavors"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceElbFlavorsV3() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceElbFlavorsV3Read,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"max_connections": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"cps": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"qps": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"bandwidth": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			// Computed values.
+			"flavors": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"max_connections": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"cps": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"qps": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"bandwidth": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceElbFlavorsV3Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	region := GetRegion(d, config)
+	elbClient, err := config.ElbV3Client(region)
+	if err != nil {
+		return fmt.Errorf("Error creating ELB v3 client: %s", err)
+	}
+
+	listOpts := flavors.ListOpts{}
+	if v, ok := d.GetOk("type"); ok {
+		listOpts.Type = []string{v.(string)}
+	}
+
+	pages, err := flavors.List(elbClient, listOpts).AllPages()
+	if err != nil {
+		return err
+	}
+
+	allFlavors, err := flavors.ExtractFlavors(pages)
+	if err != nil {
+		return fmt.Errorf("Unable to retrieve flavors: %s", err)
+	}
+
+	maxConnections := d.Get("max_connections").(int)
+	cps := d.Get("cps").(int)
+	qps := d.Get("qps").(int)
+	bandwidth := d.Get("bandwidth").(int)
+
+	var ids []string
+	var s []map[string]interface{}
+	for _, flavor := range allFlavors {
+		if flavor.SoldOut {
+			continue
+		}
+
+		if maxConnections > 0 && flavor.Info.Connection != maxConnections {
+			continue
+		}
+
+		if cps > 0 && flavor.Info.Cps != cps {
+			continue
+		}
+
+		if qps > 0 && flavor.Info.Qps != qps {
+			continue
+		}
+
+		if bandwidth > 0 && flavor.Info.Bandwidth != bandwidth*1000 {
+			continue
+		}
+
+		ids = append(ids, flavor.ID)
+		mapping := map[string]interface{}{
+			"id":              flavor.ID,
+			"name":            flavor.Name,
+			"type":            flavor.Type,
+			"max_connections": flavor.Info.Connection,
+			"cps":             flavor.Info.Cps,
+			"qps":             flavor.Info.Qps,
+			"bandwidth":       int(flavor.Info.Bandwidth / 1000),
+		}
+		s = append(s, mapping)
+	}
+
+	if len(ids) < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
+	}
+
+	d.SetId(HashStrings(ids))
+
+	d.Set("region", region)
+	d.Set("ids", ids)
+	if err := d.Set("flavors", s); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/flexibleengine/data_source_flexibleengine_elb_flavors_test.go
+++ b/flexibleengine/data_source_flexibleengine_elb_flavors_test.go
@@ -1,0 +1,45 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccElbFlavorsDataSource_basic(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccElbFlavorsDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckElbFlavorDataSourceID("data.flexibleengine_elb_flavors.this"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckElbFlavorDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find elb flavors data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Elb Flavors data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+const testAccElbFlavorsDataSource_basic = `
+data "flexibleengine_elb_flavors" "this" {
+  type = "L7"
+}
+`

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/elb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/swr"
@@ -248,6 +249,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_identity_custom_role_v3":   dataSourceIdentityCustomRoleV3(),
 			"flexibleengine_vpcep_public_services":     dataSourceVPCEPPublicServices(),
 			"flexibleengine_vpcep_endpoints":           dataSourceVPCEPEndpoints(),
+			"flexibleengine_elb_flavors":               dataSourceElbFlavorsV3(),
 
 			// importing data source
 			"flexibleengine_cbr_vaults":       cbr.DataSourceCbrVaultsV3(),
@@ -401,6 +403,8 @@ func Provider() *schema.Provider {
 
 			"flexibleengine_vpc_v1":        vpc.ResourceVirtualPrivateCloudV1(),
 			"flexibleengine_vpc_subnet_v1": vpc.ResourceVpcSubnetV1(),
+
+			"flexibleengine_lb_loadbalancer_v3": elb.ResourceLoadBalancerV3(),
 
 			// Deprecated resource
 			"flexibleengine_elb_loadbalancer": resourceELoadBalancer(),


### PR DESCRIPTION
related to #755 

new resource: **flexibleengine_lb_loadbalancer_v3**
new data source: **flexibleengine_elb_flavors**

```
$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccElbV3LoadBalancer_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccElbV3LoadBalancer_basic -timeout 720m
=== RUN   TestAccElbV3LoadBalancer_basic
=== PAUSE TestAccElbV3LoadBalancer_basic
=== CONT  TestAccElbV3LoadBalancer_basic
--- PASS: TestAccElbV3LoadBalancer_basic (158.11s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      158.209s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccElbFlavorsDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccElbFlavorsDataSource_basic -timeout 720m
=== RUN   TestAccElbFlavorsDataSource_basic
=== PAUSE TestAccElbFlavorsDataSource_basic
=== CONT  TestAccElbFlavorsDataSource_basic
--- PASS: TestAccElbFlavorsDataSource_basic (35.77s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 35.824s
```