### PR TITLE
feat(apigw): add group and api resources

### DIFF
--- a/docs/resources/api_gateway_api.md
+++ b/docs/resources/api_gateway_api.md
@@ -1,0 +1,167 @@
+---
+subcategory: "API Gateway"
+---
+
+# flexibleengine_api_gateway_api
+
+Provides an API gateway API resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_api_gateway_group" "apigw_group" {
+  name        = "apigw_group"
+  description = "your descpiption"
+}
+
+resource "flexibleengine_api_gateway_api" "apigw_api" {
+  group_id                 = flexibleengine_api_gateway_group.apigw_group.id
+  name                     = "apigw_api"
+  description              = "your descpiption"
+  tags                     = ["tag1", "tag2"]
+  visibility               = 1
+  auth_type                = "IAM"
+  backend_type             = "HTTP"
+  request_protocol         = "HTTPS"
+  request_method           = "GET"
+  request_uri              = "/test/path1"
+  example_success_response = "example response"
+
+  http_backend {
+    protocol   = "HTTPS"
+    method     = "GET"
+    uri        = "/web/openapi"
+    url_domain = "backenddomain.com"
+    timeout    = 10000
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the API resource. If omitted, the provider-level
+  region will be used. Changing this creates a new API resource.
+
+* `name` - (Required, String) Specifies the name of the API. An API name consists of 3–64 characters, starting with a
+  letter. Only letters, digits, and underscores (_) are allowed.
+
+* `group_id` - (Required, String, ForceNew) Specifies the ID of the API group. Changing this creates a new resource.
+
+* `visibility` - (Required, Int) Specifies whether the API is available to the public. The value can only be 1 (public).
+
+* `auth_type` - (Required, String) Specifies the security authentication mode. The value can be 'APP', 'IAM', and '
+  NONE'.
+
+* `request_protocol` - (Optional, String) Specifies the request protocol. The value can be 'HTTP', 'HTTPS', and 'BOTH'
+  which means the API can be accessed through both 'HTTP' and 'HTTPS'. Defaults to 'HTTPS'.
+
+* `request_method` - (Required, String) Specifies the request method, including 'GET','POST','PUT' and etc..
+
+* `request_uri` - (Required, String) Specifies the request path of the API. The value must comply with URI
+  specifications.
+
+* `backend_type` - (Required, String) Specifies the service backend type. The value can be:
+  + 'HTTP': the web service backend
+  + 'FUNCTION': the FunctionGraph service backend
+  + 'MOCK': the Mock service backend
+
+* `http_backend` - (Optional, List) Specifies the configuration when backend_type selected 'HTTP' (documented below).
+
+* `function_backend` - (Optional, List) Specifies the configuration when backend_type selected 'FUNCTION' (documented
+  below).
+
+* `mock_backend` - (Optional, List) Specifies the configuration when backend_type selected 'MOCK' (documented below).
+
+* `request_parameter` - (Optional, List) the request parameter list (documented below).
+
+* `backend_parameter` - (Optional, List) the backend parameter list (documented below).
+
+* `tags` - (Optional, List) the tags of API in format of string list.
+
+* `description` - (Optional, String) Specifies the description of the API. The description cannot exceed 255 characters.
+
+* `version` - (Optional, String) Specifies the version of the API. A maximum of 16 characters are allowed.
+
+* `cors` - (Optional, Bool) Specifies whether CORS is supported or not.
+
+* `example_success_response` - (Required, String) Specifies the example response for a successful request. The length
+  cannot exceed 20,480 characters.
+
+* `example_failure_response` - (Optional, String) Specifies the example response for a failed request The length cannot
+  exceed 20,480 characters.
+
+The `http_backend` object supports the following:
+
+* `protocol` - (Required, String) Specifies the backend request protocol. The value can be 'HTTP' and 'HTTPS'.
+* `method` - (Optional, String) Specifies the backend request method, including 'GET','POST','PUT' and etc..
+* `uri` - (Required, String) Specifies the backend request path. The value must comply with URI specifications.
+* `vpc_channel` - (Optional, String) Specifies the VPC channel ID. This parameter and `url_domain` are alternative.
+* `url_domain` - (Optional, String) Specifies the backend service address. An endpoint URL is in the format of
+  "domain name (or IP address):port number", with up to 255 characters. This parameter and `vpc_channel` are
+  alternative.
+* `timeout` - (Optional, Int) Timeout duration (in ms) for API Gateway to request for the backend service. Defaults to
+  50000.
+
+The `function_backend` object supports the following:
+
+* `function_urn` - (Required, String) Specifies the function URN.
+* `invocation_type` - (Required, String) Specifies the invocation mode, which can be 'async' or 'sync'.
+* `version` - (Optional, String) Specifies the function version.
+* `timeout` - (Optional, Int) Timeout duration (in ms) for API Gateway to request for FunctionGraph. Defaults to 50000.
+
+The `mock_backend` object supports the following:
+
+* `result_content` - (Optional, String) Specifies the return result.
+* `version` - (Optional, String) Specifies the version of the Mock backend.
+* `description` - (Optional, String) Specifies the description of the Mock backend. The description cannot exceed 255
+  characters.
+
+The `request_parameter` object supports the following:
+
+* `name` - (Required, String) Specifies the input parameter name. A parameter name consists of 1–32 characters, starting
+  with a letter. Only letters, digits, periods (.), hyphens (-), and underscores (_) are allowed.
+* `location` - (Required, String) Specifies the input parameter location, which can be 'PATH', 'QUERY' or 'HEADER'.
+* `type` - (Required, String) Specifies the input parameter type, which can be 'STRING' or 'NUMBER'.
+* `required` - (Optional, Bool) Specifies whether the parameter is mandatory or not.
+* `default` - (Optional, String) Specifies the default value when the parameter is optional.
+* `description` - (Optional, String) Specifies the description of the parameter. The description cannot exceed 255
+  characters.
+
+The `backend_parameter` object supports the following:
+
+* `name` - (Required, String) Specifies the parameter name. A parameter name consists of 1–32 characters, starting with
+  a letter. Only letters, digits, periods (.), hyphens (-), and underscores (_) are allowed.
+* `location` - (Required, String) Specifies the parameter location, which can be 'PATH', 'QUERY' or 'HEADER'.
+* `type` - (Required, String) Specifies the parameter type, which can be 'REQUEST', 'CONSTANT', or 'SYSTEM'.
+* `value` - (Required, String) Specifies the parameter value, which is a string of not more than 255 characters. The
+  value varies depending on the parameter type:
+  + 'REQUEST': parameter name in `request_parameter`
+  + 'CONSTANT': real value of the parameter
+  + 'SYSTEM': gateway parameter name
+
+* `description` - (Optional, String) Specifies the description of the parameter. The description cannot exceed 255
+  characters.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the API.
+* `group_name` - The name of the API group to which the API belongs.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `delete` - Default is 10 minute.
+
+## Import
+
+API can be imported using the `id`, e.g.
+
+```
+$ terraform import flexibleengine_api_gateway_api.api "774438a28a574ac8a496325d1bf51807"
+```

--- a/docs/resources/api_gateway_group.md
+++ b/docs/resources/api_gateway_group.md
@@ -1,0 +1,44 @@
+---
+subcategory: "API Gateway"
+---
+
+# flexibleengine_api_gateway_group
+
+Provides an API gateway group resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_api_gateway_group" "apigw_group" {
+  name        = "apigw_group"
+  description = "your descpiption"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the API gateway group resource. If omitted, the
+  provider-level region will be used. Changing this creates a new gateway group resource.
+
+* `name` - (Required, String) Specifies the name of the API group. An API group name consists of 3–64 characters,
+  starting with a letter. Only letters, digits, and underscores (_) are allowed.
+
+* `description` - (Optional, String) Specifies the description of the API group. The description cannot exceed 255
+  characters.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the API group.
+* `status` - Status of the API group.
+
+## Import
+
+API groups can be imported using the `id`, e.g.
+
+```
+$ terraform import flexibleengine_api_gateway_group.apigw_group "c8738f7c-a4b0-4c5f-a202-bda7dc4018a4"
+```

--- a/flexibleengine/acceptance/resource_flexibleengine_api_gateway_api_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_api_gateway_api_test.go
@@ -1,0 +1,177 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/shared/v1/apis"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccApiGatewayAPI_basic(t *testing.T) {
+	var resName = "flexibleengine_api_gateway_api.acc_apigw_api"
+	rName := fmt.Sprintf("acc_test_%s", acctest.RandString(5))
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApiGatewayApiDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigwAPI_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApiGatewayApiExists(resName),
+					resource.TestCheckResourceAttr(resName, "name", rName),
+					resource.TestCheckResourceAttr(resName, "group_name", rName),
+					resource.TestCheckResourceAttr(resName, "cors", "false"),
+					resource.TestCheckResourceAttr(resName, "auth_type", "NONE"),
+					resource.TestCheckResourceAttr(resName, "visibility", "1"),
+					resource.TestCheckResourceAttr(resName, "backend_type", "HTTP"),
+					resource.TestCheckResourceAttr(resName, "request_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resName, "request_method", "GET"),
+					resource.TestCheckResourceAttr(resName, "request_uri", "/test/path1"),
+					resource.TestCheckResourceAttr(resName, "http_backend.0.protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resName, "http_backend.0.method", "GET"),
+					resource.TestCheckResourceAttr(resName, "http_backend.0.uri", "/web/openapi"),
+					resource.TestCheckResourceAttr(resName, "http_backend.0.timeout", "10000"),
+				),
+			},
+			{
+				Config: testAccApigwAPI_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApiGatewayApiExists(resName),
+					resource.TestCheckResourceAttr(resName, "description", "updated by acc test"),
+					resource.TestCheckResourceAttr(resName, "auth_type", "IAM"),
+					resource.TestCheckResourceAttr(resName, "cors", "true"),
+					resource.TestCheckResourceAttr(resName, "request_protocol", "BOTH"),
+					resource.TestCheckResourceAttr(resName, "request_uri", "/test/path2"),
+				),
+			},
+			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckApiGatewayApiDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	apigwClient, err := config.ApiGatewayV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating api gateway client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_api_gateway_api" {
+			continue
+		}
+
+		_, err := apis.Get(apigwClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("api gateway API still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckApiGatewayApiExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Resource %s not found", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		apigwClient, err := config.ApiGatewayV1Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating api gateway client: %s", err)
+		}
+
+		found, err := apis.Get(apigwClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("apigateway API not found")
+		}
+
+		return nil
+	}
+}
+
+func testAccApigwAPI_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_api_gateway_group" "acc_apigw_group" {
+  name        = "%s"
+  description = "created by acc test"
+}
+
+resource "flexibleengine_api_gateway_api" "acc_apigw_api" {
+  group_id    = flexibleengine_api_gateway_group.acc_apigw_group.id
+  name        = "%s"
+  visibility  = 1
+  description = "created by acc test"
+  tags        = ["tag1","tag2"]
+
+  auth_type        = "NONE"
+  backend_type     = "HTTP"
+  request_protocol = "HTTPS"
+  request_method   = "GET"
+  request_uri      = "/test/path1"
+  example_success_response = "this is a successful response"
+
+  http_backend {
+    protocol   = "HTTPS"
+    method     = "GET"
+    uri        = "/web/openapi"
+    url_domain = "yourdomain.com"
+    timeout    = 10000
+  }
+}
+`, rName, rName)
+}
+
+func testAccApigwAPI_update(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_api_gateway_group" "acc_apigw_group" {
+  name        = "%s"
+  description = "created by acc test"
+}
+
+resource "flexibleengine_api_gateway_api" "acc_apigw_api" {
+  group_id    = flexibleengine_api_gateway_group.acc_apigw_group.id
+  name        = "%s"
+  visibility  = 1
+  cors        = true
+  description = "updated by acc test"
+  tags        = ["tag1","tag2"]
+
+  auth_type        = "IAM"
+  backend_type     = "HTTP"
+  request_protocol = "BOTH"
+  request_method   = "GET"
+  request_uri      = "/test/path2"
+  example_success_response = "this is a successful response"
+
+  http_backend {
+    protocol   = "HTTPS"
+    method     = "GET"
+    uri        = "/web/openapi"
+    url_domain = "yourdomain.com"
+    timeout    = 10000
+  }
+}
+`, rName, rName)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_api_gateway_group_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_api_gateway_group_test.go
@@ -1,0 +1,117 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/shared/v1/groups"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func TestAccApiGatewayGroup_basic(t *testing.T) {
+	var resName = "flexibleengine_api_gateway_group.acc_apigw_group"
+	rName := fmt.Sprintf("acc_test_%s", acctest.RandString(5))
+	rNameUpdate := rName + "_Update"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApiGatewayGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigwGroup_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApiGatewayGroupExists(resName),
+					resource.TestCheckResourceAttr(resName, "name", rName),
+					resource.TestCheckResourceAttr(resName, "description", "created by acc test"),
+				),
+			},
+			{
+				Config: testAccApigwGroup_update(rNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApiGatewayGroupExists(resName),
+					resource.TestCheckResourceAttr(resName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resName, "description", "updated by acc test"),
+				),
+			},
+			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckApiGatewayGroupDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	apigwClient, err := config.ApiGatewayV1Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating api gateway client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_api_gateway_group" {
+			continue
+		}
+
+		_, err := groups.Get(apigwClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("api gateway group still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckApiGatewayGroupExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Resource %s not found", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		apigwClient, err := config.ApiGatewayV1Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating api gateway client: %s", err)
+		}
+
+		found, err := groups.Get(apigwClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("apigateway group not found")
+		}
+
+		return nil
+	}
+}
+
+func testAccApigwGroup_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_api_gateway_group" "acc_apigw_group" {
+  name        = "%s"
+  description = "created by acc test"
+}
+`, rName)
+}
+
+func testAccApigwGroup_update(rNameUpdate string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_api_gateway_group" "acc_apigw_group" {
+  name        = "%s"
+  description = "updated by acc test"
+}
+`, rNameUpdate)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
@@ -390,6 +391,8 @@ func Provider() *schema.Provider {
 			"flexibleengine_dli_queue":                          ResourceDliQueueV1(),
 
 			// importing resource
+			"flexibleengine_api_gateway_api":        huaweicloud.ResourceAPIGatewayAPI(),
+			"flexibleengine_api_gateway_group":      huaweicloud.ResourceAPIGatewayGroup(),
 			"flexibleengine_cbr_policy":             cbr.ResourceCBRPolicyV3(),
 			"flexibleengine_cbr_vault":              cbr.ResourceCBRVaultV3(),
 			"flexibleengine_fgs_dependency":         fgs.ResourceFgsDependency(),


### PR DESCRIPTION
new resource:
**flexibleengine_api_gateway_api**
**flexibleengine_api_gateway_group**

```
$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccApiGatewayGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccApiGatewayGroup_basic -timeout 720m
=== RUN   TestAccApiGatewayGroup_basic
=== PAUSE TestAccApiGatewayGroup_basic
=== CONT  TestAccApiGatewayGroup_basic
--- PASS: TestAccApiGatewayGroup_basic (90.52s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      90.60

$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccApiGatewayAPI_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccApiGatewayAPI_basic -timeout 720m
=== RUN   TestAccApiGatewayAPI_basic
=== PAUSE TestAccApiGatewayAPI_basic
=== CONT  TestAccApiGatewayAPI_basic
--- PASS: TestAccApiGatewayAPI_basic (80.08s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      81.913s
```