### PR TITLE
feat(elb): support to create listeners with v3 APIs

### DIFF
--- a/docs/resources/lb_listener_v3.md
+++ b/docs/resources/lb_listener_v3.md
@@ -1,0 +1,111 @@
+---
+subcategory: "Elastic Load Balance (ELB)"
+---
+
+# flexibleengine_lb_listener_v3
+
+Manages an ELB v3 listener resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_lb_loadbalancer_v3" "test" {
+  ...
+}
+
+resource "flexibleengine_lb_listener_v3" "basic" {
+  name            = "basic"
+  description     = "basic description"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v3.test.id
+
+  idle_timeout     = 60
+  request_timeout  = 60
+  response_timeout = 60
+
+  tags = {
+    key = "value"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the listener resource. If omitted, the
+  provider-level region will be used. Changing this creates a new listener.
+
+* `loadbalancer_id` - (Required, String, ForceNew) The load balancer on which to provision this listener. Changing this
+  creates a new listener.
+
+* `protocol` - (Required, String, ForceNew) The protocol can either be *TCP*, *UDP*, *HTTP* or *HTTPS*.
+  Changing this creates a new listener.
+
+* `protocol_port` - (Required, Int, ForceNew) The port on which to listen for client traffic. Changing this creates a
+  new listener.
+
+* `name` - (Optional, String) Human-readable name for the listener.
+
+* `default_pool_id` - (Optional, String) The ID of the default pool with which the listener is associated. Changing this
+  creates a new listener.
+
+* `description` - (Optional, String) Human-readable description for the listener.
+
+* `http2_enable` - (Optional, Bool) Specifies whether to use HTTP/2. The default value is false. This parameter is valid
+  only when the protocol is set to *HTTPS*.
+
+* `forward_eip` - (Optional, Bool) Specifies whether transfer the load balancer EIP in the X-Forward-EIP header to
+  backend servers. The default value is false. This parameter is valid only when the protocol is set to *HTTP* or
+  *HTTPS*.
+
+* `access_policy` - (Optional, String) Specifies the access policy for the listener. Valid options are *white* and
+  *black*.
+
+* `ip_group` - (Optional, String) Specifies the ip group id for the listener.
+
+* `server_certificate` - (Optional, String) Specifies the ID of the server certificate used by the listener.
+  This parameter is mandatory when protocol is set to *HTTPS*.
+
+* `sni_certificate` - (Optional, List) Lists the IDs of SNI certificates (server certificates with a domain name) used
+  by the listener. This parameter is valid when protocol is set to *HTTPS*.
+
+* `ca_certificate` - (Optional, String) Specifies the ID of the CA certificate used by the listener.
+  This parameter is valid when protocol is set to *HTTPS*.
+
+* `tls_ciphers_policy` - (Optional, String) Specifies the TLS cipher policy for the listener. Valid options are:
+  tls-1-0-inherit, tls-1-0, tls-1-1, tls-1-2, tls-1-2-strict, tls-1-2-fs, tls-1-0-with-1-3, and tls-1-2-fs-with-1-3.
+  This parameter is valid when protocol is set to *HTTPS*.
+
+* `idle_timeout` - (Optional, Int) Specifies the idle timeout for the listener. Value range: 0 to 4000.
+
+* `request_timeout` - (Optional, Int) Specifies the request timeout for the listener. Value range: 1 to 300.
+  This parameter is valid when protocol is set to *HTTP* or *HTTPS*.
+
+* `response_timeout` - (Optional, Int) Specifies the response timeout for the listener. Value range: 1 to 300.
+  This parameter is valid when protocol is set to *HTTP* or *HTTPS*.
+
+* `tags` - (Optional, Map) The key/value pairs to associate with the listener.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The unique ID for the listener.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `update` - Default is 10 minute.
+* `delete` - Default is 10 minute.
+
+## Import
+
+ELB listener can be imported using the listener ID, e.g.
+
+```
+$ terraform import flexibleengine_lb_listener_v3.listener_1 5c20fdad-7288-11eb-b817-0255ac10158b
+```

--- a/flexibleengine/acceptance/resource_flexibleengine_lb_listener_v3_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_lb_listener_v3_test.go
@@ -1,0 +1,113 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/elb/v3/listeners"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getELBListenerResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.ElbV3Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating ELB v3 client: %s", err)
+	}
+	return listeners.Get(client, state.Primary.ID).Extract()
+}
+
+func TestAccElbV3Listener_basic(t *testing.T) {
+	var listener listeners.Listener
+	rName := acceptance.RandomAccResourceNameWithDash()
+	rNameUpdate := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "flexibleengine_lb_listener_v3.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&listener,
+		getELBListenerResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccElbV3ListenerConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "forward_eip", "true"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
+				),
+			},
+			{
+				Config: testAccElbV3ListenerConfig_update(rName, rNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "forward_eip", "false"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform_update"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccElbV3ListenerConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_lb_listener_v3" "test" {
+  name            = "%s"
+  description     = "test description"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v3.test.id
+  forward_eip     = true
+
+  idle_timeout     = 62
+  request_timeout  = 63
+  response_timeout = 64
+
+  tags = {
+    key   = "value"
+    owner = "terraform"
+  }
+}
+`, testAccElbV3LoadBalancerConfig_basic(rName), rName)
+}
+
+func testAccElbV3ListenerConfig_update(rName, rNameUpdate string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_lb_listener_v3" "test" {
+  name            = "%s"
+  description     = "test description"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v3.test.id
+
+  idle_timeout     = 62
+  request_timeout  = 63
+  response_timeout = 64
+
+  tags = {
+    key1  = "value1"
+    owner = "terraform_update"
+  }
+}
+`, testAccElbV3LoadBalancerConfig_basic(rName), rNameUpdate)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -408,6 +408,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_vpc_subnet_v1": vpc.ResourceVpcSubnetV1(),
 
 			"flexibleengine_lb_loadbalancer_v3": elb.ResourceLoadBalancerV3(),
+			"flexibleengine_lb_listener_v3":     elb.ResourceListenerV3(),
 
 			// Deprecated resource
 			"flexibleengine_elb_loadbalancer": resourceELoadBalancer(),


### PR DESCRIPTION
related to #755 

new resource: **flexibleengine_lb_listener_v3**

```
$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccElbV3Listener_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccElbV3Listener_basic -timeout 720m
=== RUN   TestAccElbV3Listener_basic
=== PAUSE TestAccElbV3Listener_basic
=== CONT  TestAccElbV3Listener_basic
--- PASS: TestAccElbV3Listener_basic (187.56s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      187.661s
```