### PR TITLE
feat(cce): support data volume encryption in cce node and pool

### DIFF
--- a/docs/resources/cce_node_pool_v3.md
+++ b/docs/resources/cce_node_pool_v3.md
@@ -6,7 +6,6 @@ subcategory: "Cloud Container Engine (CCE)"
 
 Add a node pool to a container cluster.
 
-
 ## Example Usage
 
 ```hcl
@@ -38,9 +37,10 @@ resource "flexibleengine_cce_node_pool_v3" "node_pool" {
     volumetype = "SAS"
   }
 }
-``` 
+```
 
 ## Argument Reference
+
 The following arguments are supported:
 
 * `cluster_id` - (Required, String, ForceNew) ID of the cluster. Changing this parameter will create a new resource.
@@ -51,8 +51,8 @@ The following arguments are supported:
 
 * `flavor_id` - (Required, String, ForceNew) Specifies the flavor id. Changing this parameter will create a new resource.
 
-*  `type` - (Optional, String, ForceNew) Node Pool type. Possible values are: "vm" and "ElasticBMS".
- 
+* `type` - (Optional, String, ForceNew) Node Pool type. Possible values are: "vm" and "ElasticBMS".
+
 * `availability_zone` - (Optional, String, ForceNew) specify the name of the available partition (AZ).
     Default value is random to create nodes in a random AZ in the node pool.
     Changing this parameter will create a new resource.
@@ -104,31 +104,33 @@ The following arguments are supported:
 
 The `root_volume` block supports:
 
-* `size` - (Required, Int) Disk size in GB.
-    
-* `volumetype` - (Required, String) Disk type.
-    
-* `extend_params` - (Optional, Map) Disk expansion parameters in key/value pair format.
+* `size` - (Required, Int) Specifies the disk size in GB.
+
+* `volumetype` - (Required, String) Specifies the disk type.
+
+* `extend_params` - (Optional, Map) Specifies the disk expansion parameters in key/value pair format.
 
 The `data_volumes` block supports:
-    
-* `size` - (Required, Int) Disk size in GB.
-    
-* `volumetype` - (Required, String) Disk type.
-    
-* `extend_params` - (Optional, Map) Disk expansion parameters in key/value pair format.
+
+* `size` - (Required, Int) Specifies the disk size in GB.
+
+* `volumetype` - (Required, String) Specifies the disk type.
+
+* `kms_key_id` - (Optional, String) Specifies the KMS key ID. This is used to encrypt the volume.
+
+* `extend_params` - (Optional, Map) Specifies the disk expansion parameters in key/value pair format.
 
 The `taints` block supports:
-    
+
 * `key` - (Required, String) A key must contain 1 to 63 characters starting with a letter or digit.
   Only letters, digits, hyphens (-), underscores (_), and periods (.) are allowed.
   A DNS subdomain name can be used as the prefix of a key.
-    
+
 * `value` - (Required, String) A value must start with a letter or digit and can contain a maximum of 63 characters,
   including letters, digits, hyphens (-), underscores (_), and periods (.).
-    
+
 * `effect` - (Required, String) Available options are *NoSchedule*, *PreferNoSchedule* and *NoExecute*.
-    
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
@@ -140,14 +142,16 @@ In addition to all arguments above, the following attributes are exported:
 * `billing_mode` -  Billing mode of a node.
 
 ## Timeouts
+
 This resource provides the following timeouts configuration options:
-- `create` - Default is 20 minute.
-- `delete` - Default is 20 minute.
+
+* `create` - Default is 20 minute.
+* `delete` - Default is 20 minute.
 
 ## Import
 
 Node_pool can be imported using the cluster and node_pool id, e.g.
 
 ```
-$ terraform import flexibleengine_cce_node_pool_v3.node_pool_1 <cluster-id>/<node_pool-id>
+terraform import flexibleengine_cce_node_pool_v3.node_pool_1 <cluster-id>/<node_pool-id>
 ```

--- a/docs/resources/cce_node_v3.md
+++ b/docs/resources/cce_node_v3.md
@@ -2,8 +2,9 @@
 subcategory: "Cloud Container Engine (CCE)"
 ---
 
-# flexibleengine_cce_nodes_v3
-Add a node to a container cluster. 
+# flexibleengine_cce_node_v3
+
+Add a node to a container cluster.
 
 ## Example Usage
 
@@ -34,6 +35,7 @@ resource "flexibleengine_cce_node_v3" "node_1" {
 ```
 
 ## Argument Reference
+
 The following arguments are supported:
 
 * `cluster_id` - (Required) ID of the cluster. Changing this parameter will create a new resource.
@@ -41,10 +43,12 @@ The following arguments are supported:
 * `name` - (Optional) Node Name.
 
 * `flavor_id` - (Required) Specifies the flavor id. Changing this parameter will create a new resource.
-    
-* `availability_zone` - (Required) specify the name of the available partition (AZ). Changing this parameter will create a new resource.
 
-* `key_pair` - (Required) Key pair name when logging in to select the key pair mode. Changing this parameter will create a new resource.
+* `availability_zone` - (Required) specify the name of the available partition (AZ).
+  Changing this parameter will create a new resource.
+
+* `key_pair` - (Required) Key pair name when logging in to select the key pair mode.
+  Changing this parameter will create a new resource.
 
 * `os` - (Optional) Operating System of the node, possible values are EulerOS 2.2 and CentOS 7.6. Defaults to EulerOS 2.2.
     Changing this parameter will create a new resource.
@@ -57,13 +61,12 @@ The following arguments are supported:
 
 * `eip_ids` - (Optional) List of existing elastic IP IDs. Changing this parameter will create a new resource.
 
--> **Note:**
-If the `eip_ids` parameter is configured, you do not need to configure the `eip_count` and bandwidth parameters:
-`iptype`, `bandwidth_charge_mode`, `bandwidth_size` and `share_type`.
+  -> If the `eip_ids` parameter is configured, you do not need to configure the `eip_count` and bandwidth parameters:
+  `iptype`, `bandwidth_charge_mode`, `bandwidth_size` and `share_type`.
 
 * `eip_count` - (Optional) Number of elastic IPs to be dynamically created. Changing this parameter will create a new resource.
 
-* `iptype` - (Optional) Elastic IP type. 
+* `iptype` - (Optional) Elastic IP type.
 
 * `bandwidth_charge_mode` - (Optional) Bandwidth billing type. Changing this parameter will create a new resource.
 
@@ -87,11 +90,12 @@ If the `eip_ids` parameter is configured, you do not need to configure the `eip_
 * `postinstall` - (Optional) Script required after installation. The input value can be a Base64 encoded string or not.
    Changing this parameter will create a new resource.
 
-* `extend_param` - (Optional, Map, ForceNew) Extended parameter. Changing this parameter will create a new resource. Availiable keys :
+* `extend_param` - (Optional, Map, ForceNew) Extended parameter. Changing this parameter will create a new resource.
+  Availiable keys:
 
-    * `agency_name` - Specifies the agency name to provide temporary credentials for CCE node to access other cloud services.
-    * `dockerBaseSize` - The available disk space of a single docker container on the node in device mapper mode.
-    * `DockerLVMConfigOverride` - Docker data disk configurations. The following is an example default configuration:
+  + `agency_name` - Specifies the agency name to provide temporary credentials for CCE node to access other cloud services.
+  + `dockerBaseSize` - The available disk space of a single docker container on the node in device mapper mode.
+  + `DockerLVMConfigOverride` - Docker data disk configurations. The following is an example default configuration:
 
     ```hcl
     extend_param = {
@@ -102,27 +106,31 @@ If the `eip_ids` parameter is configured, you do not need to configure the `eip_
 **root_volume** **- (Required)** It corresponds to the system disk related configuration.
   Changing this parameter will create a new resource.
 
-  * `size` - (Required) Disk size in GB. 
-  * `volumetype` - (Required) Disk type.    
-  * `extend_params` - (Optional) Disk expansion parameters in key/value pair format.
+  * `size` - (Required) Specifies the disk size in GB.
+  * `volumetype` - (Required) Specifies the disk type.
+  * `extend_params` - (Optional) Specifies the disk expansion parameters in key/value pair format.
 
 **data_volumes** **- (Required)** Represents the data disk to be created.
   Changing this parameter will create a new resource.
-    
-  * `size` - (Required) Disk size in GB.
-  * `volumetype` - (Required) Disk type.  
-  * `extend_params` - (Optional) Disk expansion parameters in key/value pair format.
+
+  * `size` - (Required) Specifies the disk size in GB.
+  * `volumetype` - (Required) Specifies the disk type.
+  * `extend_params` - (Optional) Specifies the disk expansion parameters in key/value pair format.
+  * `kms_key_id` - (Optional) Specifies the ID of a KMS key. This is used to encrypt the volume.
+
+  -> You need to create an agency (EVSAccessKMS) when disk encryption is used in the current project for the first time ever.
+  The account and permission of the created agency are `op_svc_evs` and **KMS Administrator**, respectively.
 
 **taints** **- (Optional)** You can add taints to created nodes to configure anti-affinity.
   Changing this parameter will create a new resource.
   Each taint contains the following parameters:
 
-  * `key` - (Required) A key must contain 1 to 63 characters starting with a letter or digit. Only letters, digits, hyphens (-),
-    underscores (_), and periods (.) are allowed. A DNS subdomain name can be used as the prefix of a key.
-  * `value` - (Required) A value must start with a letter or digit and can contain a maximum of 63 characters, including letters,
-    digits, hyphens (-), underscores (_), and periods (.).
+  * `key` - (Required) A key must contain 1 to 63 characters starting with a letter or digit. Only letters, digits,
+    hyphens (-), underscores (_), and periods (.) are allowed. A DNS subdomain name can be used as the prefix of a key.
+  * `value` - (Required) A value must start with a letter or digit and can contain a maximum of 63 characters,
+    including letters, digits, hyphens (-), underscores (_), and periods (.).
   * `effect` - (Required) Available options are NoSchedule, PreferNoSchedule, and NoExecute.
-    
+
 ## Attributes Reference
 
 All above argument parameters can be exported as attribute parameters along with attribute reference.

--- a/flexibleengine/resource_flexibleengine_cce_node_pool.go
+++ b/flexibleengine/resource_flexibleengine_cce_node_pool.go
@@ -113,6 +113,11 @@ func resourceCCENodePool() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
+						"kms_key_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
 						"extend_params": {
 							Type:     schema.TypeMap,
 							Optional: true,


### PR DESCRIPTION
add `data_volumes.*.kms_key_id` to support encrypt a data volume.

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCCENodeV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCCENodeV3_basic -timeout 720m
=== RUN   TestAccCCENodeV3_basic
--- PASS: TestAccCCENodeV3_basic (878.21s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 878.290s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCCENodeV3_data_volume_encryption'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCCENodeV3_data_volume_encryption -timeout 720m
=== RUN   TestAccCCENodeV3_data_volume_encryption
=== PAUSE TestAccCCENodeV3_data_volume_encryption
=== CONT  TestAccCCENodeV3_data_volume_encryption
--- PASS: TestAccCCENodeV3_data_volume_encryption (827.92s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 827.975s
```