### PR TITLE
feat(eps) support enterprise management service

### DIFF
--- a/docs/data-sources/enterprise_project.md
+++ b/docs/data-sources/enterprise_project.md
@@ -1,0 +1,35 @@
+---
+subcategory: "Enterprise Project Management Service (EPS)"
+---
+
+# flexibleengine_enterprise_project
+
+Use this data source to get an enterprise project from Flexibleengine.
+
+## Example Usage
+
+```hcl
+data "flexibleengine_enterprise_project" "test" {
+  name = "test"
+}
+```
+
+## Argument Reference
+
+* `name` - (Optional, String) Specifies the enterprise project name. Fuzzy search is supported.
+
+* `id` - (Optional, String) Specifies the ID of an enterprise project. The value "0" indicates the default enterprise project.
+
+* `status` - (Optional, Int) Specifies the status of an enterprise project.
+    + 1 indicates Enabled.
+    + 2 indicates Disabled.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `description` - The supplementary information about the enterprise project.
+
+* `created_at` - The UTC time when the enterprise project was created. Example: 2018-05-18T06:49:06Z
+
+* `updated_at` - The UTC time when the enterprise project was modified. Example: 2018-05-28T02:21:36Z

--- a/docs/resources/enterprise_project.md
+++ b/docs/resources/enterprise_project.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Enterprise Project Management Service (EPS)"
+---
+
+# flexibleengine_enterprise_project
+
+Use this resource to manage an enterprise project within FlexibleEngine.
+
+-> Deleting enterprise projects is not support. If you destroy a resource of enterprise project,
+  the project is only disabled and removed from the state, but it remains in the cloud.
+  Please set `insecure = true` in provider block to ignore SSL certificate verification when you got an x509 error.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_enterprise_project" "test" {
+  name        = "test"
+  description = "example project"
+}
+```
+
+## Argument Reference
+
+* `name` - (Optional, String) Specifies the name of the enterprise project.
+  This parameter can contain 1 to 64 characters. Only letters, digits, underscores (_), and hyphens (-) are allowed.
+  The name must be unique in the domain and cannot include any form of the word "default" ("deFaulT", for instance).
+
+* `description` - (Optional, String) Specifies the description of the enterprise project.
+
+* `enable` - (Optional, Bool) Specifies whether to enable the enterprise project. Default to *true*.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `status` - Indicates the status of an enterprise project.
+  + 1 indicates Enabled.
+  + 2 indicates Disabled.
+
+* `type` - Indicates the type of the enterprise project.
+
+* `created_at` - Indicates the UTC time when the enterprise project was created. Example: 2018-05-18T06:49:06Z
+
+* `updated_at` - Indicates the UTC time when the enterprise project was modified. Example: 2018-05-28T02:21:36Z
+
+## Import
+
+Enterprise projects can be imported using the `id`, e.g.
+
+```
+$ terraform import flexibleengine_enterprise_project.test 88f889c7-270e-4e77-8230-bf7db08d9b0e
+```

--- a/flexibleengine/acceptance/data_source_flexibleengine_enterprise_project_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_enterprise_project_test.go
@@ -1,0 +1,38 @@
+package acceptance
+
+import (
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccEnterpriseProjectDataSource_basic(t *testing.T) {
+	dataSourceName := "data.flexibleengine_enterprise_project.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnterpriseProjectDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", "default"),
+					resource.TestCheckResourceAttr(dataSourceName, "id", "0"),
+				),
+			},
+		},
+	})
+}
+
+const testAccEnterpriseProjectDataSource_basic = `
+data "flexibleengine_enterprise_project" "test" {
+  name = "default"
+}
+`

--- a/flexibleengine/acceptance/resource_flexibleengine_enterprise_project_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_enterprise_project_test.go
@@ -1,0 +1,109 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/eps/v1/enterpriseprojects"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getResourceEnterpriseProject(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	epsClient, err := config.EnterpriseProjectClient(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to create EPS client : %s", err)
+	}
+
+	return enterpriseprojects.Get(epsClient, state.Primary.ID).Extract()
+
+}
+
+func TestAccEnterpriseProject_basic(t *testing.T) {
+	var project enterpriseprojects.Project
+
+	rName := acceptance.RandomAccResourceName()
+	updateName := rName + "update"
+	resourceName := "flexibleengine_enterprise_project.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&project,
+		getResourceEnterpriseProject,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckEnterpriseProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEnterpriseProject_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "terraform test"),
+					resource.TestCheckResourceAttr(resourceName, "status", "1"),
+				),
+			},
+			{
+				Config: testAccEnterpriseProject_update(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+					resource.TestCheckResourceAttr(resourceName, "description", "terraform test update"),
+					resource.TestCheckResourceAttr(resourceName, "status", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckEnterpriseProjectDestroy(s *terraform.State) error {
+	conf := testAccProvider.Meta().(*config.Config)
+	epsClient, err := conf.EnterpriseProjectClient(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Unable to create EPS client : %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_enterprise_project" {
+			continue
+		}
+
+		project, err := enterpriseprojects.Get(epsClient, rs.Primary.ID).Extract()
+		if err == nil {
+			if project.Status != 2 {
+				return fmt.Errorf("Project still active")
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccEnterpriseProject_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_enterprise_project" "test" {
+  name        = "%s"
+  description = "terraform test"
+}`, rName)
+}
+
+func testAccEnterpriseProject_update(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_enterprise_project" "test" {
+  name        = "%s"
+  description = "terraform test update"
+}`, rName)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -15,6 +15,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/elb"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eps"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/swr"
@@ -253,8 +254,9 @@ func Provider() *schema.Provider {
 			"flexibleengine_elb_flavors":               dataSourceElbFlavorsV3(),
 
 			// importing data source
-			"flexibleengine_cbr_vaults":       cbr.DataSourceCbrVaultsV3(),
-			"flexibleengine_fgs_dependencies": fgs.DataSourceFunctionGraphDependencies(),
+			"flexibleengine_enterprise_project": eps.DataSourceEnterpriseProject(),
+			"flexibleengine_cbr_vaults":         cbr.DataSourceCbrVaultsV3(),
+			"flexibleengine_fgs_dependencies":   fgs.DataSourceFunctionGraphDependencies(),
 
 			// Deprecated data source
 			"flexibleengine_compute_availability_zones_v2":      dataSourceAvailabilityZones(),
@@ -391,8 +393,10 @@ func Provider() *schema.Provider {
 			"flexibleengine_dli_queue":                          ResourceDliQueueV1(),
 
 			// importing resource
-			"flexibleengine_api_gateway_api":        huaweicloud.ResourceAPIGatewayAPI(),
-			"flexibleengine_api_gateway_group":      huaweicloud.ResourceAPIGatewayGroup(),
+			"flexibleengine_api_gateway_api":   huaweicloud.ResourceAPIGatewayAPI(),
+			"flexibleengine_api_gateway_group": huaweicloud.ResourceAPIGatewayGroup(),
+
+			"flexibleengine_enterprise_project":     eps.ResourceEnterpriseProject(),
 			"flexibleengine_cbr_policy":             cbr.ResourceCBRPolicyV3(),
 			"flexibleengine_cbr_vault":              cbr.ResourceCBRVaultV3(),
 			"flexibleengine_fgs_dependency":         fgs.ResourceFgsDependency(),
@@ -526,6 +530,9 @@ func configureProvider(_ context.Context, d *schema.ResourceData) (interface{}, 
 	}
 	if _, ok := endpoints["dns"]; !ok {
 		endpoints["dns"] = fmt.Sprintf("https://dns.%s/", config.Cloud)
+	}
+	if _, ok := endpoints["eps"]; !ok {
+		endpoints["eps"] = fmt.Sprintf("https://eps.%s/", config.Cloud)
 	}
 
 	config.Endpoints = endpoints


### PR DESCRIPTION
```
$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccEnterpriseProject_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccEnterpriseProject_basic -timeout 720m
=== RUN   TestAccEnterpriseProject_basic
=== PAUSE TestAccEnterpriseProject_basic
=== CONT  TestAccEnterpriseProject_basic
--- PASS: TestAccEnterpriseProject_basic (75.40s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      75.522s

$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccEnterpriseProjectDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccEnterpriseProjectDataSource_basic -timeout 720m
=== RUN   TestAccEnterpriseProjectDataSource_basic
=== PAUSE TestAccEnterpriseProjectDataSource_basic
=== CONT  TestAccEnterpriseProjectDataSource_basic
--- PASS: TestAccEnterpriseProjectDataSource_basic (36.73s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      36.852s
```