### PR TITLE
feat(elb): add elb ipgroup and certificate resource

### DIFF
--- a/docs/data-sources/elb_certificate.md
+++ b/docs/data-sources/elb_certificate.md
@@ -1,0 +1,44 @@
+---
+subcategory: "Elastic Load Balance (ELB)"
+---
+
+# flexibleengine_elb_certificate
+
+Use this data source to get the ELB certificate in FlexibleEngine.
+
+## Example Usage
+
+```hcl
+variable "certificate_name" {}
+
+data "flexibleengine_elb_certificate" "test" {
+  name = var.certificate_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to obtain the Dedicated ELB certificate. If omitted, the
+  provider-level region will be used.
+
+* `name` - (Required, String) The name of certificate. The value is case sensitive and does not supports fuzzy matching.
+
+  -> **NOTE:** The certificate name is not unique. Only returns the last created one when matched multiple certificates.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The certificate ID in UUID format.
+
+* `domain` - The domain of the certificate. This parameter is valid only when `type` is "server".
+
+* `type` - Specifies the certificate type. The value can be one of the following:
+  + `server`: indicates the server certificate.
+  + `client`: indicates the CA certificate.
+
+* `description` - Human-readable description for the certificate.
+
+* `expiration` - Indicates the time when the certificate expires.

--- a/docs/resources/elb_certificate.md
+++ b/docs/resources/elb_certificate.md
@@ -1,21 +1,18 @@
 ---
-subcategory: "Deprecated"
+subcategory: "Elastic Load Balance (ELB)"
 ---
 
-# flexibleengine_lb_certificate_v2
+# flexibleengine_elb_certificate
 
-Manages an **enhanced** load balancer certificate resource within FlexibleEngine.
-
-!> **Warning:** It has been deprecated, using `flexibleengine_elb_certificate` instead.
+Manages an ELB certificate resource within FlexibleEngine.
 
 ## Example Usage
 
 ```hcl
-resource "flexibleengine_lb_certificate_v2" "certificate_1" {
+resource "flexibleengine_elb_certificate" "certificate_1" {
   name        = "certificate_1"
   description = "terraform test certificate"
   domain      = "www.elb.com"
-
   private_key = <<EOT
 -----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN2s8tZ/6LC3X82fajpVsYqF1x
@@ -46,7 +43,7 @@ nEqm7HWkNxHhf8A6En/IjleuddS1sf9e/x+TJN1Xhnt9W6pe7Fk1
 -----END RSA PRIVATE KEY-----
 EOT
 
-certificate = <<EOT
+  certificate = <<EOT
 -----BEGIN CERTIFICATE-----
 MIIDpTCCAo2gAwIBAgIJAKdmmOBYnFvoMA0GCSqGSIb3DQEBCwUAMGkxCzAJBgNV
 BAYTAnh4MQswCQYDVQQIDAJ4eDELMAkGA1UEBwwCeHgxCzAJBgNVBAoMAnh4MQsw
@@ -77,31 +74,47 @@ EOT
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to obtain the V2 Networking client.
-    A Networking client is needed to create an LB certificate. If omitted, the
-    `region` argument of the provider is used. Changing this creates a new
-    LB certificate.
+* `region` - (Optional, String, ForceNew) The region in which to create the ELB certificate resource. If omitted, the
+  provider-level region will be used. Changing this creates a new certificate.
 
-* `name` - (Optional) Human-readable name for the Certificate. Does not have
-    to be unique.
+* `name` - (Optional, String) Specifies the name of the certificate. Does not have to be unique.
 
-* `private_key` - (Required) The private encrypted key of the Certificate, PEM format.
+* `description` - (Optional, String) Specifies the description of the certificate.
 
-* `certificate` - (Required) The public encrypted key of the Certificate, PEM format.
+* `type` - (Optional, String, ForceNew) Specifies the certificate type. The default value is "server".
+  The value can be one of the following:
+  + server: indicates the server certificate.
+  + client: indicates the CA certificate.
 
-* `description` - (Optional) Human-readable description for the Certificate.
+* `certificate` - (Required, String) Specifies the public encrypted key of the certificate, PEM format.
 
-* `domain` - (Optional) The domain of the Certificate.
+* `private_key` - (Optional, String) Specifies the private encrypted key of the certificate, PEM format.
+  This parameter is valid and mandatory only when `type` is set to "server".
+
+* `domain` - (Optional, String) Specifies the domain of the certificate. The value contains a maximum of 100 characters.
+  This parameter is valid only when `type` is set to "server".
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
-* `region` - See Argument Reference above.
-* `name` - See Argument Reference above.
-* `description` - See Argument Reference above.
-* `domain` - See Argument Reference above.
-* `private_key` - See Argument Reference above.
-* `certificate` - See Argument Reference above.
+* `id` - Specifies a resource ID in UUID format.
 * `update_time` - Indicates the update time.
 * `create_time` - Indicates the creation time.
+* `expire_time` - Indicates the expire time.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `update` - Default is 10 minute.
+* `delete` - Default is 5 minute.
+
+## Import
+
+ELB certificate can be imported using the certificate ID, e.g.
+
+```
+$ terraform import flexibleengine_elb_certificate.certificate_1 5c20fdad-7288-11eb-b817-0255ac10158b
+```

--- a/docs/resources/elb_ipgroup.md
+++ b/docs/resources/elb_ipgroup.md
@@ -1,0 +1,61 @@
+---
+subcategory: "Elastic Load Balance (ELB)"
+---
+
+# flexibleengine_elb_ipgroup
+
+Manages an ELB IP Group resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_elb_ipgroup" "basic" {
+  name        = "basic"
+  description = "basic example"
+
+  ip_list {
+    ip          = "192.168.10.10"
+    description = "ECS01"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the ip group resource. If omitted, the
+  provider-level region will be used. Changing this creates a new ip group.
+
+* `name` - (Required, String) Specifies the name of the ip group.
+
+* `description` - (Optional, String) Specifies the description of the ip group.
+
+* `ip_list` - (Required, List) Specifies an array of one or more ip addresses. The ip_list object structure is
+  documented below.
+
+The `ip_list` block supports:
+
+* `ip` - (Required, String) IP address or CIDR block.
+
+* `description` - (Optional, String) Human-readable description for the ip.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The uuid of the ip group.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `update` - Default is 10 minute.
+* `delete` - Default is 5 minute.
+
+ELB IP group can be imported using the IP group ID, e.g.
+
+```
+$ terraform import flexibleengine_elb_ipgroup.group_1 5c20fdad-7288-11eb-b817-0255ac10158b
+```

--- a/flexibleengine/acceptance/resource_flexibleengine_elb_certificate_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_elb_certificate_test.go
@@ -1,0 +1,298 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/elb/v3/certificates"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccElbV3Certificate_basic(t *testing.T) {
+	var c certificates.Certificate
+	name := fmt.Sprintf("tf-cert-%s", acctest.RandString(5))
+	resourceName := "flexibleengine_elb_certificate.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckElbV3CertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccElbV3CertificateConfig_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckElbV3CertificateExists(resourceName, &c),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "type", "server"),
+				),
+			},
+			{
+				Config: testAccElbV3CertificateConfig_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_updated", name)),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccElbV3Certificate_client(t *testing.T) {
+	var c certificates.Certificate
+	name := fmt.Sprintf("tf-cert-%s", acctest.RandString(5))
+	resourceName := "flexibleengine_elb_certificate.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckElbV3CertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccElbV3CertificateConfig_client(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckElbV3CertificateExists(resourceName, &c),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "type", "client"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckElbV3CertificateDestroy(s *terraform.State) error {
+	conf := acceptance.TestAccProvider.Meta().(*config.Config)
+	elbClient, err := conf.ElbV3Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating ELB v3 client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_elb_certificate" {
+			continue
+		}
+
+		_, err := certificates.Get(elbClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("certificate still exists: %s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckElbV3CertificateExists(
+	n string, c *certificates.Certificate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conf := acceptance.TestAccProvider.Meta().(*config.Config)
+		elbClient, err := conf.ElbV3Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating ELB v3 client: %s", err)
+		}
+
+		found, err := certificates.Get(elbClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("Certificate not found")
+		}
+
+		*c = *found
+
+		return nil
+	}
+}
+
+func testAccElbV3CertificateConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_elb_certificate" "test" {
+  name        = "%s"
+  description = "terraform test certificate"
+  domain      = "www.elb.com"
+  private_key = <<EOT
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN2s8tZ/6LC3X82fajpVsYqF1x
+qEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYldiE6Vp8HH5BSKaCWKVg8lGWg1
+UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb3iyNBmiZ8aZhGw2pI1YwR+15
+MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dzQ8z1JXWdg8/9Zx7Ktvgwu5PQ
+M3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5mf2DPkVgM08XAgaLJcLigwD5
+13koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwIDAQABAoIBACU9S5fjD9/jTMXA
+DRs08A+gGgZUxLn0xk+NAPX3LyB1tfdkCaFB8BccLzO6h3KZuwQOBPv6jkdvEDbx
+Nwyw3eA/9GJsIvKiHc0rejdvyPymaw9I8MA7NbXHaJrY7KpqDQyk6sx+aUTcy5jg
+iMXLWdwXYHhJ/1HVOo603oZyiS6HZeYU089NDUcX+1SJi3e5Ke0gPVXEqCq1O11/
+rh24bMxnwZo4PKBWdcMBN5Zf/4ij9vrZE+fFzW7vGBO48A5lvZxWU2U5t/OZQRtN
+1uLOHmMFa0FIF2aWbTVfwdUWAFsvAOkHj9VV8BXOUwKOUuEktdkfAlvrxmsFrO/H
+yDeYYPkCgYEA/S55CBbR0sMXpSZ56uRn8JHApZJhgkgvYr+FqDlJq/e92nAzf01P
+RoEBUajwrnf1ycevN/SDfbtWzq2XJGqhWdJmtpO16b7KBsC6BdRcH6dnOYh31jgA
+vABMIP3wzI4zSVTyxRE8LDuboytF1mSCeV5tHYPQTZNwrplDnLQhywcCgYEAw8Yc
+Uk/eiFr3hfH/ZohMfV5p82Qp7DNIGRzw8YtVG/3+vNXrAXW1VhugNhQY6L+zLtJC
+aKn84ooup0m3YCg0hvINqJuvzfsuzQgtjTXyaE0cEwsjUusOmiuj09vVx/3U7siK
+Hdjd2ICPCvQ6Q8tdi8jV320gMs05AtaBkZdsiWUCgYEAtLw4Kk4f+xTKDFsrLUNf
+75wcqhWVBiwBp7yQ7UX4EYsJPKZcHMRTk0EEcAbpyaJZE3I44vjp5ReXIHNLMfPs
+uvI34J4Rfot0LN3n7cFrAi2+wpNo+MOBwrNzpRmijGP2uKKrq4JiMjFbKV/6utGF
+Up7VxfwS904JYpqGaZctiIECgYA1A6nZtF0riY6ry/uAdXpZHL8ONNqRZtWoT0kD
+79otSVu5ISiRbaGcXsDExC52oKrSDAgFtbqQUiEOFg09UcXfoR6HwRkba2CiDwve
+yHQLQI5Qrdxz8Mk0gIrNrSM4FAmcW9vi9z4kCbQyoC5C+4gqeUlJRpDIkQBWP2Y4
+2ct/bQKBgHv8qCsQTZphOxc31BJPa2xVhuv18cEU3XLUrVfUZ/1f43JhLp7gynS2
+ep++LKUi9D0VGXY8bqvfJjbECoCeu85vl8NpCXwe/LoVoIn+7KaVIZMwqoGMfgNl
+nEqm7HWkNxHhf8A6En/IjleuddS1sf9e/x+TJN1Xhnt9W6pe7Fk1
+-----END RSA PRIVATE KEY-----
+EOT
+
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIDpTCCAo2gAwIBAgIJAKdmmOBYnFvoMA0GCSqGSIb3DQEBCwUAMGkxCzAJBgNV
+BAYTAnh4MQswCQYDVQQIDAJ4eDELMAkGA1UEBwwCeHgxCzAJBgNVBAoMAnh4MQsw
+CQYDVQQLDAJ4eDELMAkGA1UEAwwCeHgxGTAXBgkqhkiG9w0BCQEWCnh4QDE2My5j
+b20wHhcNMTcxMjA0MDM0MjQ5WhcNMjAxMjAzMDM0MjQ5WjBpMQswCQYDVQQGEwJ4
+eDELMAkGA1UECAwCeHgxCzAJBgNVBAcMAnh4MQswCQYDVQQKDAJ4eDELMAkGA1UE
+CwwCeHgxCzAJBgNVBAMMAnh4MRkwFwYJKoZIhvcNAQkBFgp4eEAxNjMuY29tMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN
+2s8tZ/6LC3X82fajpVsYqF1xqEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYld
+iE6Vp8HH5BSKaCWKVg8lGWg1UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb
+3iyNBmiZ8aZhGw2pI1YwR+15MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dz
+Q8z1JXWdg8/9Zx7Ktvgwu5PQM3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5
+mf2DPkVgM08XAgaLJcLigwD513koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwID
+AQABo1AwTjAdBgNVHQ4EFgQUo5A2tIu+bcUfvGTD7wmEkhXKFjcwHwYDVR0jBBgw
+FoAUo5A2tIu+bcUfvGTD7wmEkhXKFjcwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0B
+AQsFAAOCAQEAWJ2rS6Mvlqk3GfEpboezx2J3X7l1z8Sxoqg6ntwB+rezvK3mc9H0
+83qcVeUcoH+0A0lSHyFN4FvRQL6X1hEheHarYwJK4agb231vb5erasuGO463eYEG
+r4SfTuOm7SyiV2xxbaBKrXJtpBp4WLL/s+LF+nklKjaOxkmxUX0sM4CTA7uFJypY
+c8Tdr8lDDNqoUtMD8BrUCJi+7lmMXRcC3Qi3oZJW76ja+kZA5mKVFPd1ATih8TbA
+i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
+i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+8Kg==
+-----END CERTIFICATE-----
+EOT
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+`, name)
+}
+
+func testAccElbV3CertificateConfig_update(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_elb_certificate" "test" {
+  name        = "%s_updated"
+  description = "terraform test certificate"
+  domain      = "www.elb.com"
+  private_key = <<EOT
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN2s8tZ/6LC3X82fajpVsYqF1x
+qEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYldiE6Vp8HH5BSKaCWKVg8lGWg1
+UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb3iyNBmiZ8aZhGw2pI1YwR+15
+MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dzQ8z1JXWdg8/9Zx7Ktvgwu5PQ
+M3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5mf2DPkVgM08XAgaLJcLigwD5
+13koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwIDAQABAoIBACU9S5fjD9/jTMXA
+DRs08A+gGgZUxLn0xk+NAPX3LyB1tfdkCaFB8BccLzO6h3KZuwQOBPv6jkdvEDbx
+Nwyw3eA/9GJsIvKiHc0rejdvyPymaw9I8MA7NbXHaJrY7KpqDQyk6sx+aUTcy5jg
+iMXLWdwXYHhJ/1HVOo603oZyiS6HZeYU089NDUcX+1SJi3e5Ke0gPVXEqCq1O11/
+rh24bMxnwZo4PKBWdcMBN5Zf/4ij9vrZE+fFzW7vGBO48A5lvZxWU2U5t/OZQRtN
+1uLOHmMFa0FIF2aWbTVfwdUWAFsvAOkHj9VV8BXOUwKOUuEktdkfAlvrxmsFrO/H
+yDeYYPkCgYEA/S55CBbR0sMXpSZ56uRn8JHApZJhgkgvYr+FqDlJq/e92nAzf01P
+RoEBUajwrnf1ycevN/SDfbtWzq2XJGqhWdJmtpO16b7KBsC6BdRcH6dnOYh31jgA
+vABMIP3wzI4zSVTyxRE8LDuboytF1mSCeV5tHYPQTZNwrplDnLQhywcCgYEAw8Yc
+Uk/eiFr3hfH/ZohMfV5p82Qp7DNIGRzw8YtVG/3+vNXrAXW1VhugNhQY6L+zLtJC
+aKn84ooup0m3YCg0hvINqJuvzfsuzQgtjTXyaE0cEwsjUusOmiuj09vVx/3U7siK
+Hdjd2ICPCvQ6Q8tdi8jV320gMs05AtaBkZdsiWUCgYEAtLw4Kk4f+xTKDFsrLUNf
+75wcqhWVBiwBp7yQ7UX4EYsJPKZcHMRTk0EEcAbpyaJZE3I44vjp5ReXIHNLMfPs
+uvI34J4Rfot0LN3n7cFrAi2+wpNo+MOBwrNzpRmijGP2uKKrq4JiMjFbKV/6utGF
+Up7VxfwS904JYpqGaZctiIECgYA1A6nZtF0riY6ry/uAdXpZHL8ONNqRZtWoT0kD
+79otSVu5ISiRbaGcXsDExC52oKrSDAgFtbqQUiEOFg09UcXfoR6HwRkba2CiDwve
+yHQLQI5Qrdxz8Mk0gIrNrSM4FAmcW9vi9z4kCbQyoC5C+4gqeUlJRpDIkQBWP2Y4
+2ct/bQKBgHv8qCsQTZphOxc31BJPa2xVhuv18cEU3XLUrVfUZ/1f43JhLp7gynS2
+ep++LKUi9D0VGXY8bqvfJjbECoCeu85vl8NpCXwe/LoVoIn+7KaVIZMwqoGMfgNl
+nEqm7HWkNxHhf8A6En/IjleuddS1sf9e/x+TJN1Xhnt9W6pe7Fk1
+-----END RSA PRIVATE KEY-----
+EOT
+
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIDpTCCAo2gAwIBAgIJAKdmmOBYnFvoMA0GCSqGSIb3DQEBCwUAMGkxCzAJBgNV
+BAYTAnh4MQswCQYDVQQIDAJ4eDELMAkGA1UEBwwCeHgxCzAJBgNVBAoMAnh4MQsw
+CQYDVQQLDAJ4eDELMAkGA1UEAwwCeHgxGTAXBgkqhkiG9w0BCQEWCnh4QDE2My5j
+b20wHhcNMTcxMjA0MDM0MjQ5WhcNMjAxMjAzMDM0MjQ5WjBpMQswCQYDVQQGEwJ4
+eDELMAkGA1UECAwCeHgxCzAJBgNVBAcMAnh4MQswCQYDVQQKDAJ4eDELMAkGA1UE
+CwwCeHgxCzAJBgNVBAMMAnh4MRkwFwYJKoZIhvcNAQkBFgp4eEAxNjMuY29tMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN
+2s8tZ/6LC3X82fajpVsYqF1xqEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYld
+iE6Vp8HH5BSKaCWKVg8lGWg1UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb
+3iyNBmiZ8aZhGw2pI1YwR+15MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dz
+Q8z1JXWdg8/9Zx7Ktvgwu5PQM3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5
+mf2DPkVgM08XAgaLJcLigwD513koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwID
+AQABo1AwTjAdBgNVHQ4EFgQUo5A2tIu+bcUfvGTD7wmEkhXKFjcwHwYDVR0jBBgw
+FoAUo5A2tIu+bcUfvGTD7wmEkhXKFjcwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0B
+AQsFAAOCAQEAWJ2rS6Mvlqk3GfEpboezx2J3X7l1z8Sxoqg6ntwB+rezvK3mc9H0
+83qcVeUcoH+0A0lSHyFN4FvRQL6X1hEheHarYwJK4agb231vb5erasuGO463eYEG
+r4SfTuOm7SyiV2xxbaBKrXJtpBp4WLL/s+LF+nklKjaOxkmxUX0sM4CTA7uFJypY
+c8Tdr8lDDNqoUtMD8BrUCJi+7lmMXRcC3Qi3oZJW76ja+kZA5mKVFPd1ATih8TbA
+i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
+i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+9Aa==
+-----END CERTIFICATE-----
+EOT
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
+}
+`, name)
+}
+
+func testAccElbV3CertificateConfig_client(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_elb_certificate" "test" {
+  name        = "%s"
+  description = "terraform CA certificate"
+  type        = "client"
+
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIDpTCCAo2gAwIBAgIJAKdmmOBYnFvoMA0GCSqGSIb3DQEBCwUAMGkxCzAJBgNV
+BAYTAnh4MQswCQYDVQQIDAJ4eDELMAkGA1UEBwwCeHgxCzAJBgNVBAoMAnh4MQsw
+CQYDVQQLDAJ4eDELMAkGA1UEAwwCeHgxGTAXBgkqhkiG9w0BCQEWCnh4QDE2My5j
+b20wHhcNMTcxMjA0MDM0MjQ5WhcNMjAxMjAzMDM0MjQ5WjBpMQswCQYDVQQGEwJ4
+eDELMAkGA1UECAwCeHgxCzAJBgNVBAcMAnh4MQswCQYDVQQKDAJ4eDELMAkGA1UE
+CwwCeHgxCzAJBgNVBAMMAnh4MRkwFwYJKoZIhvcNAQkBFgp4eEAxNjMuY29tMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwZ5UJULAjWr7p6FVwGRQRjFN
+2s8tZ/6LC3X82fajpVsYqF1xqEuUDndDXVD09E4u83MS6HO6a3bIVQDp6/klnYld
+iE6Vp8HH5BSKaCWKVg8lGWg1UM9wZFnlryi14KgmpIFmcu9nA8yV/6MZAe6RSDmb
+3iyNBmiZ8aZhGw2pI1YwR+15MVqFFGB+7ExkziROi7L8CFCyCezK2/oOOvQsH1dz
+Q8z1JXWdg8/9Zx7Ktvgwu5PQM3cJtSHX6iBPOkMU8Z8TugLlTqQXKZOEgwajwvQ5
+mf2DPkVgM08XAgaLJcLigwD513koAdtJd5v+9irw+5LAuO3JclqwTvwy7u/YwwID
+AQABo1AwTjAdBgNVHQ4EFgQUo5A2tIu+bcUfvGTD7wmEkhXKFjcwHwYDVR0jBBgw
+FoAUo5A2tIu+bcUfvGTD7wmEkhXKFjcwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0B
+AQsFAAOCAQEAWJ2rS6Mvlqk3GfEpboezx2J3X7l1z8Sxoqg6ntwB+rezvK3mc9H0
+83qcVeUcoH+0A0lSHyFN4FvRQL6X1hEheHarYwJK4agb231vb5erasuGO463eYEG
+r4SfTuOm7SyiV2xxbaBKrXJtpBp4WLL/s+LF+nklKjaOxkmxUX0sM4CTA7uFJypY
+c8Tdr8lDDNqoUtMD8BrUCJi+7lmMXRcC3Qi3oZJW76ja+kZA5mKVFPd1ATih8TbA
+i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
+i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+8Kg==
+-----END CERTIFICATE-----
+EOT
+}
+`, name)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_elb_ipgroup_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_elb_ipgroup_test.go
@@ -1,0 +1,137 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/elb/v3/ipgroups"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccElbV3IpGroup_basic(t *testing.T) {
+	var c ipgroups.IpGroup
+	name := fmt.Sprintf("tf-acc-%s", acctest.RandString(5))
+	resourceName := "flexibleengine_elb_ipgroup.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckElbV3IpGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccElbV3IpGroupConfig_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckElbV3IpGroupExists(resourceName, &c),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", "terraform test"),
+					resource.TestCheckResourceAttr(resourceName, "ip_list.#", "1"),
+				),
+			},
+			{
+				Config: testAccElbV3IpGroupConfig_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s_updated", name)),
+					resource.TestCheckResourceAttr(resourceName, "description", "terraform test updated"),
+					resource.TestCheckResourceAttr(resourceName, "ip_list.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckElbV3IpGroupDestroy(s *terraform.State) error {
+	conf := acceptance.TestAccProvider.Meta().(*config.Config)
+	elbClient, err := conf.ElbV3Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating ELB v3 client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_elb_ipgroup" {
+			continue
+		}
+
+		_, err := ipgroups.Get(elbClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("IpGroup still exists: %s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckElbV3IpGroupExists(
+	n string, c *ipgroups.IpGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conf := acceptance.TestAccProvider.Meta().(*config.Config)
+		elbClient, err := conf.ElbV3Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating ELB v3 client: %s", err)
+		}
+
+		found, err := ipgroups.Get(elbClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("IpGroup not found")
+		}
+
+		*c = *found
+
+		return nil
+	}
+}
+
+func testAccElbV3IpGroupConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_elb_ipgroup" "test"{
+  name        = "%s"
+  description = "terraform test"
+
+  ip_list {
+    ip = "192.168.10.10"
+    description = "ECS01"
+  }
+}
+`, name)
+}
+
+func testAccElbV3IpGroupConfig_update(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_elb_ipgroup" "test"{
+  name        = "%s_updated"
+  description = "terraform test updated"
+
+  ip_list {
+    ip          = "192.168.10.10"
+    description = "ECS01"
+  }
+
+  ip_list {
+    ip          = "192.168.10.11"
+    description = "ECS02"
+  }
+}
+`, name)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -256,6 +256,7 @@ func Provider() *schema.Provider {
 			// importing data source
 			"flexibleengine_enterprise_project": eps.DataSourceEnterpriseProject(),
 			"flexibleengine_cbr_vaults":         cbr.DataSourceCbrVaultsV3(),
+			"flexibleengine_elb_certificate":    elb.DataSourceELBCertificateV3(),
 			"flexibleengine_fgs_dependencies":   fgs.DataSourceFunctionGraphDependencies(),
 
 			// Deprecated data source
@@ -288,7 +289,6 @@ func Provider() *schema.Provider {
 			"flexibleengine_fw_rule_v2":                         resourceFWRuleV2(),
 			"flexibleengine_images_image_v2":                    resourceImagesImageV2(),
 			"flexibleengine_kms_key_v1":                         resourceKmsKeyV1(),
-			"flexibleengine_lb_certificate_v2":                  resourceCertificateV2(),
 			"flexibleengine_lb_loadbalancer_v2":                 resourceLoadBalancerV2(),
 			"flexibleengine_lb_listener_v2":                     resourceListenerV2(),
 			"flexibleengine_lb_pool_v2":                         resourcePoolV2(),
@@ -413,13 +413,16 @@ func Provider() *schema.Provider {
 
 			"flexibleengine_lb_loadbalancer_v3": elb.ResourceLoadBalancerV3(),
 			"flexibleengine_lb_listener_v3":     elb.ResourceListenerV3(),
+			"flexibleengine_elb_certificate":    elb.ResourceCertificateV3(),
+			"flexibleengine_elb_ipgroup":        elb.ResourceIpGroupV3(),
 
 			// Deprecated resource
-			"flexibleengine_elb_loadbalancer": resourceELoadBalancer(),
-			"flexibleengine_elb_listener":     resourceEListener(),
-			"flexibleengine_elb_backend":      resourceBackend(),
-			"flexibleengine_elb_health":       resourceHealth(),
-			"flexibleengine_rds_instance_v1":  resourceRdsInstance(),
+			"flexibleengine_elb_loadbalancer":  resourceELoadBalancer(),
+			"flexibleengine_elb_listener":      resourceEListener(),
+			"flexibleengine_elb_backend":       resourceBackend(),
+			"flexibleengine_elb_health":        resourceHealth(),
+			"flexibleengine_lb_certificate_v2": resourceCertificateV2(),
+			"flexibleengine_rds_instance_v1":   resourceRdsInstance(),
 		},
 		// configuring the provider
 		ConfigureContextFunc: configureProvider,


### PR DESCRIPTION
new resource:
* flexibleengine_elb_certificate
* flexibleengine_elb_ipgroup

new data source:
* flexibleengine_elb_certificate

```
$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccElbV3IpGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccElbV3IpGroup_basic -timeout 720m
=== RUN   TestAccElbV3IpGroup_basic
=== PAUSE TestAccElbV3IpGroup_basic
=== CONT  TestAccElbV3IpGroup_basic
--- PASS: TestAccElbV3IpGroup_basic (92.86s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      93.105s
$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccElbV3Certificate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccElbV3Certificate -timeout 720m
=== RUN   TestAccElbV3Certificate_basic
=== PAUSE TestAccElbV3Certificate_basic
=== RUN   TestAccElbV3Certificate_client
=== PAUSE TestAccElbV3Certificate_client
=== CONT  TestAccElbV3Certificate_basic
=== CONT  TestAccElbV3Certificate_client
--- PASS: TestAccElbV3Certificate_client (53.09s)
--- PASS: TestAccElbV3Certificate_basic (95.16s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      95.310s
$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccDataSourceELbCertificate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccDataSourceELbCertificate_basic -timeout 720m
=== RUN   TestAccDataSourceELbCertificate_basic
--- PASS: TestAccDataSourceELbCertificate_basic (45.22s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      45.326s
```