### PR TITLE
fix: remove tags validation of compute instance

### DIFF
--- a/docs/resources/compute_instance_v2.md
+++ b/docs/resources/compute_instance_v2.md
@@ -329,7 +329,7 @@ The following arguments are supported:
 
 * `auto_recovery` - (Optional) Configures or deletes automatic recovery of an instance
 
-* `tags` - (Optional) Tags key/value pairs to associate with the instance.
+* `tags` - (Optional) Specifies the key/value pairs to associate with the instance.
 
 The `network` block supports:
 

--- a/flexibleengine/resource_flexibleengine_compute_instance_v2.go
+++ b/flexibleengine/resource_flexibleengine_compute_instance_v2.go
@@ -333,9 +333,9 @@ func resourceComputeInstanceV2() *schema.Resource {
 				Computed: true,
 			},
 			"tags": {
-				Type:         schema.TypeMap,
-				Optional:     true,
-				ValidateFunc: validateECSTagValue,
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"all_metadata": {
 				Type:     schema.TypeMap,

--- a/flexibleengine/resource_flexibleengine_compute_instance_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_compute_instance_v2_test.go
@@ -30,6 +30,7 @@ func TestAccComputeV2Instance_basic(t *testing.T) {
 					testAccCheckComputeV2InstanceMetadata(&instance, "foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "availability_zone", OS_AVAILABILITY_ZONE),
 					resource.TestCheckResourceAttr(resourceName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value.key"),
 				),
 			},
 			{
@@ -466,7 +467,7 @@ resource "flexibleengine_compute_instance_v2" "instance_1" {
   }
   tags = {
     key1 = "value1"
-    key2 = "value2"
+    key2 = "value.key"
   }
 }
 `, OS_AVAILABILITY_ZONE, OS_NETWORK_ID)

--- a/flexibleengine/validators.go
+++ b/flexibleengine/validators.go
@@ -309,21 +309,6 @@ func validateAntiDdosAppTypeID(v interface{}, k string) (ws []string, errors []e
 	return
 }
 
-func validateECSTagValue(v interface{}, k string) (ws []string, errors []error) {
-	tagmap := v.(map[string]interface{})
-	vv := regexp.MustCompile(`^[0-9a-zA-Z-_]+$`)
-	for k, v := range tagmap {
-		value := v.(string)
-		if !vv.MatchString(value) {
-			err := fmt.Errorf("Tag value must be string only contains digits, "+
-				"letters, underscores(_) and hyphens(-), but got %s=%s", k, value)
-			errors = append(errors, err)
-			break
-		}
-	}
-	return
-}
-
 // RFC3339ZNoTNoZ is a time format
 const RFC3339ZNoTNoZ = "2006-01-02 15:04:05"
 


### PR DESCRIPTION
the tags validation is not correct, should be removed.

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccComputeV2Instance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccComputeV2Instance_basic -timeout 720m
=== RUN   TestAccComputeV2Instance_basic
--- PASS: TestAccComputeV2Instance_basic (145.58s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 145.693s
```