### PR TITLE
feat(dms/kafka) support manager user and password

### DIFF
--- a/docs/resources/dms_kafka_instance.md
+++ b/docs/resources/dms_kafka_instance.md
@@ -30,8 +30,10 @@ resource "flexibleengine_dms_kafka_instance" "product_1" {
   network_id        = var.subnet_id
   security_group_id = var.security_group_id
 
-  access_user = "user"
-  password    = "Kafkatest@123"
+  manager_user     = "admin"
+  manager_password = "AdminTest@123"
+  access_user      = "user"
+  password         = "Kafkatest@123"
 }
 ```
 
@@ -89,6 +91,15 @@ The following arguments are supported:
 
   Defaults to **dms.physical.storage.ultra**. Changing this creates a new instance resource.
 
+* `manager_user` - (Optional, String, ForceNew) Specifies the username for logging in to the Kafka Manager.
+  The username consists of 4 to 64 characters and can contain letters, digits, hyphens (-), and underscores (_).
+  Changing this creates a new instance resource.
+
+* `manager_password` - (Optional, String, ForceNew) Specifies the password for logging in to the Kafka Manager. The
+  password must meet the following complexity requirements: Must be 8 to 32 characters long. Must contain at least 2 of
+  the following character types: lowercase letters, uppercase letters, digits, and special characters (`~!@#$%^&*()-_
+  =+\\|[{}]:'",<.>/?). Changing this creates a new instance resource.
+
 * `access_user` - (Optional, String, ForceNew) Specifies a username who can accesse the instance with
   SASL authentication. A username consists of 4 to 64 characters and supports only letters, digits, and hyphens (-).
   Changing this creates a new instance resource.
@@ -125,6 +136,7 @@ In addition to all arguments above, the following attributes are exported:
 * `subnet_name` - Indicates the name of a subnet.
 * `security_group_name` - Indicates the name of a security group.
 * `node_num` - Indicates the count of ECS instances.
+* `manegement_connect_address` - Indicates the connection address of the Kafka Manager of a Kafka instance.
 * `connect_address` - Indicates the IP addresses of the DMS Kafka instance.
 * `port` - Indicates the port number of the DMS Kafka instance.
 * `ssl_enable` - Indicates whether the Kafka SASL_SSL is enabled.
@@ -135,12 +147,13 @@ In addition to all arguments above, the following attributes are exported:
 DMS Kafka instance can be imported using the instance id, e.g.
 
 ```
- $ terraform import flexibleengine_dms_kafka_instance.instance_1 8d3c7938-dc47-4937-a30f-c80de381c5e3
+$ terraform import flexibleengine_dms_kafka_instance.instance_1 8d3c7938-dc47-4937-a30f-c80de381c5e3
 ```
 
-Note that the imported state may not be identical to your resource definition, because of `access_user` and `password`
-are missing from the API response due to security reason. It is generally recommended running `terraform plan` after
-importing a DMS Kafka instance. You can then decide if changes should be applied to the instance, or the resource
+Note that the imported state may not be identical to your resource definition, because of `access_user`, `password`,
+`manager_user` and `manager_password` are missing from the API response due to security reason.
+It is generally recommended running `terraform plan` after importing a DMS Kafka instance.
+You can then decide if changes should be applied to the instance, or the resource
 definition should be updated to align with the instance. Also you can ignore changes as below.
 
 ```
@@ -149,7 +162,7 @@ resource "flexibleengine_dms_kafka_instance" "instance_1" {
 
   lifecycle {
     ignore_changes = [
-      access_user, password,
+      access_user, password, manager_user, manager_password,
     ]
   }
 }

--- a/flexibleengine/resource_flexibleengine_dms_kafka_instance_test.go
+++ b/flexibleengine/resource_flexibleengine_dms_kafka_instance_test.go
@@ -31,6 +31,7 @@ func TestAccDmsKafkaInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "status", "RUNNING"),
 					resource.TestCheckResourceAttr(resourceName, "ssl_enable", "true"),
 					resource.TestCheckResourceAttrSet(resourceName, "product_spec_code"),
+					resource.TestCheckResourceAttrSet(resourceName, "manegement_connect_address"),
 					resource.TestCheckResourceAttrSet(resourceName, "port"),
 				),
 			},
@@ -46,7 +47,7 @@ func TestAccDmsKafkaInstance_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"access_user", "password",
+					"access_user", "password", "manager_user", "manager_password",
 				},
 			},
 		},
@@ -129,6 +130,8 @@ func testAccDmsKafkaInstance_basic(resName string) string {
 
 resource "flexibleengine_dms_kafka_instance" "instance_1" {
   name               = "%s"
+  manager_user       = "admin"
+  manager_password   = "Dmstest@123"
   access_user        = "user"
   password           = "Dmstest@123"
   vpc_id             = flexibleengine_vpc_v1.vpc_1.id
@@ -149,6 +152,8 @@ func testAccDmsKafkaInstance_update(resName, resUpdate string) string {
 resource "flexibleengine_dms_kafka_instance" "instance_1" {
   name               = "%s"
   description        = "instance update description"
+  manager_user       = "admin"
+  manager_password   = "Dmstest@123"
   access_user        = "user"
   password           = "Dmstest@123"
   vpc_id             = flexibleengine_vpc_v1.vpc_1.id

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.25.3
-	github.com/chnsz/golangsdk v0.0.0-20220712120536-79e07dbb668c
+	github.com/chnsz/golangsdk v0.0.0-20220802123257-6d62ca9bcbcf
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.92
-	github.com/huaweicloud/terraform-provider-huaweicloud v1.38.2-0.20220729080106-cbbbd93b6613
+	github.com/huaweicloud/terraform-provider-huaweicloud v1.38.2
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/mitchellh/go-homedir v1.1.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chnsz/golangsdk v0.0.0-20220712120536-79e07dbb668c h1:nypZgt4qDK+8HxcVoC3SWxoeDwSdKf9OfOjnX+bYBFw=
 github.com/chnsz/golangsdk v0.0.0-20220712120536-79e07dbb668c/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220802123257-6d62ca9bcbcf h1:kbZPmTrPx2gm26feSwEzn08TYr8jLXXXDHWKVfcws6g=
+github.com/chnsz/golangsdk v0.0.0-20220802123257-6d62ca9bcbcf/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -220,6 +222,8 @@ github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.92 h1:uQ2DXAr9dSJ5kKy7JEc+skgD
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.92/go.mod h1:Dp/HY22Nf1KFrdZOmeOGkADh52Z/FPg/dI1w5gW4rNA=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.38.2-0.20220729080106-cbbbd93b6613 h1:Izek3Lf2ntBeSWaJFC9aRQp2DFfkM+hdhQVgovJa2ng=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.38.2-0.20220729080106-cbbbd93b6613/go.mod h1:ddGob9iJMJMpgrwEUN5RQS6jYM6RNjE7JClUQS0+eyU=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.38.2 h1:5u9YIWBozd9da6Sdz7aPYJoN0zSEdtTjq2tdRlvzK68=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.38.2/go.mod h1:ddGob9iJMJMpgrwEUN5RQS6jYM6RNjE7JClUQS0+eyU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=


### PR DESCRIPTION
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDmsKafkaInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDmsKafkaInstance_basic -timeout 720m
=== RUN   TestAccDmsKafkaInstance_basic
=== PAUSE TestAccDmsKafkaInstance_basic
=== CONT  TestAccDmsKafkaInstance_basic
--- PASS: TestAccDmsKafkaInstance_basic (956.31s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 956.403s
```