### PR TITLE
docs: fix ids in "import" sections that don't properly render on registry website

### DIFF
--- a/docs/resources/as_lifecycle_hook_v1.md
+++ b/docs/resources/as_lifecycle_hook_v1.md
@@ -70,5 +70,5 @@ In addition to all arguments above, the following attributes are exported:
 Lifecycle hooks can be imported using the AS group ID and hook ID separated by a slash, e.g.
 
 ```
-$ terraform import flexibleengine_as_lifecycle_hook_v1.test <AS group ID>/<Lifecycle hook ID>
+$ terraform import flexibleengine_as_lifecycle_hook_v1.test {AS group ID}/{Lifecycle hook ID}
 ```

--- a/docs/resources/cce_node_pool_v3.md
+++ b/docs/resources/cce_node_pool_v3.md
@@ -153,5 +153,5 @@ This resource provides the following timeouts configuration options:
 Node_pool can be imported using the cluster and node_pool id, e.g.
 
 ```
-terraform import flexibleengine_cce_node_pool_v3.node_pool_1 <cluster-id>/<node_pool-id>
+terraform import flexibleengine_cce_node_pool_v3.node_pool_1 {cluster-id}/{node_pool-id}
 ```

--- a/docs/resources/compute_floatingip_associate_v2.md
+++ b/docs/resources/compute_floatingip_associate_v2.md
@@ -119,5 +119,5 @@ This resource can be imported by specifying all three arguments, separated
 by a forward slash:
 
 ```
-$ terraform import flexibleengine_compute_floatingip_associate_v2.fip_1 <floating_ip>/<instance_id>/<fixed_ip>
+$ terraform import flexibleengine_compute_floatingip_associate_v2.fip_1 {floating_ip}/{instance_id}/{fixed_ip}
 ```

--- a/docs/resources/css_snapshot_v1.md
+++ b/docs/resources/css_snapshot_v1.md
@@ -58,5 +58,5 @@ This resource can be imported by specifying the CSS cluster ID and snapshot ID
 separated by a slash, e.g.:
 
 ```
-$ terraform import flexibleengine_css_snapshot_v1.snapshot_1 <cluster_id>/<snapshot_id>
+$ terraform import flexibleengine_css_snapshot_v1.snapshot_1 {cluster_id}/{snapshot_id}
 ```

--- a/docs/resources/dns_recordset_v2.md
+++ b/docs/resources/dns_recordset_v2.md
@@ -77,5 +77,5 @@ This resource can be imported by specifying the zone ID and recordset ID,
 separated by a forward slash.
 
 ```
-$ terraform import flexibleengine_dns_recordset_v2.recordset_1 <zone_id>/<recordset_id>
+$ terraform import flexibleengine_dns_recordset_v2.recordset_1 {zone_id}/{recordset_id}
 ```

--- a/docs/resources/mrs_job_v2.md
+++ b/docs/resources/mrs_job_v2.md
@@ -97,5 +97,5 @@ MRS jobs can be imported using their `id` and the IDs of the MRS cluster to whic
 by a slash, e.g.
 
 ```
-$ terraform import flexibleengine_mrs_job_v2.test <cluster_id>/<id>
+$ terraform import flexibleengine_mrs_job_v2.test {cluster_id}/{id}
 ```

--- a/docs/resources/sfs_access_rule_v2.md
+++ b/docs/resources/sfs_access_rule_v2.md
@@ -77,5 +77,5 @@ In addition to all arguments above, the following attributes are exported:
 SFS access rule can be imported by specifying the SFS ID and access rule ID separated by a slash, e.g.:
 
 ```
-$ terraform import flexibleengine_sfs_access_rule_v2 <sfs_id>/<rule_id>
+$ terraform import flexibleengine_sfs_access_rule_v2 {sfs_id}/{rule_id}
 ```


### PR DESCRIPTION
Some documentations don't render properly on registry website, for example :

![image](https://user-images.githubusercontent.com/632075/183263347-8adc59ed-515f-4368-976f-318657f927c4.png)

and the associated mardown :
```md
terraform import flexibleengine_cce_node_pool_v3.node_pool_1 <cluster-id>/<node_pool-id>  # it's missing the "cluster id" & "nodepool id" parts
```
I tested `{ }` renders properly (on https://registry.terraform.io/tools/doc-preview)