### PR TITLE
feat(vpc): add new data_source networking port

### DIFF
--- a/docs/data-sources/networking_port.md
+++ b/docs/data-sources/networking_port.md
@@ -1,0 +1,51 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# flexibleengine_networking_port
+
+Use this data source to get the ID of an available Flexibleengine port.
+
+## Example Usage
+
+```hcl
+data "flexibleengine_networking_port" "port_1" {
+  network_id = var.network_id
+  fixed_ip   = "192.168.0.100"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region in which to obtain the port. If omitted, the provider-level region
+  will be used.
+
+* `port_id` - (Optional, String) Specifies the ID of the port.
+
+* `network_id` - (Optional, String) Specifies the ID of the network the port belongs to.
+
+* `fixed_ip` - (Optional, String) Specifies the port IP address filter.
+
+* `mac_address` - (Optional, String) Specifies the MAC address of the port.
+
+* `status` - (Optional, String) Specifies the status of the port.
+
+* `security_group_ids` - (Optional, String) The list of port security group IDs to filter.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID in UUID format.
+
+* `name` - The name of the port.
+
+* `admin_state_up` - The administrative state of the port.
+
+* `device_owner` - The device owner of the port.
+
+* `device_id` - The ID of the device the port belongs to.
+
+* `all_fixed_ips` - The collection of Fixed IP addresses on the port.
+
+* `all_security_group_ids` - The collection of security group IDs applied on the port.

--- a/flexibleengine/acceptance/data_source_flexibleengine_networking_port_v2_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_networking_port_v2_test.go
@@ -1,0 +1,39 @@
+package acceptance
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccNetworkingV2PortDataSource_basic(t *testing.T) {
+	resourceName := "data.flexibleengine_networking_port.gw_port"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkingV2PortDataSource_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "all_fixed_ips.#", "1"),
+					resource.TestCheckResourceAttrSet(resourceName, "mac_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "status"),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetworkingV2PortDataSource_basic() string {
+	return `
+data "flexibleengine_vpc_subnet_v1" "mynet" {
+  name = "subnet-default"
+}
+
+data "flexibleengine_networking_port" "gw_port" {
+  network_id = data.flexibleengine_vpc_subnet_v1.mynet.id
+  fixed_ip   = data.flexibleengine_vpc_subnet_v1.mynet.gateway_ip
+}
+`
+}

--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -13,7 +13,6 @@ import (
 	"github.com/chnsz/golangsdk"
 	huaweisdk "github.com/chnsz/golangsdk/openstack"
 	"github.com/chnsz/golangsdk/openstack/identity/v3/domains"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	huaweiconfig "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/pathorcontents"
 )
@@ -143,7 +142,6 @@ func genClient(c *Config, ao golangsdk.AuthOptionsProvider) (*golangsdk.Provider
 	client.HTTPClient = http.Client{
 		Transport: &huaweiconfig.LogRoundTripper{
 			Rt:         transport,
-			OsDebug:    logging.IsDebugOrHigher(),
 			MaxRetries: c.MaxRetries,
 		},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -259,6 +259,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_cbr_vaults":         cbr.DataSourceCbrVaultsV3(),
 			"flexibleengine_elb_certificate":    elb.DataSourceELBCertificateV3(),
 			"flexibleengine_fgs_dependencies":   fgs.DataSourceFunctionGraphDependencies(),
+			"flexibleengine_networking_port":    vpc.DataSourceNetworkingPortV2(),
 
 			// Deprecated data source
 			"flexibleengine_compute_availability_zones_v2":      dataSourceAvailabilityZones(),

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.25.3
-	github.com/chnsz/golangsdk v0.0.0-20220802123257-6d62ca9bcbcf
+	github.com/chnsz/golangsdk v0.0.0-20220810060653-beb83c7f6d74
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
 	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.92
-	github.com/huaweicloud/terraform-provider-huaweicloud v1.38.2
+	github.com/huaweicloud/terraform-provider-huaweicloud v1.38.3-0.20220815072538-de586150a338
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/mitchellh/go-homedir v1.1.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -71,10 +71,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
-github.com/chnsz/golangsdk v0.0.0-20220712120536-79e07dbb668c h1:nypZgt4qDK+8HxcVoC3SWxoeDwSdKf9OfOjnX+bYBFw=
-github.com/chnsz/golangsdk v0.0.0-20220712120536-79e07dbb668c/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
-github.com/chnsz/golangsdk v0.0.0-20220802123257-6d62ca9bcbcf h1:kbZPmTrPx2gm26feSwEzn08TYr8jLXXXDHWKVfcws6g=
-github.com/chnsz/golangsdk v0.0.0-20220802123257-6d62ca9bcbcf/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220810060653-beb83c7f6d74 h1:l6MI1sQH4PCnIjlDbk9BDOclNdqS7BKiYxFtQM/JUvg=
+github.com/chnsz/golangsdk v0.0.0-20220810060653-beb83c7f6d74/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -220,10 +218,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.92 h1:uQ2DXAr9dSJ5kKy7JEc+skgD6t0+csI1Djr7I2/zQew=
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.92/go.mod h1:Dp/HY22Nf1KFrdZOmeOGkADh52Z/FPg/dI1w5gW4rNA=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.38.2-0.20220729080106-cbbbd93b6613 h1:Izek3Lf2ntBeSWaJFC9aRQp2DFfkM+hdhQVgovJa2ng=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.38.2-0.20220729080106-cbbbd93b6613/go.mod h1:ddGob9iJMJMpgrwEUN5RQS6jYM6RNjE7JClUQS0+eyU=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.38.2 h1:5u9YIWBozd9da6Sdz7aPYJoN0zSEdtTjq2tdRlvzK68=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.38.2/go.mod h1:ddGob9iJMJMpgrwEUN5RQS6jYM6RNjE7JClUQS0+eyU=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.38.3-0.20220815072538-de586150a338 h1:8UYvMbgorpYiFuYXXX6BS7AZSJyE5AYo4b4waI47reg=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.38.3-0.20220815072538-de586150a338/go.mod h1:CdmnHDqUz3JcUVk1P28gFmuTos2D06PEMIqC8+id0LY=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=

--- a/main.go
+++ b/main.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+	"log"
+
 	"github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine"
 	"github.com/chnsz/golangsdk/openstack/obs"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 )
 
 func main() {
+	// Remove any date and time prefix in log package function output to
+	// prevent duplicate timestamp and incorrect log level setting
+	log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
+
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: flexibleengine.Provider})
 


### PR DESCRIPTION
add new data_source networking port

Test result:
```
make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccNetworkingV2PortDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccNetworkingV2PortDataSource_basic -timeout 720m
=== RUN   TestAccNetworkingV2PortDataSource_basic
=== PAUSE TestAccNetworkingV2PortDataSource_basic
=== CONT  TestAccNetworkingV2PortDataSource_basic
--- PASS: TestAccNetworkingV2PortDataSource_basic (21.13s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      21.266s
```