### PR TITLE
feat: support vpc_eip_associate resource

### DIFF
--- a/docs/resources/vpc_eip_associate.md
+++ b/docs/resources/vpc_eip_associate.md
@@ -1,0 +1,91 @@
+---
+subcategory: "Elastic IP (EIP)"
+---
+
+# flexibleengine_vpc_eip_associate
+
+Associates an EIP to a specified IP address or port.
+
+## Example Usage
+
+### Associate with a fixed IP
+
+```hcl
+variable "public_address" {}
+variable "network_id" {}
+
+resource "flexibleengine_vpc_eip_associate" "associated" {
+  public_ip  = var.public_address
+  network_id = var.network_id
+  fixed_ip   = "192.168.0.100"
+}
+```
+
+### Associate with a port
+
+```hcl
+variable "network_id" {}
+
+data "flexibleengine_networking_port" "myport" {
+  network_id = var.network_id
+  fixed_ip   = "192.168.0.100"
+}
+
+resource "flexibleengine_vpc_eip" "myeip" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "test"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "flexibleengine_vpc_eip_associate" "associated" {
+  public_ip = flexibleengine_vpc_eip.myeip.address
+  port_id   = data.flexibleengine_networking_port.myport.id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to associate the EIP. If omitted, the provider-level
+  region will be used. Changing this creates a new resource.
+
+* `public_ip` - (Required, String, ForceNew) Specifies the EIP address to associate. Changing this creates a new resource.
+
+* `fixed_ip` - (Optional, String, ForceNew) Specifies a private IP address to associate with the EIP.
+  Changing this creates a new resource.
+
+* `network_id` - (Optional, String, ForceNew) Specifies the ID of the network to which the **fixed_ip** belongs.
+  It is mandatory when `fixed_ip` is set. Changing this creates a new resource.
+
+* `port_id` - (Optional, String, ForceNew) Specifies an existing port ID to associate with the EIP.
+  This parameter and `fixed_ip` are alternative. Changing this creates a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+* `mac_address` - The MAC address of the private IP.
+* `status` - The status of EIP, should be **BOUND**.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minute.
+* `delete` - Default is 5 minute.
+
+## Import
+
+EIP associations can be imported using the `id` of the EIP, e.g.
+
+```
+$ terraform import flexibleengine_vpc_eip_associate.eip 2c7f39f3-702b-48d1-940c-b50384177ee1
+```

--- a/flexibleengine/acceptance/resource_flexibleengine_vpc_eip_associate_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_vpc_eip_associate_test.go
@@ -1,0 +1,193 @@
+package acceptance
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/networking/v1/eips"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getEipResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.NetworkingV1Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating networking client: %s", err)
+	}
+	return eips.Get(c, state.Primary.ID).Extract()
+}
+
+func TestAccEIPAssociate_basic(t *testing.T) {
+	var eip eips.PublicIp
+	rName := acceptance.RandomAccResourceName()
+	associateName := "flexibleengine_vpc_eip_associate.test"
+	resourceName := "flexibleengine_vpc_eip.test"
+	partten := `^((25[0-5]|2[0-4]\d|(1\d{2}|[1-9]?\d))\.){3}(25[0-5]|2[0-4]\d|(1\d{2}|[1-9]?\d))$`
+
+	// flexibleengine_vpc_eip_associate and flexibleengine_vpc_eip have the same ID
+	// and call the same API to get resource
+	rc := acceptance.InitResourceCheck(
+		associateName,
+		&eip,
+		getEipResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEIPAssociate_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(associateName, "status", "BOUND"),
+					resource.TestCheckResourceAttrPair(
+						associateName, "public_ip", resourceName, "address"),
+					resource.TestMatchOutput("public_ip_address", regexp.MustCompile(partten)),
+				),
+			},
+			{
+				ResourceName:      associateName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccEIPAssociate_port(t *testing.T) {
+	var eip eips.PublicIp
+	rName := acceptance.RandomAccResourceName()
+	associateName := "flexibleengine_vpc_eip_associate.test"
+	resourceName := "flexibleengine_vpc_eip.test"
+
+	// flexibleengine_vpc_eip_associate and flexibleengine_vpc_eip have the same ID
+	// and call the same API to get resource
+	rc := acceptance.InitResourceCheck(
+		associateName,
+		&eip,
+		getEipResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccEIPAssociate_port(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(associateName, "status", "BOUND"),
+					resource.TestCheckResourceAttrPtr(
+						associateName, "port_id", &eip.PortID),
+					resource.TestCheckResourceAttrPair(
+						associateName, "public_ip", resourceName, "address"),
+				),
+			},
+			{
+				ResourceName:      associateName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccEIPAssociate_base(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc_v1" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test" {
+  name       = "%[1]s"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = flexibleengine_vpc_v1.test.id
+}
+
+resource "flexibleengine_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    share_type  = "PER"
+    size        = 5
+    name        = "%[1]s"
+    charge_mode = "traffic"
+  }
+}`, rName)
+}
+
+func testAccEIPAssociate_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_compute_flavors_v2" "test" {
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core          = 2
+  memory_size       = 4
+}
+
+data "flexibleengine_images_image_v2" "test" {
+  name        = "OBS Ubuntu 18.04"
+  most_recent = true
+}
+
+resource "flexibleengine_compute_instance_v2" "test" {
+  name               = "%[2]s"
+  image_id           = data.flexibleengine_images_image_v2.test.id
+  flavor_id          = data.flexibleengine_compute_flavors_v2.test.flavors[0]
+  availability_zone  = data.flexibleengine_availability_zones.test.names[0]
+  security_groups    = ["default"]
+
+  network {
+    uuid = flexibleengine_vpc_subnet_v1.test.id
+  }
+}
+
+resource "flexibleengine_vpc_eip_associate" "test" {
+  public_ip  = flexibleengine_vpc_eip.test.address
+  network_id = flexibleengine_compute_instance_v2.test.network[0].uuid
+  fixed_ip   = flexibleengine_compute_instance_v2.test.network[0].fixed_ip_v4
+}
+
+data "flexibleengine_compute_instance_v2" "test" {
+  depends_on = [flexibleengine_vpc_eip_associate.test]
+
+  name = "%[2]s"
+}
+
+output "public_ip_address" {
+  value = data.flexibleengine_compute_instance_v2.test.floating_ip
+}
+`, testAccEIPAssociate_base(rName), rName)
+}
+
+func testAccEIPAssociate_port(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_networking_vip_v2" "test" {
+  name       = "%s"
+  network_id = flexibleengine_vpc_subnet_v1.test.id
+  subnet_id  = flexibleengine_vpc_subnet_v1.test.subnet_id
+}
+
+resource "flexibleengine_vpc_eip_associate" "test" {
+  public_ip = flexibleengine_vpc_eip.test.address
+  port_id   = flexibleengine_networking_vip_v2.test.id
+}
+`, testAccEIPAssociate_base(rName), rName)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -15,6 +15,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cce"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/elb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eps"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
@@ -417,6 +418,8 @@ func Provider() *schema.Provider {
 
 			"flexibleengine_vpc_v1":        vpc.ResourceVirtualPrivateCloudV1(),
 			"flexibleengine_vpc_subnet_v1": vpc.ResourceVpcSubnetV1(),
+
+			"flexibleengine_vpc_eip_associate": eip.ResourceEIPAssociate(),
 
 			"flexibleengine_lb_loadbalancer_v3": elb.ResourceLoadBalancerV3(),
 			"flexibleengine_lb_listener_v3":     elb.ResourceListenerV3(),


### PR DESCRIPTION
the testing result as follows:
```
$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccEIPAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccEIPAssociate_basic -timeout 720m
=== RUN   TestAccEIPAssociate_basic
=== PAUSE TestAccEIPAssociate_basic
=== CONT  TestAccEIPAssociate_basic
--- PASS: TestAccEIPAssociate_basic (194.06s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      194.134s

$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccEIPAssociate_port'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccEIPAssociate_port -timeout 720m
=== RUN   TestAccEIPAssociate_port
=== PAUSE TestAccEIPAssociate_port
=== CONT  TestAccEIPAssociate_port
--- PASS: TestAccEIPAssociate_port (144.95s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      145.062s
```