### PR TITLE
feat(iam): support identity group and users data source

### DIFF
--- a/docs/data-sources/identity_group.md
+++ b/docs/data-sources/identity_group.md
@@ -1,0 +1,49 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+---
+
+# flexibleengine_identity_group
+
+Use this data source to get details of the specified IAM user group.
+
+~> You *must* have IAM read privileges to use this data source.
+
+## Example Usage
+
+```hcl
+data "flexibleengine_identity_group" "group" {
+  name = "my_group"
+}
+```
+
+## Argument Reference
+
+* `name` - (Optional, String) Specifies the name of the identity group.
+
+* `id` - (Optional, String) Specifies the ID of the identity group.
+
+* `description` - (Optional, String) Specifies the description of the identity group.
+
+## Attributes Reference
+
+* `domain_id` - Indicates the domain the group belongs to.
+
+* `users` - Indicates the users the group contains. Structure is documented below.
+
+The `users` block contains:
+
+* `name` - Indicates the IAM user name.
+
+* `id` - Indicates the ID of the User.
+
+* `description` - Indicates the description of the IAM user.
+
+* `enabled` - Indicates the whether the IAM user is enabled.
+
+* `password_expires_at` - Indicates the time when the password will expire.
+  Null indicates that the password has unlimited validity.
+
+* `password_status` - Indicates the password status. True means that the password needs to be changed,
+  and false means that the password is normal.
+
+* `password_strength` - Indicates the password strength. The value can be high, mid, or low.

--- a/docs/data-sources/identity_users.md
+++ b/docs/data-sources/identity_users.md
@@ -1,0 +1,49 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+---
+
+# flexibleengine_identity_users
+
+Use this data source to query the IAM user list within FlexibleEngine.
+
+~> You *must* have IAM read privileges to use this data source.
+
+## Example Usage
+
+```hcl
+data "flexibleengine_identity_users" "all" {}
+
+data "flexibleengine_identity_users" "one" {
+  name = "user_name"
+}
+```
+
+## Argument Reference
+
+* `name` - (Optional, String) Specifies the IAM user name.
+
+* `enabled` - (Optional, String) Specifies the status of the IAM user, the default value is **true**.
+
+## Attributes Reference
+
+* `id` - The data source ID.
+
+* `users` - The details of the queried IAM users. The structure is documented below.
+
+The `users` block contains:
+
+* `id` - Indicates the ID of the User.
+
+* `name` - Indicates the IAM user name.
+
+* `description` - Indicates the description of the IAM user.
+
+* `enabled` - Indicates the whether the IAM user is enabled.
+
+* `groups` - Indicates the user groups to which an IAM user belongs.
+
+* `password_expires_at` - Indicates the time when the password will expire.
+  Null indicates that the password has unlimited validity.
+
+* `password_status` - Indicates the password status. True means that the password needs to be changed,
+  and false means that the password is normal.

--- a/flexibleengine/acceptance/data_source_flexibleengine_identity_group_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_identity_group_test.go
@@ -1,0 +1,50 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccIdentityGroupDataSource_basic(t *testing.T) {
+	resourceName := "data.flexibleengine_identity_group.test"
+	rName := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(resourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityGroupDataSource_by_name(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+		},
+	})
+}
+
+func testAccIdentityGroupDataSource_by_name(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_identity_group_v3" "group_1" {
+  name        = "%s"
+  description = "A ACC test group"
+}
+
+data "flexibleengine_identity_group" "test" {
+  name = flexibleengine_identity_group_v3.group_1.name
+  
+  depends_on = [
+    flexibleengine_identity_group_v3.group_1
+  ]
+}
+`, rName)
+}

--- a/flexibleengine/acceptance/data_source_flexibleengine_identity_users_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_identity_users_test.go
@@ -1,0 +1,37 @@
+package acceptance
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccIdentityUsersDataSource_basic(t *testing.T) {
+	dataSourceName := "data.flexibleengine_identity_users.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccUsersDataSourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrSet(dataSourceName, "users.#"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "users.0.id"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "users.0.name"),
+				),
+			},
+		},
+	})
+}
+
+const testAccUsersDataSourceBasic string = `
+data "flexibleengine_identity_users" "test" {
+}
+`

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/elb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eps"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/swr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpc"
@@ -261,6 +262,8 @@ func Provider() *schema.Provider {
 			"flexibleengine_elb_certificate":    elb.DataSourceELBCertificateV3(),
 			"flexibleengine_fgs_dependencies":   fgs.DataSourceFunctionGraphDependencies(),
 			"flexibleengine_networking_port":    vpc.DataSourceNetworkingPortV2(),
+			"flexibleengine_identity_group":     iam.DataSourceIdentityGroup(),
+			"flexibleengine_identity_users":     iam.DataSourceIdentityUsers(),
 
 			// Deprecated data source
 			"flexibleengine_compute_availability_zones_v2":      dataSourceAvailabilityZones(),


### PR DESCRIPTION
fixes #214 

new data source:
+ flexibleengine_identity_group
+ flexibleengine_identity_users

the testing result as follows:
```
$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccIdentityUsersDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccIdentityUsersDataSource_basic -timeout 720m
=== RUN   TestAccIdentityUsersDataSource_basic
=== PAUSE TestAccIdentityUsersDataSource_basic
=== CONT  TestAccIdentityUsersDataSource_basic
--- PASS: TestAccIdentityUsersDataSource_basic (77.18s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      77.314s

$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccIdentityGroupDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccIdentityGroupDataSource_basic -timeout 720m
=== RUN   TestAccIdentityGroupDataSource_basic
=== PAUSE TestAccIdentityGroupDataSource_basic
=== CONT  TestAccIdentityGroupDataSource_basic
--- PASS: TestAccIdentityGroupDataSource_basic (39.02s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      39.102s
```