### PR TITLE
fix(cce/node_pool): add Synchronized into pending list

### DIFF
--- a/docs/resources/cce_node_pool_v3.md
+++ b/docs/resources/cce_node_pool_v3.md
@@ -118,6 +118,9 @@ The `data_volumes` block supports:
 
 * `kms_key_id` - (Optional, String) Specifies the KMS key ID. This is used to encrypt the volume.
 
+  -> You need to create an agency (EVSAccessKMS) when disk encryption is used in the current project for the first time ever.
+  The account and permission of the created agency are `op_svc_evs` and **KMS Administrator**, respectively.
+
 * `extend_params` - (Optional, Map) Specifies the disk expansion parameters in key/value pair format.
 
 The `taints` block supports:

--- a/flexibleengine/resource_flexibleengine_cce_node_pool.go
+++ b/flexibleengine/resource_flexibleengine_cce_node_pool.go
@@ -346,7 +346,7 @@ func resourceCCENodePoolCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:      []string{"Synchronizing"},
+		Pending:      []string{"Synchronizing", "Synchronized"},
 		Target:       []string{""},
 		Refresh:      waitForCceNodePoolActive(nodePoolClient, clusterid, s.Metadata.Id),
 		Timeout:      d.Timeout(schema.TimeoutCreate),
@@ -479,12 +479,12 @@ func resourceCCENodePoolUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	stateConf := &resource.StateChangeConf{
-		Pending:    []string{"Synchronizing"},
+		Pending:    []string{"Synchronizing", "Synchronized"},
 		Target:     []string{""},
 		Refresh:    waitForCceNodePoolActive(nodePoolClient, clusterid, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      15 * time.Second,
-		MinTimeout: 5 * time.Second,
+		Delay:      60 * time.Second,
+		MinTimeout: 10 * time.Second,
 	}
 	_, err = stateConf.WaitForState()
 	if err != nil {


### PR DESCRIPTION
fixes #787 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCCENodePool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCCENodePool_basic -timeout 720m
=== RUN   TestAccCCENodePool_basic
=== PAUSE TestAccCCENodePool_basic
=== CONT  TestAccCCENodePool_basic
--- PASS: TestAccCCENodePool_basic (1015.55s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 1015.750s
```