### PR TITLE
feat(smn): add data source to retrieve topics

### DIFF
--- a/docs/data-sources/smn_topics.md
+++ b/docs/data-sources/smn_topics.md
@@ -1,0 +1,52 @@
+---
+subcategory: "Simple Message Notification (SMN)"
+---
+
+# flexibleengine_smn_topics
+
+Use this data source to get an array of SMN topics.
+
+## Example Usage
+
+```hcl
+variable "topic_name" {}
+
+data "flexibleengine_smn_topics" "tpoic_1" {
+  name = var.topic_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to obtain the SMN topics. If omitted, the
+  provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the name of the topic.
+
+* `topic_urn` - (Optional, String) Specifies the topic URN.
+
+* `display_name` - (Optional, String) Specifies the topic display name.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `topics` - An array of SMN topics found. Structure is documented below.
+
+The `topics` block supports:
+
+* `name` - The name of the topic.
+
+* `id` - The topic ID. The value is the topic URN.
+
+* `topic_urn` - The topic URN.
+
+* `display_name` - The topic display name.
+
+* `push_policy` - Message pushing policy.
+  + **0**: indicates that the message sending fails and the message is cached in the queue.
+  + **1**: indicates that the failed message is discarded.

--- a/flexibleengine/acceptance/data_source_flexibleengine_smn_topics_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_smn_topics_test.go
@@ -1,0 +1,50 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataTopics_basic(t *testing.T) {
+	dataSourceName := "data.flexibleengine_smn_topics.test"
+	resourceName := "flexibleengine_smn_topic_v2.topic_1"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+	rName := acceptance.RandomAccResourceNameWithDash()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataTopicsConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(dataSourceName, "topics.0.id", resourceName, "id"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "topics.0.topic_urn", resourceName, "topic_urn"),
+					resource.TestCheckResourceAttrPair(dataSourceName, "topics.0.display_name", resourceName, "display_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataTopicsConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_smn_topic_v2" "topic_1" {
+  name         = "%[1]s"
+  display_name = "The display name of %[1]s"
+}
+
+data "flexibleengine_smn_topics" "test" {
+  name = "%[1]s"
+
+  depends_on = [
+    flexibleengine_smn_topic_v2.topic_1
+  ]
+}
+`, rName)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/smn"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/swr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpc"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
@@ -266,6 +267,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_networking_port":    vpc.DataSourceNetworkingPortV2(),
 			"flexibleengine_identity_group":     iam.DataSourceIdentityGroup(),
 			"flexibleengine_identity_users":     iam.DataSourceIdentityUsers(),
+			"flexibleengine_smn_topics":         smn.DataSourceTopics(),
 
 			// Deprecated data source
 			"flexibleengine_compute_availability_zones_v2":      dataSourceAvailabilityZones(),


### PR DESCRIPTION
fixes #804 

the result of acceptance as follows:
```
make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccDataTopics_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccDataTopics_basic -timeout 720m
=== RUN   TestAccDataTopics_basic
=== PAUSE TestAccDataTopics_basic
=== CONT  TestAccDataTopics_basic
--- PASS: TestAccDataTopics_basic (27.50s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      27.591s
```