### PR TITLE
feat(sfs): add data source to retrieve sfs turbos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: ">=1.16"
 
     - name: Build
       run: make build

--- a/docs/data-sources/sfs_turbos.md
+++ b/docs/data-sources/sfs_turbos.md
@@ -1,0 +1,73 @@
+---
+subcategory: "Scalable File Service (SFS)"
+---
+
+# flexibleengine_sfs_turbos
+
+Use this data source to get the list of the available SFS turbos.
+
+## Example Usage
+
+```hcl
+variable "sfs_turbo_name" {}
+
+data "flexibleengine_sfs_turbos" "test" {
+  name = var.sfs_turbo_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to obtain the SFS turbo file systems.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the name of the SFS turbo file system.
+
+* `size` - (Optional, Int) Specifies the capacity of the SFS turbo file system, in GB.
+  The value ranges from `500` to `32,768`, and must be large than `10,240` for an enhanced file system.
+
+* `share_proto` - (Optional, String) Specifies the protocol of the SFS turbo file system. The valid value is **NFS**.
+
+* `share_type` - (Optional, String) Specifies the type of the SFS turbo file system.
+  The valid values are **STANDARD** and **PERFORMANCE**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `turbos` - The list of the SFS turbo file systems. The [object](#turbo) structure is documented below.
+
+<a name="turbo"></a>
+The `turbos` block supports:
+
+* `id` - The resource ID of the SFS turbo file system.
+
+* `name` - The name of the SFS turbo file system.
+
+* `size` - The capacity of the SFS turbo file system.
+
+* `share_proto` - The protocol of the SFS turbo file system.
+
+* `share_type` - The type of the SFS turbo file system.
+
+* `version` - The version of the SFS turbo file system.
+
+* `enhanced` - Whether the SFS turbo file system is enhanced.
+
+* `availability_zone` - The availability zone where the SFS turbo file system is located.
+
+* `available_capacity` - The available capacity of the SFS turbo file system, in GB.
+
+* `export_location` - The mount point of the SFS turbo file system.
+
+* `crypt_key_id` - The ID of a KMS key to encrypt the SFS turbo file system.
+
+* `vpc_id` - The ID of the VPC to which the SFS turbo belongs.
+
+* `subnet_id` - The **network ID** of the subnet to which the SFS turbo belongs.
+
+* `security_group_id` - The ID of the security group to which the SFS turbo belongs.

--- a/flexibleengine/acceptance/data_source_flexibleengine_sfs_turbos_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_sfs_turbos_test.go
@@ -1,0 +1,125 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccTurbosDataSource_basic(t *testing.T) {
+	var (
+		rName         = acceptance.RandomAccResourceNameWithDash()
+		dcByName      = acceptance.InitDataSourceCheck("data.flexibleengine_sfs_turbos.by_name")
+		dcBySize      = acceptance.InitDataSourceCheck("data.flexibleengine_sfs_turbos.by_size")
+		dcByShareType = acceptance.InitDataSourceCheck("data.flexibleengine_sfs_turbos.by_share_type")
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTurbosDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dcByName.CheckResourceExists(),
+					resource.TestCheckOutput("name_query_result_validation", "true"),
+					dcBySize.CheckResourceExists(),
+					resource.TestCheckOutput("size_query_result_validation", "true"),
+					dcByShareType.CheckResourceExists(),
+					resource.TestCheckOutput("share_type_query_result_validation", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccTurbosDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+variable "turbo_configuration" {
+  type = list(object({
+    size        = number
+    share_type  = string
+  }))
+
+  default = [
+    {size = 500, share_type = "PERFORMANCE"},
+    {size = 600, share_type = "STANDARD"},
+    {size = 600, share_type = "PERFORMANCE"},
+  ]
+}
+
+data "flexibleengine_availability_zones" "test" {}
+
+resource "flexibleengine_vpc_v1" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test" {
+  vpc_id = flexibleengine_vpc_v1.test.id
+
+  name       = "%[1]s"
+  cidr       = cidrsubnet(flexibleengine_vpc_v1.test.cidr, 4, 1)
+  gateway_ip = cidrhost(cidrsubnet(flexibleengine_vpc_v1.test.cidr, 4, 1), 1)
+}
+
+resource "flexibleengine_networking_secgroup_v2" "test" {
+  name = "%[1]s"
+}
+
+resource "flexibleengine_sfs_turbo" "test" {
+  count = length(var.turbo_configuration)
+
+  vpc_id            = flexibleengine_vpc_v1.test.id
+  subnet_id         = flexibleengine_vpc_subnet_v1.test.id
+  security_group_id = flexibleengine_networking_secgroup_v2.test.id
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+
+  name        = "%[1]s-${count.index}"
+  size        = var.turbo_configuration[count.index]["size"]
+  share_proto = "NFS"
+  share_type  = var.turbo_configuration[count.index]["share_type"]
+}
+
+data "flexibleengine_sfs_turbos" "by_name" {
+  depends_on = [flexibleengine_sfs_turbo.test]
+
+  name = flexibleengine_sfs_turbo.test[0].name
+}
+
+data "flexibleengine_sfs_turbos" "by_size" {
+  depends_on = [flexibleengine_sfs_turbo.test]
+
+  size = var.turbo_configuration[0]["size"]
+}
+
+data "flexibleengine_sfs_turbos" "by_share_type" {
+  depends_on = [flexibleengine_sfs_turbo.test]
+
+  share_type = var.turbo_configuration[1]["share_type"]
+}
+
+output "name_query_result_validation" {
+  value = contains(data.flexibleengine_sfs_turbos.by_name.turbos[*].id,
+  flexibleengine_sfs_turbo.test[0].id) && !contains(data.flexibleengine_sfs_turbos.by_name.turbos[*].id,
+  flexibleengine_sfs_turbo.test[1].id) && !contains(data.flexibleengine_sfs_turbos.by_name.turbos[*].id,
+  flexibleengine_sfs_turbo.test[2].id)
+}
+
+output "size_query_result_validation" {
+  value = contains(data.flexibleengine_sfs_turbos.by_size.turbos[*].id,
+  flexibleengine_sfs_turbo.test[0].id) && !contains(data.flexibleengine_sfs_turbos.by_size.turbos[*].id,
+  flexibleengine_sfs_turbo.test[1].id) && !contains(data.flexibleengine_sfs_turbos.by_size.turbos[*].id,
+  flexibleengine_sfs_turbo.test[2].id)
+}
+
+output "share_type_query_result_validation" {
+  value = contains(data.flexibleengine_sfs_turbos.by_share_type.turbos[*].id,
+  flexibleengine_sfs_turbo.test[1].id) && !contains(data.flexibleengine_sfs_turbos.by_share_type.turbos[*].id,
+  flexibleengine_sfs_turbo.test[0].id) && !contains(data.flexibleengine_sfs_turbos.by_share_type.turbos[*].id,
+  flexibleengine_sfs_turbo.test[2].id)
+}
+`, rName)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -22,6 +22,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/sfs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/smn"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/swr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpc"
@@ -267,6 +268,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_networking_port":    vpc.DataSourceNetworkingPortV2(),
 			"flexibleengine_identity_group":     iam.DataSourceIdentityGroup(),
 			"flexibleengine_identity_users":     iam.DataSourceIdentityUsers(),
+			"flexibleengine_sfs_turbos":         sfs.DataSourceTurbos(),
 			"flexibleengine_smn_topics":         smn.DataSourceTopics(),
 
 			// Deprecated data source

--- a/flexibleengine/resource_flexibleengine_dli_queue_v1.go
+++ b/flexibleengine/resource_flexibleengine_dli_queue_v1.go
@@ -220,9 +220,7 @@ func resourceDliQueueDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-/*
-  support cu_count scaling
-*/
+// support cu_count scaling
 func resourceDliQueueUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	client, err := config.DliV1Client(config.GetRegion(d))

--- a/flexibleengine/resource_flexibleengine_mrs_cluster_v2.go
+++ b/flexibleengine/resource_flexibleengine_mrs_cluster_v2.go
@@ -283,9 +283,7 @@ func resourceMRSClusterV2() *schema.Resource {
 	}
 }
 
-/*
-   for custom node,the groupName should been empty
-*/
+// for custom node, the groupName should been empty
 func nodeGroupSchemaResource(groupName string, nodeScalable bool, minNodeNum, maxNodeNum int) *schema.Resource {
 	nodeResource := schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -1056,8 +1054,8 @@ func resourceMRSClusterV2Delete(d *schema.ResourceData, meta interface{}) error 
 }
 
 /*
-	When the host type is core, the map key format: {type}-{groupName},
-	parse from the host name : {clustId}_{groupName}xxxx[-000x]
+When the host type is core, the map key format: {type}-{groupName},
+parse from the host name : {clustId}_{groupName}xxxx[-000x]
 */
 func queryMrsClusterHosts(d *schema.ResourceData, mrsV1Client *golangsdk.ServiceClient) (map[string][]string, error) {
 

--- a/flexibleengine/resource_flexibleengine_mrs_job_v2.go
+++ b/flexibleengine/resource_flexibleengine_mrs_job_v2.go
@@ -187,7 +187,8 @@ func buildMRSMapReduceJobRequestArguments(d *schema.ResourceData) []string {
 }
 
 // The request arguments of the SparkSubmit job is:
-//   <program parameters> --master yarn-cluster <jar path (/python path)> <parameters>.
+//
+//	<program parameters> --master yarn-cluster <jar path (/python path)> <parameters>.
 func buildMRSSparkSubmitJobRequestArguments(d *schema.ResourceData) []string {
 	programsMap := d.Get("program_parameters").(map[string]interface{})
 	programs := buildMRSJobProgramParameters(programsMap)
@@ -349,7 +350,8 @@ func makeMRSMapReduceJobParameters(job *jobs.Job) (string, string, error) {
 }
 
 // The string arguments of the flink job is:
-//   '<program parameters> --master yarn-cluster <jar path (/python path)> <parameters>'.
+//
+//	'<program parameters> --master yarn-cluster <jar path (/python path)> <parameters>'.
 func makeMRSSparkSubmitJobParameters(job *jobs.Job) (string, string, map[string]interface{}, error) {
 	programs := make(map[string]interface{})
 	arguments := makeMRSArgumentsByString(job.Arguments)

--- a/flexibleengine/structure.go
+++ b/flexibleengine/structure.go
@@ -170,9 +170,8 @@ func flattenStackOutputs(stackOutputs []*stacks.Output) map[string]string {
 	return outputs
 }
 
-// flattenStackParameters is flattening list of
-//  stack Parameters and only returning existing
-// parameters to avoid clash with default values
+// flattenStackParameters is flattening list of stack Parameters and
+// only returning existing parameters to avoid clash with default values
 func flattenStackParameters(stackParams map[string]string,
 	originalParams map[string]interface{}) map[string]string {
 	params := make(map[string]string, len(stackParams))

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.25.3
-	github.com/chnsz/golangsdk v0.0.0-20220815060718-d9eb219b1e74
+	github.com/chnsz/golangsdk v0.0.0-20220916061340-f9686bd568aa
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.0
-	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.102
-	github.com/huaweicloud/terraform-provider-huaweicloud v1.39.1-0.20220816075448-24c96aa9cb15
+	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.107
+	github.com/huaweicloud/terraform-provider-huaweicloud v1.40.2
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/mitchellh/go-homedir v1.1.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chnsz/golangsdk v0.0.0-20220815060718-d9eb219b1e74 h1:6bXF32b5+XWTtzNs1vjzTT03S4a6qLti3Xv5OXqKoWM=
 github.com/chnsz/golangsdk v0.0.0-20220815060718-d9eb219b1e74/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20220916061340-f9686bd568aa h1:VccbtQluQ//VcajUlrKkkXgP3oJDfL6+E+3GU5SpUhY=
+github.com/chnsz/golangsdk v0.0.0-20220916061340-f9686bd568aa/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
@@ -218,8 +220,12 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.102 h1:dq22kaGkkTN60p8yPk0hFlmQKsrDH4CLkY5lmF2h+Cg=
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.102/go.mod h1:i26wWZgTXy1S6CByqx7SX4lpNPECzAFF940ver/Zi9k=
+github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.107 h1:o5QLb/cB65mRY3wAQgUOGdl7YfQB19eoGSThPTrIIW8=
+github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.0.107/go.mod h1:QpZ96CRqyqd5fEODVmnzDNp3IWi5W95BFmWz1nfkq+s=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.39.1-0.20220816075448-24c96aa9cb15 h1:oOpeOBktMn6rqzynoQx10rHLYROyhPuu7IJ2qY63J50=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.39.1-0.20220816075448-24c96aa9cb15/go.mod h1:vY9hDH4f476qePmUSeqLtQRlltW4t+e1SgBKwLQ/MPs=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.40.2 h1:rdULkGNaYZ89rB3eCffsaau681ji2Q8lhkbv70HwLYA=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.40.2/go.mod h1:g89prN0G2JscKTTQE2lHVMeoLFg8GZtSbHUyz+AQW+I=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
@@ -239,6 +245,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -294,6 +302,8 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OH
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
 github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
@@ -321,6 +331,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
@@ -357,6 +368,8 @@ golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 h1:kUhD7nTDoI3fVd9G4ORWrbV5NY0liEs/Jg2pv5f+bBA=
 golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e h1:T8NU3HyQ8ClP4SEE+KbFlg6n0NhuTsN4MyznaarGsZM=
+golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -626,6 +639,8 @@ gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=


### PR DESCRIPTION
fixes #767 

the testing result as follows:
```
$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccTurbosDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccTurbosDataSource_basic -timeout 720m
=== RUN   TestAccTurbosDataSource_basic
=== PAUSE TestAccTurbosDataSource_basic
=== CONT  TestAccTurbosDataSource_basic
--- PASS: TestAccTurbosDataSource_basic (401.54s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      401.605s
```