### PR TITLE
fix(cce): set internal_endpoint and external_endpoint correctly

### DIFF
--- a/docs/data-sources/cce_cluster_v3.md
+++ b/docs/data-sources/cce_cluster_v3.md
@@ -64,3 +64,11 @@ All above argument parameters can be exported as attribute parameters along with
 * `external_apig_endpoint` - The endpoint of the cluster to be accessed through API Gateway.
 
 * `billingMode` - Charging mode of the cluster.
+
+* `authentication_mode` - Authentication mode of the cluster, possible values are x509 and rbac.
+
+* `masters` - Advanced configuration of master nodes. Structure is documented below.
+
+The `masters` block supports:
+
+* `availability_zone` - The availability zone (AZ) of the master node.

--- a/flexibleengine/data_source_flexibleengine_cce_cluster_v3_test.go
+++ b/flexibleengine/data_source_flexibleengine_cce_cluster_v3_test.go
@@ -24,6 +24,8 @@ func TestAccCCEClusterV3DataSource_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", cceName),
 					resource.TestCheckResourceAttr(resourceName, "status", "Available"),
 					resource.TestCheckResourceAttr(resourceName, "cluster_type", "VirtualMachine"),
+					resource.TestCheckResourceAttr(resourceName, "authentication_mode", "rbac"),
+					resource.TestCheckResourceAttrSet(resourceName, "internal_endpoint"),
 				),
 			},
 		},

--- a/flexibleengine/resource_flexibleengine_cce_cluster_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_cce_cluster_v3_test.go
@@ -33,6 +33,7 @@ func TestAccCCEClusterV3_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cluster_version", "v1.17.9-r0"),
 					resource.TestCheckResourceAttr(resourceName, "container_network_type", "overlay_l2"),
 					resource.TestCheckResourceAttr(resourceName, "authentication_mode", "rbac"),
+					resource.TestCheckResourceAttrSet(resourceName, "internal_endpoint"),
 				),
 			},
 			{


### PR DESCRIPTION
`internal_endpoint` and `external_endpoint` are always empty as the provider misused the field of API response, so fix it.
the testing as follows:

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCCEClusterV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCCEClusterV3_basic -timeout 720m
=== RUN   TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (415.54s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 415.579s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCCEClusterV3DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCCEClusterV3DataSource_basic -timeout 720m
=== RUN   TestAccCCEClusterV3DataSource_basic
--- PASS: TestAccCCEClusterV3DataSource_basic (401.53s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 401.560s
```