### PR TITLE
chore(rts): fix misuse of reflect.StringHeader

### DIFF
--- a/flexibleengine/data_source_flexibleengine_rts_software_config_v1_test.go
+++ b/flexibleengine/data_source_flexibleengine_rts_software_config_v1_test.go
@@ -62,7 +62,7 @@ resource "flexibleengine_rts_software_config_v1" "config_1" {
 }
 
 data "flexibleengine_rts_software_config_v1" "configs" {
-  id = "${flexibleengine_rts_software_config_v1.config_1.id}"
+  id = flexibleengine_rts_software_config_v1.config_1.id
 }
 `, rtsName)
 }

--- a/flexibleengine/data_source_flexibleengine_rts_stack_resource_v1_test.go
+++ b/flexibleengine/data_source_flexibleengine_rts_stack_resource_v1_test.go
@@ -85,7 +85,7 @@ JSON
 }
 
 data "flexibleengine_rts_stack_resource_v1" "resource_1" {
-  stack_name = "${flexibleengine_rts_stack_v1.stack_1.name}"
+  stack_name    = flexibleengine_rts_stack_v1.stack_1.name
   resource_name = "random"
 }
 `, stackName)

--- a/flexibleengine/data_source_flexibleengine_rts_stack_v1_test.go
+++ b/flexibleengine/data_source_flexibleengine_rts_stack_v1_test.go
@@ -83,7 +83,7 @@ JSON
 }
 
 data "flexibleengine_rts_stack_v1" "stacks" {
-        name = "${flexibleengine_rts_stack_v1.stack_1.name}"
+  name = flexibleengine_rts_stack_v1.stack_1.name
 }
 `, stackName)
 }

--- a/flexibleengine/resource_flexibleengine_rts_stack_v1.go
+++ b/flexibleengine/resource_flexibleengine_rts_stack_v1.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"log"
 	"time"
-
-	"reflect"
 	"unsafe"
 
 	"github.com/chnsz/golangsdk"
@@ -435,7 +433,5 @@ func waitForRTSStackUpdate(orchestrationClient *golangsdk.ServiceClient, stackNa
 }
 
 func BytesToString(b []byte) string {
-	bh := (*reflect.SliceHeader)(unsafe.Pointer(&b))
-	sh := reflect.StringHeader{Data: bh.Data, Len: bh.Len}
-	return *(*string)(unsafe.Pointer(&sh))
+	return *(*string)(unsafe.Pointer(&b))
 }

--- a/flexibleengine/resource_flexibleengine_rts_stack_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_rts_stack_v1_test.go
@@ -136,7 +136,6 @@ resource "flexibleengine_rts_stack_v1" "stack_1" {
     }
   }
 JSON
-
 }
 `
 
@@ -174,6 +173,5 @@ resource "flexibleengine_rts_stack_v1" "stack_1" {
     }
   }
 JSON
-
 }
 `


### PR DESCRIPTION
**misuse of reflect.StringHeader**
```
$ make vet
go vet .
# github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine
flexibleengine/resource_flexibleengine_rts_stack_v1.go:440:35: possible misuse of reflect.StringHeader
```

the testing result as follows:
```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccRts'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccRts -timeout 720m
=== RUN   TestAccRtsConfigV1DataSource_basic
--- PASS: TestAccRtsConfigV1DataSource_basic (27.27s)
=== RUN   TestAccRtsSoftwareConfigV1_basic
--- PASS: TestAccRtsSoftwareConfigV1_basic (27.20s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 54.512s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccRTS'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccRTS -timeout 720m
=== RUN   TestAccRTSStackResourcesV1_dataSource
--- PASS: TestAccRTSStackResourcesV1_dataSource (42.50s)
=== RUN   TestAccRTSStackV1DataSource_basic
--- PASS: TestAccRTSStackV1DataSource_basic (44.17s)
=== RUN   TestAccRTSStackV1_basic
--- PASS: TestAccRTSStackV1_basic (71.55s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 158.260s
```