### PR TITLE
feat(apig): add new apig resources

### DIFF
--- a/docs/data-sources/apig_environments.md
+++ b/docs/data-sources/apig_environments.md
@@ -1,0 +1,50 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+---
+
+# flexibleengine_apig_environments
+
+Use this data source to query the environment list under the APIG instance within Flexibleengine.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "environment_name" {}
+
+data "flexibleengine_apig_environments" "test" {
+  instance_id = var.instance_id
+  name        = var.environment_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the APIG environment list.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies an ID of the APIG dedicated instance to which the API
+  environment belongs.
+
+* `name` - (Optional, String) Specifies the name of the API environment. The API environment name consists of 3 to 64
+  characters, starting with a letter. Only letters, digits and underscores (_) are allowed.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Data source ID.
+
+* `environments` - List of APIG environment details. The structure is documented below.
+
+The `environments` block supports:
+
+* `id` - ID of the APIG environment.
+
+* `name` - The environment name.
+
+* `description` - The description about the API environment.
+
+* `create_time` - Time when the APIG environment was created, in RFC-3339 format.

--- a/docs/resources/apig_api.md
+++ b/docs/resources/apig_api.md
@@ -1,0 +1,372 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+---
+
+# flexibleengine_apig_api
+
+Manages an APIG API resource within Flexibleengine.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "group_id" {}
+variable "api_name" {}
+variable "custom_response_id" {}
+variable "custom_auth_id" {}
+variable "vpc_channel_id" {}
+
+resource "flexibleengine_apig_api" "test" {
+  instance_id             = var.instance_id
+  group_id                = var.group_id
+  type                    = "Public"
+  name                    = var.api_name
+  request_protocol        = "HTTP"
+  request_method          = "POST"
+  request_path            = "/terraform/users"
+  security_authentication = "AUTHORIZER"
+  matching                = "Exact"
+  success_response        = "Successful"
+  response_id             = var.custom_response_id
+  authorizer_id           = var.custom_auth_id
+
+  backend_params {
+    type     = "SYSTEM"
+    name     = "X-User-Auth"
+    location = "HEADER"
+    value    = "user_name"
+  }
+
+  web {
+    path             = "/backend/users"
+    vpc_channel_id   = var.vpc_channel_id
+    request_method   = "POST"
+    request_protocol = "HTTP"
+    timeout          = 5000
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the API resource. If omitted, the
+  provider-level region will be used. Changing this will create a new API resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies an ID of the APIG dedicated instance to which the API belongs
+  to. Changing this will create a new API resource.
+
+* `group_id` - (Required, String) Specifies an ID of the APIG group to which the API belongs to.
+
+* `type` - (Required, String) Specifies the API type. The valid values are **Public** and **Private**.
+
+* `name` - (Required, String) Specifies the API name, which can consists of 3 to 64 characters, starting with a letter.
+  Only letters, digits and underscores (_) are allowed. Chinese characters must be in UTF-8 or Unicode format.
+
+* `request_method` - (Required, String) Specifies the request method of the API. The valid values are **GET**, **POST**
+  , **PUT**, **DELETE**, **HEAD**, **PATCH**, **OPTIONS** and **ANY**.
+
+* `request_path` - (Required, String) Specifies the request address, which can contain a maximum of 512 characters
+  request parameters enclosed with brackets ({}).
+  + The address can contain special characters, such as asterisks (), percent signs (%), hyphens (-), and
+      underscores (_) and must comply with URI specifications.
+  + The address can contain environment variables, each starting with a letter and consisting of 3 to 32 characters.
+      Only letters, digits, hyphens (-), and underscores (_) are allowed in environment variables.
+
+* `request_protocol` - (Required, String) Specifies the request protocol of the API. The valid value are
+  **HTTP**, **HTTPS** and **BOTH**.
+
+* `request_params` - (Optional, List) Specifies an array of one or more request parameters of the front-end. The maximum
+  of request parameters is 50. The [object](#apig_api_request_params) structure is documented below.
+
+* `backend_params` - (Optional, List) Specifies an array of one or more backend parameters.
+  The [object](#apig_api_backend_params) structure is documented below. The maximum of request parameters is 50.
+
+* `security_authentication` - (Optional, String) Specifies the security authentication mode. The valid values are
+  **NONE**, **APP** and **IAM**, default to **NONE**.
+
+* `simple_authentication` - (Optional, Bool) Specifies whether AppCode authentication is enabled. The applicaiton code
+  must located in the header when `simple_authentication` is true.
+
+* `authorizer_id` - (Optional, String) Specifies ID of the front-end custom authorizer.
+
+* `body_description` - (Optional, String) Specifies the description of the API request body, which can be an example
+  request body, media type or parameters. The request body does not exceed 20,480 characters. Chinese characters must be
+  in UTF-8 or Unicode format.
+
+* `cors` - (Optional, Bool) Specifies whether CORS is supported, default to false.
+
+* `description` - (Optional, String) Specifies the API description, which can contain a maximum of 255 characters. The
+  Chinese characters must be in UTF-8 or Unicode format.
+
+* `matching` - (Optional, String) Specifies the route matching mode. The valid value are **Exact** and **Prefix**,
+  default to **Exact**.
+
+* `response_id` - (Optional, String) Specifies the APIG group response ID.
+
+* `success_response` - (Optional, String) Specifies the example response for a successful request. Ensure that the
+  response does not exceed 20,480 characters. Chinese characters must be in UTF-8 or Unicode format.
+
+* `failure_response` - (Optional, String) Specifies the example response for a successful request. Ensure that the
+  response does not exceed 20,480 characters. Chinese characters must be in UTF-8 or Unicode format.
+
+* `mock` - (Optional, List, ForceNew) Specifies the mock backend details. The [object](#apig_api_mock) structure is documented
+  below. Changing this will create a new API resource.
+
+* `func_graph` - (Optional, List, ForceNew) Specifies the function graph backend details. The [object](#apig_api_func_graph)
+  structure is documented below. Changing this will create a new API resource.
+
+* `web` - (Optional, List, ForceNew) Specifies the web backend details. The [object](#apig_api_web) structure is documented
+  below. Changing this will create a new API resource.
+
+* `mock_policy` - (Optional, List) Specifies the Mock policy backends. The maximum of the policy is 5.
+  The [object](#apig_api_mock_policy) structure is documented below.
+
+* `func_graph_policy` - (Optional, List) Specifies the Mock policy backends. The maximum of the policy is 5.
+  The [object](#apig_api_func_graph_policy) structure is documented below.
+
+* `web_policy` - (Optional, List) Specifies the example response for a failed request. The maximum of the policy is 5.
+  The [object](#apig_api_web_policy) structure is documented below.
+
+<a name="apig_api_request_params"></a>
+The `request_params` block supports:
+
+* `name` - (Required, String) Specifies the request parameter name, which contain of 1 to 32 characters and start with a
+  letter. Only letters, digits, hyphens (-), underscores (_) and periods (.) are allowed. If Location is specified as
+  **HEADER** and `security_authentication` is specified as **APP**, the parameter name is not 'Authorization' (
+  case-insensitive) and cannot contain underscores.
+
+* `required` - (Required, Bool) Specifies whether the request parameter is required.
+
+* `location` - (Optional, String) Specifies the location of the request parameter. The valid values are **PATH**,
+  **QUERY** and **HEADER**, default to **PATH**.
+
+* `type` - (Optional, String) Specifies the request parameter type. The valid values are **STRING** and **NUMBER**,
+  default to **STRING**.
+
+* `maximum` - (Optional, Int) Specifies the maximum value or size of the request parameter.
+
+* `minimum` - (Optional, Int) Specifies the minimum value or size of the request parameter. For string type,
+  The `maximum` and `minimum` means size. For number type, they means value.
+
+* `example` - (Optional, String) Specifies the example value of the request parameter, which contain a maximum of 255
+  characters, and the angle brackets (< and >) are not allowed.
+
+* `default` - (Optional, String) Specifies the default value of the request parameter, which contain a maximum of 255
+  characters, and the angle brackets (< and >) are not allowed.
+
+* `description` - (Optional, String) Specifies the description of the request parameter, which contain a maximum of 255
+  characters, and the angle brackets (< and >) are not allowed.
+
+<a name="apig_api_backend_params"></a>
+The `backend_params` block supports:
+
+* `type` - (Required, String) Specifies the backend parameter type. The valid values are **REQUEST**, **CONSTANT**
+  and **SYSTEM**.
+
+* `name` - (Required, String) Specifies the backend parameter name, which contain of 1 to 32 characters and start with a
+  letter. Only letters, digits, hyphens (-), underscores (_) and periods (.) are allowed. The parameter name is not
+  case-sensitive. It cannot start with 'x-apig-' or 'x-sdk-' and cannot be 'x-stage'. If the location is specified as
+  **HEADER**, the name cannot contain underscores.
+
+* `location` - (Required, String) Specifies the location of the backend parameter. The valid values are **PATH**,
+  **QUERY** and **HEADER**.
+
+* `value` - (Required, String) Specifies the request parameter name corresponding to the request parameter name of the
+  back-end parameter.
+
+* `description` - (Optional, String) Specifies the description of the constant or system parameter, which contain a
+  maximum of 255 characters, and the angle brackets (< and >) are not allowed.
+
+<a name="apig_api_mock"></a>
+The `mock` block supports:
+
+* `response` - (Required, String) Specifies the response of the backend policy, which contain a maximum of 2,048
+  characters, and the angle brackets (< and >) are not allowed.
+
+  -> **NOTE:**  Mock enables APIG to return a response without sending the request to the backend. This is useful for
+  testing APIs when the backend is not available.
+
+* `authorizer_id` - (Optional, String) Specifies the ID of the backend custom authorization.
+
+<a name="apig_api_func_graph"></a>
+The `func_graph` block supports:
+
+* `function_urn` - (Required, String) Specifies the function graph URN.
+
+* `version` - (Required, String) Specifies the version of the function graph.
+
+* `timeout` - (Optional, Int) Specifies the location of the backend parameter. The valid value is range form 1 to
+  600,000, default to 5,000.
+
+* `invocation_type` - (Optional, String) Specifies the invocation mode. The valid values are **async** and **sync**,
+  default to **sync**.
+
+* `authorizer_id` - (Optional, String) Specifies the ID of the backend custom authorization.
+
+<a name="apig_api_web"></a>
+The `web` block supports:
+
+* `path` - (Required, String) Specifies the backend request address, which can contain a maximum of 512 characters and
+  must comply with URI specifications.
+  + The request address can contain request parameters enclosed with brackets ({}).
+  + The request address can contain special characters, such as asterisks (*), percent signs (%), hyphens (-) and
+      underscores (_) and must comply with URI specifications.
+  + The address can contain environment variables, each starting with a letter and consisting of 3 to 32 characters.
+      Only letters, digits, hyphens (-), and underscores (_) are allowed in environment variables.
+
+* `host_header` - (Optional, String) Specifies the proxy host header. The host header can be customized for requests to
+  be forwarded to cloud servers through the VPC channel. By default, the original host header of the request is used.
+
+* `vpc_channel_id` - (Optional, String) Specifies the VPC channel ID. This parameter and `backend_address` are
+  alternative.
+
+* `backend_address` - (Optional, String) Specifies the backend service address, which consists of a domain name or IP
+  address, and a port number, with not more than 255 characters. The backend service address must be in the format "Host
+  name:Port number", for example, apig.example.com:7443. If the port number is not specified, the default HTTPS port
+  443, or the default HTTP port 80 is used. The backend service address can contain environment variables, each starting
+  with a letter and consisting of 3 to 32 characters. Only letters, digits, hyphens (-), and underscores (_) are
+  allowed.
+
+* `request_method` - (Optional, String) Specifies the backend request method of the API. The valid types are **GET**,
+  **POST**, **PUT**, **DELETE**, **HEAD**, **PATCH**, **OPTIONS** and **ANY**.
+
+* `request_protocol` - (Optional, String) Specifies the backend request protocol. The valid values are **HTTP** and
+  **HTTPS**, default to **HTTPS**.
+
+* `timeout` - (Optional, Int) Specifies the timeout, in ms, which allowed for APIG to request the backend service. The
+  valid value is range from 1 to 600,000, default to 5,000.
+
+* `ssl_enable` - (Optional, Bool) Specifies the indicates whether to enable two-way authentication, default to false.
+
+* `authorizer_id` - (Optional, String) Specifies the ID of the backend custom authorization.
+
+<a name="apig_api_mock_policy"></a>
+The `mock_policy` block supports:
+
+* `name` - (Required, String) Specifies the backend policy name, which can contains of 3 to 64 characters and start with
+  a letter. Only letters, digits, and underscores (_) are allowed.
+
+* `conditions` - (Required, List) Specifies an array of one or more policy conditions. Up to five conditions can be set.
+  The [object](#apig_api_conditions) structure is documented below.
+
+* `response` - (Optional, String) Specifies the response of the backend policy, which contain a maximum of 2,048
+  characters, and the angle brackets (< and >) are not allowed.
+
+* `effective_mode` - (Optional, String) Specifies the effective mode of the backend policy. The valid values are **ALL**
+  and **ANY**, default to **ANY**.
+
+* `backend_params` - (Optional, List) Specifies an array of one or more backend parameters. The maximum of request
+  parameters is 50. The [object](#apig_api_backend_params) structure is documented above.
+
+* `authorizer_id` - (Optional, String) Specifies the ID of the backend custom authorization.
+
+<a name="apig_api_func_graph_policy"></a>
+The `func_graph_policy` block supports:
+
+* `name` - (Required, String) Specifies the backend policy name, which can contains of 3 to 64 characters and start with
+  a letter. Only letters, digits, and underscores (_) are allowed.
+
+* `function_urn` - (Required, String) Specifies the URN of the function graph.
+
+* `conditions` - (Required, List) Specifies an array of one or more policy conditions. Up to five conditions can be set.
+  The [object](#apig_api_conditions) structure is documented below.
+
+* `invocation_mode` - (Optional, String) Specifies the invocation mode of the function graph. The valid values are
+  **async** and **sync**, default to **sync**.
+
+* `effective_mode` - (Optional, String) Specifies the effective mode of the backend policy. The valid values are **ALL**
+  and **ANY**, default to **ANY**.
+
+* `timeout` - (Optional, Int) Specifies the timeout, in ms, which allowed for APIG to request the backend service. The
+  valid value is range from 1 to 600,000, default to 5,000.
+
+* `version` - (Optional, String) Specifies the version of the function graph.
+
+* `backend_params` - (Optional, List) Specifies an array of one or more backend parameters. The maximum of request
+  parameters is 50. The [object](#apig_api_backend_params) structure is documented above.
+
+* `authorizer_id` - (Optional, String) Specifies the ID of the backend custom authorization.
+
+<a name="apig_api_web_policy"></a>
+The `web_policy` block supports:
+
+* `name` - (Required, String) Specifies the backend policy name, which can contains of 3 to 64 characters and start with
+  a letter. Only letters, digits, and underscores (_) are allowed.
+
+* `path` - (Required, String) Specifies the backend request address, which can contain a maximum of 512 characters and
+  must comply with URI specifications.
+  + The request address can contain request parameters enclosed with brackets ({}).
+  + The request address can contain special characters, such as asterisks (*), percent signs (%), hyphens (-) and
+      underscores (_) and must comply with URI specifications.
+  + The address can contain environment variables, each starting with a letter and consisting of 3 to 32 characters.
+      Only letters, digits, hyphens (-), and underscores (_) are allowed in environment variables.
+
+* `request_method` - (Required, String) Specifies the backend request method of the API. The valid types are **GET**,
+  **POST**, **PUT**, **DELETE**, **HEAD**, **PATCH**, **OPTIONS** and **ANY**.
+
+* `conditions` - (Required, List) Specifies an array of one or more policy conditions. Up to five conditions can be set.
+  The [object](#apig_api_conditions) structure is documented below.
+
+* `host_header` - (Optional, String) Specifies the proxy host header. The host header can be customized for requests to
+  be forwarded to cloud servers through the VPC channel. By default, the original host header of the request is used.
+
+* `vpc_channel_id` - (Optional, String) Specifies the VPC channel ID. This parameter and `backend_address` are
+  alternative.
+
+* `backend_address` - (Optional, String) Specifies the backend service address, which consists of a domain name or IP
+  address, and a port number, with not more than 255 characters. The backend service address must be in the format "Host
+  name:Port number", for example, apig.example.com:7443. If the port number is not specified, the default HTTPS port 443
+  or the default HTTP port 80 is used. The backend service address can contain environment variables, each starting with
+  a letter and consisting of 3 to 32 characters. Only letters, digits, hyphens (-), and underscores (_) are allowed.
+
+* `request_protocol` - (Optional, String) Specifies the backend request protocol. The valid values are **HTTP** and
+  **HTTPS**, default to **HTTPS**.
+
+* `effective_mode` - (Optional, String) Specifies the effective mode of the backend policy. The valid values are **ALL**
+  and **ANY**, default to **ANY**.
+
+* `timeout` - (Optional, Int) Specifies the timeout, in ms, which allowed for APIG to request the backend service. The
+  valid value is range from 1 to 600,000, default to 5,000.
+
+* `backend_params` - (Optional, List) Specifies an array of one or more backend parameters. The maximum of request
+  parameters is 50. The [object](#apig_api_backend_params) structure is documented above.
+
+* `authorizer_id` - (Optional, String) Specifies the ID of the backend custom authorization.
+
+<a name="apig_api_conditions"></a>
+The `conditions` block supports:
+
+* `value` - (Required, String) Specifies the condition type. For a condition with the input parameter source:
+  + If the condition type is **Enumerated**, separate condition values with commas.
+  + If the condition type is **Matching**, enter a regular expression compatible with PERL.
+
+  For a condition with the Source IP address source, enter IPv4 addresses and separate them with commas. The CIDR
+  address format is supported.
+
+* `param_name` - (Optional, String) Specifies the request parameter name. This parameter is required if the policy type
+  is param.
+
+* `source` - (Optional, String) Specifies the policy type. The valid values are **param** and **source**, default to
+  **source**.
+
+* `type` - (Optional, String) Specifies the condition type of the backend policy. The valid values are **Equal**,
+  **Enumerated** and **Matching**, default to **Equal**.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the APIG API.
+* `register_time` - Time when the API is registered, in UTC format.
+* `update_time` - Time when the API was last modified, in UTC format.
+
+## Import
+
+APIs can be imported using their `name` and ID of the APIG dedicated instance to which the API belongs, separated by a
+slash, e.g.
+
+```
+$ terraform import flexibleengine_apig_api.test <instance_id>/<name>
+```

--- a/docs/resources/apig_api_publishment.md
+++ b/docs/resources/apig_api_publishment.md
@@ -1,0 +1,91 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+---
+
+# flexibleengine_apig_api_publishment
+
+API publish Management within Flexibleengine.
+
+~> If you republish on the same environment or switch versions through other ways (such as console) after the API is
+published through terraform, the current resource attributes will be affected, resulting in data inconsistency.
+
+## Example Usage
+
+### Publish a new version of the API
+
+```hcl
+variable "instance_id" {}
+variable "env_id" {}
+variable "api_id" {}
+
+resource "flexibleengine_apig_api_publishment" "default" {
+  instance_id = var.instance_id
+  env_id      = var.env_id
+  api_id      = var.api_id
+}
+```
+
+### Switch to a specified version of the API which is published
+
+```hcl
+variable "instance_id" {}
+variable "env_id" {}
+variable "api_id" {}
+variable "version_id" {}
+
+resource "flexibleengine_apig_api_publishment" "default" {
+  instance_id = var.instance_id
+  env_id      = var.env_id
+  api_id      = var.api_id
+  version_id  = var.version_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to publish APIs.
+  If omitted, the provider-level region will be used. Changing this will create a new publishment resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies an ID of the APIG dedicated instance to which the API belongs
+  to. Changing this will create a new publishment resource.
+
+* `env_id` - (Required, String, ForceNew) Specifies the environment ID to which the current version of the API will be
+  published or has been published. Changing this will create a new publishment resource.
+
+* `api_id` - (Required, String, ForceNew) Specifies the API ID to be published or already published.
+  Changing this will create a new publishment resource.
+
+* `description` - (Optional, String) Specifies the description of the current publishment.
+
+* `version_id` - (Optional, String) Specifies the version ID of the current publishment.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Resource ID, which is constructed from the instance ID, environment ID, and API ID, separated by slashes.
+
+* `env_name` - Environment name to which the current version of the API is published.
+
+* `publish_time` - Time when the current version was published.
+
+* `histories` - All publish informations of the API. The structure is documented below.
+
+* `publish_id` - The publish ID of the API in current environment.
+
+The `histories` block supports:
+
+* `version_id` - Version ID of the API publishment.
+
+* `description` - Version description of the API publishment.
+
+## Import
+
+APIs can be imported using their `instance_id`, `env_id` and `api_id`, separated by slashes, e.g.
+
+```
+$ terraform import flexibleengine_apig_api_publishment.test
+9b0a0a2f97aa43afbf7d852e3ba6a6f9/c5b32727186c4fe6b60408a8a297be09/9a3b3484c08545f9b9b0dcb2de0f5b8a
+```

--- a/docs/resources/apig_application.md
+++ b/docs/resources/apig_application.md
@@ -1,0 +1,70 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+---
+
+# flexibleengine_apig_application
+
+Manages an APIG application resource within Flexibleengine.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "app_name" {}
+variable "app_code" {}
+
+resource "flexibleengine_apig_application" "test" {
+  instance_id = var.instance_id
+  name        = var.app_name
+  description = "Created by script"
+
+  app_codes = [var.app_code]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the APIG application resource. If
+  omitted, the provider-level region will be used. Changing this will create a new APIG application resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies an ID of the APIG dedicated instance to which the APIG
+  application belongs to. Changing this will create a new APIG application resource.
+
+* `name` - (Required, String) Specifies the name of the API application. The API group name consists of 3 to 64
+  characters, starting with a letter. Only letters, digits and underscores (_) are allowed. Chinese characters must be
+  in UTF-8 or Unicode format.
+
+* `description` - (Optional, String) Specifies the description about the APIG application. The description contain a
+  maximum of 255 characters and the angle brackets (< and >) are not allowed. Chinese characters must be in UTF-8 or
+  Unicode format.
+
+* `app_codes` - (Required, List) Specifies an array of one or more application codes which the APIG application belongs
+  to. Up to five application codes can be created. The code consists of 64 to 180 characters, starting with a letter,
+  digit, plus sign (+) or slash (/). Only letters, digits and following special special characters are allowed: !@#$%+-_
+  /=
+
+* `secret_action` - (Optional, String) Specifies the secret action to be done for the APIG application. The valid action
+  is *RESET*.
+
+  -> **NOTE:** The `secret_action` is a one-time action.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the APIG application.
+* `registraion_time` - Registration time, in RFC-3339 format.
+* `update_time` - Time when the API group was last modified, in RFC-3339 format.
+* `app_key` - App key.
+* `app_secret` - App secret.
+
+## Import
+
+APIG Applications can be imported using their `id` and ID of the APIG dedicated instance to which the application
+belongs, separated by a slash, e.g.
+
+```
+$ terraform import flexibleengine_apig_application.test <instance id>/<id>
+```

--- a/docs/resources/apig_custom_authorizer.md
+++ b/docs/resources/apig_custom_authorizer.md
@@ -1,0 +1,97 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+---
+
+# flexibleengine_apig_custom_authorizer
+
+Manages an APIG custom authorizer resource within Flexibleengine.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "authorizer_name" {}
+variable "function_urn" {}
+
+resource "flexibleengine_apig_custom_authorizer" "test" {
+  instance_id  = var.instance_id
+  name         = var.authorizer_name
+  function_urn = var.function_urn
+  type         = "FRONTEND"
+  cache_age    = 60
+
+  identity {
+    name     = "user_name"
+    location = "QUERY"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the custom authorizer resource.
+  If omitted, the provider-level region will be used.
+  Changing this will create a new custom authorizer resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies an ID of the APIG dedicated instance to which the
+  custom authorizer belongs to.
+  Changing this will create a new custom authorizer resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the custom authorizer.
+  The custom authorizer name consists of 3 to 64 characters, starting with a letter.
+  Only letters, digits and underscores (_) are allowed.
+  Changing this will create a new custom authorizer resource.
+
+* `type` - (Required, String, ForceNew) Specifies the custom authoriz type.
+  The valid values are *FRONTEND* and *BACKEND*.
+  Changing this will create a new custom authorizer resource.
+
+* `function_urn` - (Required, String, ForceNew) Specifies the uniform function URN of the function graph resource.
+  Changing this will create a new custom authorizer resource.
+
+* `is_body_send` - (Optional, Bool, ForceNew) Specifies whether to send the body.
+  Changing this will create a new custom authorizer resource.
+
+* `cache_age` - (Optional, String) Specifies the maximum cache age.
+  Changing this will create a new custom authorizer resource.
+
+* `user_data` - (Optional, String, ForceNew) Specifies the user data, which can contain a maximum of 2,048 characters.
+  The user data is used by APIG to invoke the specified authentication function when accessing the backend service.
+  Changing this will create a new custom authorizer resource.
+
+  -> **NOTE:** The user data will be displayed in plain text on the console.
+
+* `identity` - (Optional, List) Specifies an array of one or more parameter identities of the custom authorizer.
+  The object structure is documented below.
+
+The `identity` block supports:
+
+* `name` - (Required, String, ForceNew) Specifies the name of the parameter to be verified.
+  The parameter includes front-end and back-end parameters.
+  Changing this will create a new custom authorizer resource.
+
+* `location` - (Required, String, ForceNew) Specifies the parameter location, which support 'HEADER' and 'QUERY'.
+  Changing this will create a new custom authorizer resource.
+
+* `validation` - (Required, String, ForceNew) Specifies the parameter verification expression.
+  If omitted, the custom authorizer will not perform verification.
+  The valid value is range form 1 to 2,048.
+  Changing this will create a new custom authorizer resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the custom authorizer.
+* `create_time` - Time when the APIG custom authorizer was created.
+
+## Import
+
+Custom Authorizers of the APIG can be imported using their `name` and the ID of the APIG instance to which the group belongs,
+separated by a slash, e.g.
+
+```
+$ terraform import flexibleengine_apig_custom_authorizer.test <instance id>/<name>
+```

--- a/docs/resources/apig_environment.md
+++ b/docs/resources/apig_environment.md
@@ -1,0 +1,54 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+---
+
+# flexibleengine_apig_environment
+
+Manages an APIG environment resource within Flexibleengine.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "environment_name" {}
+variable "description" {}
+
+resource "flexibleengine_apig_environment" "test" {
+  instance_id = var.instance_id
+  name        = var.environment_name
+  description = var.description
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the APIG environment resource. If
+  omitted, the provider-level region will be used. Changing this will create a new APIG environment resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies an ID of the APIG dedicated instance to which the API
+  environment belongs to. Changing this will create a new APIG environment resource.
+
+* `name` - (Required, String) Specifies the name of the API environment. The API environment name consists of 3 to 64
+  characters, starting with a letter. Only letters, digits and underscores (_) are allowed.
+
+* `description` - (Optional, String) Specifies the description about the API environment. The description contain a
+  maximum of 255 characters and the angle brackets (< and >) are not allowed. Chinese characters must be in UTF-8 or
+  Unicode format.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the APIG environment.
+* `create_time` - Time when the APIG environment was created, in RFC-3339 format.
+
+## Import
+
+Environments can be imported using their `id` and the ID of the APIG instance to which the environment belongs,
+separated by a slash, e.g.
+
+```
+$ terraform import flexibleengine_apig_environment.test <instance ID>/<id>
+```

--- a/docs/resources/apig_group.md
+++ b/docs/resources/apig_group.md
@@ -1,0 +1,88 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+---
+
+# flexibleengine_apig_group
+
+Manages an APIG (API) group resource within Flexibleengine.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "group_name" {}
+variable "description" {}
+variable "environment_id" {}
+
+resource "flexibleengine_apig_group" "test" {
+  instance_id = var.instance_id
+  name        = var.group_name
+  description = var.description
+
+  environment {
+    variable {
+      name  = "TERRAFORM"
+      value = "/stage/terraform"
+    }
+    environment_id = var.environment_id
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the API group resource. If omitted,
+  the provider-level region will be used. Changing this will create a new API group resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies an ID of the APIG dedicated instance to which the API group
+  belongs to. Changing this will create a new API group resource.
+
+* `name` - (Required, String) Specifies the name of the API group. The API group name consists of 3 to 64 characters,
+  starting with a letter. Only letters, digits and underscores (_) are allowed. Chinese characters must be in UTF-8 or
+  Unicode format.
+
+* `description` - (Optional, String) Specifies the description about the API group. The description contain a maximum of
+  255 characters and the angle brackets (< and >) are not allowed. Chinese characters must be in UTF-8 or Unicode
+  format.
+
+* `environment` - (Optional, List) Specifies an array of one or more APIG environments of the associated APIG group. The
+  object structure is documented below.
+
+The `environment` block supports:
+
+* `variable` - (Required, List) Specifies an array of one or more APIG environment variables. The object structure is
+  documented below. The environment variables of different groups are isolated in the same environment.
+
+* `environment_id` - (Required, String) Specifies the APIG environment ID of the associated APIG group.
+
+The `variable` block supports:
+
+* `name` - (Required, String) Specifies the variable name, which can contains of 3 to 32 characters, starting with a
+  letter. Only letters, digits, hyphens (-), and underscores (_) are allowed. In the definition of an API, `name` (
+  case-sensitive) indicates a variable, such as #Name#. It is replaced by the actual value when the API is published in
+  an environment. The variable names are not allowed to be repeated for an API group.
+
+* `value` - (Required, String) Specifies the environment ariable value, which can contains of 1 to 255 characters. Only
+  letters, digits and special characters (_-/.:) are allowed.
+
+  -> **NOTE:** The variable value will be displayed in plain text on the console.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the API group.
+* `registraion_time` - Registration time, in RFC-3339 format.
+* `update_time` - Time when the API group was last modified, in RFC-3339 format.
+* `environment/variable/variable_id` - ID of the environment variable.
+
+## Import
+
+API groups of the APIG can be imported using their `id` and the ID of the APIG instance to which the group belongs,
+separated by a slash, e.g.
+
+```
+$ terraform import flexibleengine_apig_group.test <instance id>/<id>
+```

--- a/docs/resources/apig_instance.md
+++ b/docs/resources/apig_instance.md
@@ -1,0 +1,102 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+---
+
+# flexibleengine_apig_instance
+
+Manages an APIG dedicated instance resource within Flexibleengine.
+
+## Example Usage
+
+```hcl
+variable "instance_name" {}
+variable "vpc_id" {}
+variable "subnet_id" {}
+variable "security_group_id" {}
+variable "eip_id" {}
+
+data "flexibleengine_availability_zones" "test" {}
+
+resource "flexibleengine_apig_instance" "test" {
+  name                  = var.instance_name
+  edition               = "BASIC"
+  vpc_id                = var.vpc_id
+  subnet_id             = var.subnet_id
+  security_group_id     = var.security_group_id
+  maintain_begin        = "06:00:00"
+  description           = "Created by script"
+  bandwidth_size        = 3
+  eip_id                = var.eip_id
+
+  available_zones = [
+    data.flexibleengine_availability_zones.test.names[0],
+    data.flexibleengine_availability_zones.test.names[1],
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the APIG dedicated instance resource.
+  If omitted, the provider-level region will be used. Changing this will create a new APIG dedicated instance resource.
+
+* `name` - (Required, String) Specifies the name of the API dedicated instance. The API group name consists of 3 to 64
+  characters, starting with a letter. Only letters, digits, and underscores (_) are allowed.
+
+* `edition` - (Required, String, ForceNew) Specifies the edition of the APIG dedicated instance. The supported editions
+  are as follows: BASIC, PROFESSIONAL, ENTERPRISE, PLATINUM. Changing this will create a new APIG dedicated instance
+  resource.
+
+* `vpc_id` - (Required, String, ForceNew) Specifies an ID of the VPC used to create the APIG dedicated instance.
+  Changing this will create a new APIG dedicated instance resource.
+
+* `subnet_id` - (Required, String, ForceNew) Specifies an ID of the VPC subnet used to create the APIG dedicated
+  instance. Changing this will create a new APIG dedicated instance resource.
+
+* `security_group_id` - (Required, String) Specifies an ID of the security group to which the APIG dedicated instance
+  belongs to.
+
+* `available_zones` - (Optional, List, ForceNew) Specifies an array of available zone names for the APIG dedicated
+  instance. Changing this will create a new APIG dedicated instance resource.
+
+* `description` - (Optional, String) Specifies the description about the APIG dedicated instance. The description
+  contain a maximum of 255 characters and the angle brackets (< and >) are not allowed.
+
+* `maintain_begin` - (Optional, String) Specifies a start time of the maintenance time window in the format 'xx:00:00'.
+  The value of xx can be 02, 06, 10, 14, 18 or 22.
+
+* `bandwidth_size` - (Optional, Int) Specifies the egress bandwidth size of the APIG dedicated instance. The range of
+  valid value is from 1 to 2000.
+
+* `eip_id` - (Optional, String) Specifies the eip ID associated with the APIG dedicated instance.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the APIG dedicated instance.
+* `maintain_end` - End time of the maintenance time window, 4-hour difference between the start time and end time.
+* `create_time` - Time when the APIG instance is created, in RFC-3339 format.
+* `status` - Status of the APIG dedicated instance.
+* `supported_features` - The supported features of the APIG dedicated instance.
+* `egress_address` - The egress (nat) public ip address.
+* `ingress_address` - The ingress eip address.
+* `vpc_ingress_address` - The ingress private ip address of vpc.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 40 minute.
+* `update` - Default is 10 minute.
+* `delete` - Default is 10 minute.
+
+## Import
+
+APIG Dedicated Instances can be imported by their `id`, e.g.
+
+```
+$ terraform import flexibleengine_apig_instance.test de379eed30aa4d31a84f426ea3c7ef4e
+```

--- a/docs/resources/apig_response.md
+++ b/docs/resources/apig_response.md
@@ -1,0 +1,86 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+---
+
+# flexibleengine_apig_response
+
+Manages an APIG (API) custom response resource within Flexibleengine.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "group_id" {}
+variable "response_name" {}
+
+resource "flexibleengine_apig_response" "test" {
+  name        = var.response_name
+  instance_id = var.instance_id
+  group_id    = var.group_id
+
+  rule {
+    error_type  = "AUTHORIZER_FAILURE"
+    body        = "{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}"
+    status_code = 401
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the API custom response resource. If
+  omitted, the provider-level region will be used. Changing this will create a new API custom response resource.
+
+* `group_id` - (Required, String, ForceNew) Specifies the ID of the API group to which the API response belongs to.
+  Changing this will create a new API custom response resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the APIG dedicated instance to which the API group
+  where the API custom response belongs. Changing this will create a new API custom response resource.
+
+* `name` - (Required, String) Specifies the name of the API custom response. The name consists of 1 to 64 characters,
+  and only letters, digits, hyphens(-), and underscores (_) are allowed.
+
+* `rule` - (Optional, List) Specifies the API custom response rules definition. The object structure is documented
+  below.
+
+The `rule` block supports:
+
+* `error_type` - (Required, String) Specifies the type of the API custom response rule.
+  + **AUTH_FAILURE**: Authentication failed.
+  + **AUTH_HEADER_MISSING**: The identity source is missing.
+  + **AUTHORIZER_FAILURE**: Custom authentication failed.
+  + **AUTHORIZER_CONF_FAILURE**: There has been a custom authorizer error.
+  + **AUTHORIZER_IDENTITIES_FAILURE**: The identity source of the custom authorizer is invalid.
+  + **BACKEND_UNAVAILABLE**: The backend service is unavailable.
+  + **BACKEND_TIMEOUT**: Communication with the backend service timed out.
+  + **THROTTLED**: The request was rejected due to request throttling.
+  + **UNAUTHORIZED**: The app you are using has not been authorized to call the API.
+  + **ACCESS_DENIED**: Access denied.
+  + **NOT_FOUND**: No API is found.
+  + **REQUEST_PARAMETERS_FAILURE**: The request parameters are incorrect.
+  + **DEFAULT_4XX**: Another 4XX error occurred.
+  + **DEFAULT_5XX**: Another 5XX error occurred.
+
+* `body` - (Required, String) Specifies the body template of the API response rule, e.g.
+  `{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}`
+
+* `status_code` - (Optional, Int) Specifies the HTTP status code of the API response rule.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the API custom response.
+* `create_time` - Time when the API custom response is created.
+* `update_time` - Time when the API custom response was last modified.
+
+## Import
+
+API Responses can be imported using their `name` and IDs of the APIG dedicated instances and API groups to which the API
+response belongs, separated by a slash, e.g.
+
+```
+$ terraform import flexibleengine_apig_response.test <instance id>/<group id>/<name>
+```

--- a/docs/resources/apig_throttling_policy.md
+++ b/docs/resources/apig_throttling_policy.md
@@ -1,0 +1,139 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+---
+
+# flexibleengine_apig_throttling_policy
+
+Manages an APIG (API) throttling policy resource within Flexibleengine.
+
+## Example Usage
+
+### Create a basic throttling policy
+
+```hcl
+variable "instance_id" {}
+variable "policy_name" {}
+variable "description" {}
+
+resource "flexibleengine_apig_throttling_policy" "test" {
+  instance_id       = var.instance_id
+  name              = var.policy_name
+  description       = var.description
+  type              = "API-based"
+  period            = 10
+  period_unit       = "MINUTE"
+  max_api_requests  = 70
+  max_user_requests = 45
+  max_app_requests  = 45
+  max_ip_requests   = 45
+}
+```
+
+### Create a throttling policy with a special throttle
+
+```hcl
+variable "instance_id" {}
+variable "policy_name" {}
+variable "description" {}
+variable "application_id" {}
+
+resource "flexibleengine_apig_throttling_policy" "test" {
+  instance_id       = var.instance_id
+  name              = var.policy_name
+  description       = var.description
+  type              = "API-based"
+  period            = 10
+  period_unit       = "MINUTE"
+  max_api_requests  = 70
+  max_user_requests = 45
+  max_app_requests  = 45
+  max_ip_requests   = 45
+
+  app_throttles {
+    max_api_requests     = 40
+    throttling_object_id = var.application_id
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the API throttling policy resource.
+  If omitted, the provider-level region will be used. Changing this will create a new API throttling policy resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies an ID of the APIG dedicated instance to which the API
+  throttling policy belongs to. Changing this will create a new API throttling policy resource.
+
+* `name` - (Required, String) Specifies the name of the API throttling policy.
+  The policy name consists of 3 to 64 characters, starting with a letter.
+  Only letters, digits and underscores (_) are allowed.
+
+* `period` - (Required, Int) Specifies the period of time for limiting the number of API calls.
+  This parameter applies with each of the API call limits: `max_api_requests`, `max_app_requests`, `max_ip_requests`
+  and `max_user_requests`.
+
+* `max_api_requests` - (Required, Int) Specifies the maximum number of times an API can be accessed within a specified
+  period. The value of this parameter cannot exceed the default limit 200 TPS.
+
+* `max_app_requests` - (Optional, Int) Specifies the maximum number of times the API can be accessed by an app within
+  the same period. The value of this parameter must be less than or equal to the value of `max_user_requests`.
+
+* `max_ip_requests` - (Optional, Int) Specifies the maximum number of times the API can be accessed by an IP address
+  within the same period. The value of this parameter must be less than or equal to the value of `max_api_requests`.
+
+* `max_user_requests` - (Optional, Int) Specifies the maximum number of times the API can be accessed by a user within
+  the same period. The value of this parameter must be less than or equal to the value of `max_api_requests`.
+
+* `type` - (Optional, String) Specifies the type of the request throttling policy.
+  The valid values are as follows:
+  + API-based: limiting the maximum number of times a single API bound to the policy can be called within the
+    specified period.
+  + API-shared: limiting the maximum number of times all APIs bound to the policy can be called within the specified
+    period.
+
+* `description` - (Optional, String) Specifies the description about the API throttling policy.
+  The description contain a maximum of 255 characters and the angle brackets (< and >) are not allowed.
+  Chinese characters must be in UTF-8 or Unicode format.
+
+* `period_unit` - (Optional, String) Specifies the time unit for limiting the number of API calls.
+  The valid values are *SECOND*, *MINUTE*, *HOUR* and *DAY*, default to *MINUTE*.
+
+* `user_throttles` - (Optional, List) Specifies an array of one or more special throttling policies for IAM user limit.
+  The `throttle` object of the `user_throttles` structure is documented below.
+
+* `app_throttles` - (Optional, List) Specifies an array of one or more special throttling policies for APP limit.
+  The `throttle` object of the `user_throttles` structure is documented below.
+
+The `throttle` block supports:
+
+* `max_api_requests` - (Required, Int) Specifies the maximum number of times an API can be accessed within a specified
+  period.
+
+* `throttling_object_id` - (Required, String) Specifies the object ID which the special throttling policy belongs.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the API throttling policy.
+
+* `user_throttles` - An array of one or more special throttling policies for IAM user limit.
+  + `throttling_object_name` - The object name which the special user throttling policy belongs.
+  + `id` - ID of the special user throttling policy.
+
+* `app_throttles` - An array of one or more special throttling policies for APP limit.
+  + `throttling_object_name` - The object name which the special application throttling policy belongs.
+  + `id` - ID of the special application throttling policy.
+
+* `create_time` - Time when the API throttling policy was created.
+
+## Import
+
+API Throttling Policies of APIG can be imported using their `name` and the ID of the APIG instances to which the
+environment belongs, separated by a slash, e.g.
+
+```
+$ terraform import flexibleengine_apig_throttling_policy.test <instance ID>/<name>
+```

--- a/docs/resources/apig_throttling_policy_associate.md
+++ b/docs/resources/apig_throttling_policy_associate.md
@@ -1,0 +1,56 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+---
+
+# flexibleengine_apig_throttling_policy_associate
+
+Use this resource to bind the APIs to the throttling policy within Flexibleengine.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "policy_id" {}
+variable "api_publish_id1" {}
+variable "api_publish_id2" {}
+
+resource "flexibleengine_apig_throttling_policy_associate" "test" {
+  instance_id = var.instance_id
+  policy_id   = var.policy_id
+
+  publish_ids = [
+    var.api_publish_id1,
+    var.api_publish_id2,
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the API instance and throttling policy are located.
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the APIG dedicated instance to which the APIs and the
+  throttling policy belongs. Changing this will create a new resource.
+
+* `policy_id` - (Required, String, ForceNew) Specifies the ID of the API group to which the API response belongs to.
+  Changing this will create a new resource.
+
+* `publish_ids` - (Required, List) Specifies the publish ID corresponding to the API bound by the throttling policy.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Resource ID. The format is `<instance_id>/<policy_id>`.
+
+## Import
+
+Associate resources can be imported using their `policy_id` and the APIG dedicated instance ID to which the policy
+belongs, separated by a slash, e.g.
+
+```
+$ terraform import flexibleengine_apig_throttling_policy_associate.test &ltinstance id&gt/&ltpolicy_id&gt
+```

--- a/docs/resources/apig_vpc_channel.md
+++ b/docs/resources/apig_vpc_channel.md
@@ -1,0 +1,116 @@
+---
+subcategory: "API Gateway (Dedicated APIG)"
+---
+
+# flexibleengine_apig_vpc_channel
+
+Manages a VPC channel resource within Flexibleengine.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "channel_name" {}
+variable "ecs_id1" {}
+variable "ecs_id2" {}
+
+resource "flexibleengine_apig_vpc_channel" "test" {
+  instance_id = var.instance_id
+  name        = var.app_name
+  port        = 8080
+  protocol    = "HTTPS"
+  path        = "/"
+  http_code   = "201,202,203"
+
+  members {
+    id     = var.ecs_id1
+    weight = 30
+  }
+
+  members {
+    id     = var.ecs_id2
+    weight = 70
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the VPC channel resource.
+  If omitted, the provider-level region will be used.
+  Changing this will create a new VPC channel resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies an ID of the APIG dedicated instance to which the APIG
+  vpc channel belongs to.
+  Changing this will create a new VPC channel resource.
+
+* `name` - (Required, String) Specifies the name of the VPC channel.
+  The channel name consists of 3 to 64 characters, starting with a letter.
+  Only letters, digits and underscores (_) are allowed.
+  Chinese characters must be in UTF-8 or Unicode format.
+
+* `port` - (Optional, Int) Specifies the host port of the VPC channel.
+  The valid value is range from 1 to 65535.
+
+* `member_type` - (Optional, String) Specifies the type of the backend service.
+  The valid types are *ECS* and *EIP*, default to *ECS*.
+
+* `algorithm` - (Optional, String) Specifies the type of the backend service.
+  The valid types are *WRR*, *WLC*, *SH* and *URI hashing*, default to *WRR*.
+
+* `protocol` - (Optional, String) Specifies the protocol for performing health checks on backend servers in the VPC
+  channel.
+  The valid values are *TCP*, *HTTP* and *HTTPS*, default to *TCP*.
+
+* `path` - (Optional, String) Specifies the destination path for health checks.
+  Required if `protocol` is *HTTP* or *HTTPS*.
+
+* `healthy_threshold` - (Optional, Int) Specifies the healthy threshold, which refers to the number of consecutive
+  successful checks required for a backend server to be considered healthy.
+  The valid value is range from 2 to 10, default to 2.
+
+* `unhealthy_threshold` - (Optional, Int) Specifies the unhealthy threshold, which refers to the number of consecutive
+  failed checks required for a backend server to be considered unhealthy.
+  The valid value is range from 2 to 10, default to 5.
+
+* `timeout` - (Optional, Int) Specifies the timeout for determining whether a health check fails, in second.
+  The value must be less than the value of time_interval.
+  The valid value is range from 2 to 30, default to 5.
+
+* `interval` - (Optional, Int) Specifies the interval between consecutive checks, in second.
+  The valid value is range from 5 to 300, default to 10.
+
+* `members` - (Optional, List) Specifies an array of one or more backend server IDs or IP addresses that bind the VPC
+  channel.
+  The object structure is documented below.
+
+The `members` block supports:
+
+* `id` - (Optional, String) Specifies the ECS ID for each backend servers.
+  Required if `member_type` is *ECS*.
+  This parameter and `ip_address` are alternative.
+
+* `ip_address` - (Optional, String) Specifies the IP address each backend servers.
+  Required if `member_type` is *EIP*.
+
+* `weight` - (Optional, Int) Specifies the backend server weight.
+  The valid values are range from 1 to 100, default to 1.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the VPC channel.
+* `create_time` - Time when the channel created, in UTC format.
+* `status` - The status of VPC channel, supports *Normal* and *Abnormal*.
+
+## Import
+
+VPC Channels can be imported using their `name` and ID of the APIG dedicated instance to which the channel
+belongs, separated by a slash, e.g.
+
+```
+$ terraform import flexibleengine_apig_vpc_channel.test <instance id>/<channel name>
+```

--- a/flexibleengine/acceptance/data_source_flexibleengine_apig_environments_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_apig_environments_test.go
@@ -1,0 +1,51 @@
+package acceptance
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataEnvironments_basic(t *testing.T) {
+	var (
+		dataSourceName = "data.flexibleengine_apig_environments.test"
+		dc             = acceptance.InitDataSourceCheck(dataSourceName)
+		rName          = acceptance.RandomAccResourceName()
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataEnvironments_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "environments.#", regexp.MustCompile(`[1-9]\d*`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataEnvironments_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_environment" "test" {
+  name        = "%s"
+  instance_id = flexibleengine_apig_instance.test.id
+  description = "Created by script"
+}
+
+data "flexibleengine_apig_environments" "test" {
+  instance_id = flexibleengine_apig_instance.test.id
+  name        = flexibleengine_apig_environment.test.name
+}
+`, testAccApigApplication_base(rName), rName)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_apig_api_publishment_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_apig_api_publishment_test.go
@@ -1,0 +1,84 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apis"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
+)
+
+func getPublishmentResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.ApigV2Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Flexibleengine APIG v2 client: %s", err)
+	}
+	return apig.GetVersionHistories(c, state.Primary.Attributes["instance_id"], state.Primary.Attributes["env_id"],
+		state.Primary.Attributes["api_id"])
+}
+
+func TestAccApigApiPublishmentV2_basic(t *testing.T) {
+	var histories []apis.ApiVersionInfo
+
+	// The dedicated instance name only allow letters, digits and underscores (_).
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_apig_api_publishment.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&histories,
+		getPublishmentResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigApiPublishment_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "instance_id",
+						"${flexibleengine_apig_instance.test.id}"),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "env_id",
+						"${flexibleengine_apig_environment.test.id}"),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "api_id",
+						"${flexibleengine_apig_api.test.id}"),
+					resource.TestCheckResourceAttrSet(resourceName, "env_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "publish_time"),
+					resource.TestCheckResourceAttrSet(resourceName, "publish_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccApigApiPublishment_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_environment" "test" {
+  name        = "%s"
+  instance_id = flexibleengine_apig_instance.test.id
+  description = "Created by script"
+}
+
+resource "flexibleengine_apig_api_publishment" "test" {
+  instance_id = flexibleengine_apig_instance.test.id
+  env_id      = flexibleengine_apig_environment.test.id
+  api_id      = flexibleengine_apig_api.test.id
+}
+`, testAccApigAPI_basic(rName), rName)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_apig_api_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_apig_api_test.go
@@ -1,0 +1,313 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apis"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccApigAPIV2_basic(t *testing.T) {
+	var (
+		// The dedicated instance name only allow letters, digits and underscores (_).
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "flexibleengine_apig_api.test"
+		api          apis.APIResp
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigAPIDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigAPI_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigAPIExists(resourceName, &api),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "Public"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by script"),
+					resource.TestCheckResourceAttr(resourceName, "request_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "request_method", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "request_path", "/user_info/{user_age}"),
+					resource.TestCheckResourceAttr(resourceName, "security_authentication", "APP"),
+					resource.TestCheckResourceAttr(resourceName, "matching", "Exact"),
+					resource.TestCheckResourceAttr(resourceName, "success_response", "Success response"),
+					resource.TestCheckResourceAttr(resourceName, "failure_response", "Failed response"),
+					resource.TestCheckResourceAttr(resourceName, "request_params.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "backend_params.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "web.0.path", "/getUserAge/{userAge}"),
+					resource.TestCheckResourceAttr(resourceName, "web.0.request_method", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "web.0.request_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "web.0.timeout", "30000"),
+					resource.TestCheckResourceAttr(resourceName, "web_policy.#", "1"),
+					resource.TestCheckNoResourceAttr(resourceName, "mock"),
+					resource.TestCheckNoResourceAttr(resourceName, "func_graph"),
+					resource.TestCheckNoResourceAttr(resourceName, "mock_policy"),
+					resource.TestCheckNoResourceAttr(resourceName, "func_graph_policy"),
+				),
+			},
+			{
+				Config: testAccApigAPI_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigAPIExists(resourceName, &api),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "type", "Public"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by script"),
+					resource.TestCheckResourceAttr(resourceName, "request_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "request_method", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "request_path", "/user_info/{user_name}"),
+					resource.TestCheckResourceAttr(resourceName, "security_authentication", "APP"),
+					resource.TestCheckResourceAttr(resourceName, "matching", "Exact"),
+					resource.TestCheckResourceAttr(resourceName, "success_response", "Updated Success response"),
+					resource.TestCheckResourceAttr(resourceName, "failure_response", "Updated Failed response"),
+					resource.TestCheckResourceAttr(resourceName, "request_params.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "backend_params.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "web.0.path", "/getUserName/{userName}"),
+					resource.TestCheckResourceAttr(resourceName, "web.0.request_method", "GET"),
+					resource.TestCheckResourceAttr(resourceName, "web.0.request_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "web.0.timeout", "60000"),
+					resource.TestCheckResourceAttr(resourceName, "web_policy.#", "1"),
+					resource.TestCheckNoResourceAttr(resourceName, "mock"),
+					resource.TestCheckNoResourceAttr(resourceName, "func_graph"),
+					resource.TestCheckNoResourceAttr(resourceName, "mock_policy"),
+					resource.TestCheckNoResourceAttr(resourceName, "func_graph_policy"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigAPIResourceImportStateFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckApigAPIDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.ApigV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating Flexibleengine APIG v2 client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_apig_api" {
+			continue
+		}
+		_, err := apis.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("APIG v2 API (%s) is still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckApigAPIExists(n string, app *apis.APIResp) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Resource %s not found", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Unable to find API ID")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.ApigV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating Flexibleengine APIG v2 client: %s", err)
+		}
+		found, err := apis.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+		*app = *found
+		return nil
+	}
+}
+
+func testAccApigAPIResourceImportStateFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("Resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.ID == "" || rs.Primary.Attributes["instance_id"] == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", rs.Primary.Attributes["instance_id"],
+				rs.Primary.Attributes["name"])
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["name"]), nil
+	}
+}
+
+func testAccApigAPI_base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_group" "test" {
+  name        = "%s"
+  instance_id = flexibleengine_apig_instance.test.id
+  description = "Created by script"
+}
+
+resource "flexibleengine_apig_vpc_channel" "test" {
+  name        = "%s"
+  instance_id = flexibleengine_apig_instance.test.id
+  port        = 80
+  algorithm   = "WRR"
+  protocol    = "HTTP"
+  path        = "/"
+  http_code   = "201"
+
+  members {
+    id = flexibleengine_compute_instance_v2.test.id
+  }
+}
+`, testAccApigVpcChannel_base(rName), rName, rName)
+}
+
+func testAccApigAPI_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_api" "test" {
+  instance_id             = flexibleengine_apig_instance.test.id
+  group_id                = flexibleengine_apig_group.test.id
+  name                    = "%s"
+  type                    = "Public"
+  request_protocol        = "HTTP"
+  request_method          = "GET"
+  request_path            = "/user_info/{user_age}"
+  security_authentication = "APP"
+  matching                = "Exact"
+  success_response        = "Success response"
+  failure_response        = "Failed response"
+  description             = "Created by script"
+
+  request_params {
+    name     = "user_age"
+    type     = "NUMBER"
+    location = "PATH"
+    required = true
+    maximum  = 200
+    minimum  = 0
+  }
+  
+  backend_params {
+	type     = "REQUEST"
+    name     = "userAge"
+    location = "PATH"
+    value    = "user_age"
+  }
+
+  web {
+    path             = "/getUserAge/{userAge}"
+    vpc_channel_id   = flexibleengine_apig_vpc_channel.test.id
+    request_method   = "GET"
+    request_protocol = "HTTP"
+    timeout          = 30000
+  }
+
+  web_policy {
+    name             = "%s_policy1"
+    request_protocol = "HTTP"
+    request_method   = "GET"
+    effective_mode   = "ANY"
+    path             = "/getUserAge/{userAge}"
+    timeout          = 30000
+    vpc_channel_id   = flexibleengine_apig_vpc_channel.test.id
+
+    backend_params {
+      type     = "REQUEST"
+      name     = "userAge"
+      location = "PATH"
+      value    = "user_age"
+    }
+
+    conditions {
+      source     = "param"
+      param_name = "user_age"
+      type       = "Equal"
+      value      = "28"
+    }
+  }
+}
+`, testAccApigAPI_base(rName), rName, rName)
+}
+
+func testAccApigAPI_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_api" "test" {
+  instance_id             = flexibleengine_apig_instance.test.id
+  group_id                = flexibleengine_apig_group.test.id
+  name                    = "%s_update"
+  type                    = "Public"
+  request_protocol        = "HTTP"
+  request_method          = "GET"
+  request_path            = "/user_info/{user_name}"
+  security_authentication = "APP"
+  matching                = "Exact"
+  success_response        = "Updated Success response"
+  failure_response        = "Updated Failed response"
+  description             = "Updated by script"
+
+  request_params {
+    name     = "user_name"
+    type     = "STRING"
+    location = "PATH"
+    required = true
+    maximum  = 64
+    minimum  = 3
+  }
+  
+  backend_params {
+    type     = "REQUEST"
+    name     = "userName"
+    location = "PATH"
+    value    = "user_name"
+  }
+
+  web {
+    path             = "/getUserName/{userName}"
+    vpc_channel_id   = flexibleengine_apig_vpc_channel.test.id
+    request_method   = "GET"
+    request_protocol = "HTTP"
+    timeout          = 60000
+  }
+
+  web_policy {
+    name             = "%s_update_policy1"
+    request_protocol = "HTTP"
+    request_method   = "GET"
+    effective_mode   = "ANY"
+    path             = "/getAdminName/{adminName}"
+    timeout          = 60000
+    vpc_channel_id   = flexibleengine_apig_vpc_channel.test.id
+
+    backend_params {
+      type     = "REQUEST"
+      name     = "adminName"
+      location = "PATH"
+      value    = "user_name"
+    }
+
+    conditions {
+      source     = "param"
+      param_name = "user_name"
+      type       = "Equal"
+      value      = "Administrator"
+    }
+  }
+}
+`, testAccApigAPI_base(rName), rName, rName)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_apig_application_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_apig_application_test.go
@@ -1,0 +1,166 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/applications"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func TestAccApigApplicationV2_basic(t *testing.T) {
+	var (
+		// Only letters, digits and underscores (_) are allowed in the application and dedicated instance name.
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "flexibleengine_apig_application.test"
+		application  applications.Application
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigApplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigApplication_basic(rName, acctest.RandString(64)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigApplicationExists(resourceName, &application),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by script"),
+					resource.TestCheckResourceAttrSet(resourceName, "app_key"),
+					resource.TestCheckResourceAttrSet(resourceName, "app_secret"),
+				),
+			},
+			{
+				// update name, description and app_code.
+				Config: testAccApigApplication_update(rName, acctest.RandString(64)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigApplicationExists(resourceName, &application),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by script"),
+					resource.TestCheckResourceAttrSet(resourceName, "app_key"),
+					resource.TestCheckResourceAttrSet(resourceName, "app_secret"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigInstanceSubResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckApigApplicationDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.ApigV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating Flexibleengine APIG v2 client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_apig_application" {
+			continue
+		}
+		_, err := applications.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("APIG v2 application (%s) is still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckApigApplicationExists(appName string, app *applications.Application) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[appName]
+		if !ok {
+			return fmt.Errorf("Resource %s not found", appName)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No APIG V2 application Id")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.ApigV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating Flexibleengine APIG v2 client: %s", err)
+		}
+		found, err := applications.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+		*app = *found
+		return nil
+	}
+}
+
+func testAccApigInstanceSubResourceImportStateIdFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("Resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.ID == "" || rs.Primary.Attributes["instance_id"] == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.ID)
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.ID), nil
+	}
+}
+
+func testAccApigApplication_base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_networking_secgroup_v2" "test" {
+  name = "%s"
+}
+
+resource "flexibleengine_apig_instance" "test" {
+  name                  = "%s"
+  edition               = "BASIC"
+  vpc_id                = flexibleengine_vpc_v1.test.id
+  subnet_id             = flexibleengine_vpc_subnet_v1.test.id
+  security_group_id     = flexibleengine_networking_secgroup_v2.test.id
+  enterprise_project_id = "0"
+
+  available_zones = [
+    data.flexibleengine_availability_zones.test.names[0],
+  ]
+}
+`, testAccApigInstance_base(rName), rName, rName)
+}
+
+func testAccApigApplication_basic(rName, code string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_application" "test" {
+  name        = "%s"
+  instance_id = flexibleengine_apig_instance.test.id
+  description = "Created by script"
+
+  app_codes = ["%s"]
+}
+`, testAccApigApplication_base(rName), rName, utils.EncodeBase64String(code))
+}
+
+func testAccApigApplication_update(rName, code string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_application" "test" {
+  name        = "%s_update"
+  instance_id = flexibleengine_apig_instance.test.id
+  description = "Updated by script"
+
+  app_codes = ["%s"]
+}
+`, testAccApigApplication_base(rName), rName, utils.EncodeBase64String(code))
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_apig_custom_authorizer_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_apig_custom_authorizer_test.go
@@ -1,0 +1,253 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/authorizers"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccApigCustomAuthorizerV2_basic(t *testing.T) {
+	var (
+		// Only letters, digits and underscores (_) are allowed in the authorizer name, environment name
+		// and dedicated instance name.
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "flexibleengine_apig_custom_authorizer.test"
+		auth         authorizers.CustomAuthorizer
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigCustomAuthorizerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigCustomAuthorizer_front(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigCustomAuthorizerExists(resourceName, &auth),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "FRONTEND"),
+					resource.TestCheckResourceAttr(resourceName, "is_body_send", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cache_age", "60"),
+					resource.TestCheckResourceAttr(resourceName, "identity.#", "1"),
+				),
+			},
+			{
+				Config: testAccApigCustomAuthorizer_frontUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigCustomAuthorizerExists(resourceName, &auth),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "type", "FRONTEND"),
+					resource.TestCheckResourceAttr(resourceName, "is_body_send", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cache_age", "0"),
+					resource.TestCheckResourceAttr(resourceName, "identity.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccApigCustomAuthorizerV2_backend(t *testing.T) {
+	var (
+		// Only letters, digits and underscores (_) are allowed in the environment name and dedicated instance name.
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "flexibleengine_apig_custom_authorizer.test"
+		auth         authorizers.CustomAuthorizer
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigCustomAuthorizerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigCustomAuthorizer_backend(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigCustomAuthorizerExists(resourceName, &auth),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "BACKEND"),
+					resource.TestCheckResourceAttr(resourceName, "is_body_send", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cache_age", "60"),
+				),
+			},
+			{
+				Config: testAccApigCustomAuthorizer_backendUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigCustomAuthorizerExists(resourceName, &auth),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "type", "BACKEND"),
+					resource.TestCheckResourceAttr(resourceName, "is_body_send", "false"),
+					resource.TestCheckResourceAttr(resourceName, "cache_age", "45"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckApigCustomAuthorizerDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.ApigV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating Flexibleengine APIG v2 client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_apig_custom_authorizer" {
+			continue
+		}
+		_, err := authorizers.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("APIG v2 API custom authorizer (%s) is still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckApigCustomAuthorizerExists(name string, env *authorizers.CustomAuthorizer) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Resource %s not found", name)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No custom authorizer Id")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.ApigV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating Flexibleengine APIG v2 client: %s", err)
+		}
+		found, err := authorizers.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err != nil {
+			return fmt.Errorf("Error getting custom authorizer (%s): %s", rs.Primary.ID, err)
+		}
+		*env = *found
+		return nil
+	}
+}
+
+func testAccApigCustomAuthorizer_base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_fgs_function" "test" {
+  name        = "%s"
+  app         = "default"
+  description = "API custom authorization test"
+  handler     = "index.handler"
+  memory_size = 128
+  timeout     = 3
+  runtime     = "Python3.6"
+  code_type   = "inline"
+  
+  func_code = <<EOF
+# -*- coding:utf-8 -*-
+import json
+def handler(event, context):
+    if event["headers"]["authorization"]=='Basic dXNlcjE6cGFzc3dvcmQ=':
+        return {
+            'statusCode': 200,
+            'body': json.dumps({
+                "status":"allow",
+                "context":{
+                    "user_name":"user1"
+                }
+            })
+        }
+    else:
+        return {
+            'statusCode': 200,
+            'body': json.dumps({
+                "status":"deny",
+                "context":{
+                    "code":"1001",
+                    "message":"incorrect username or password"
+                }
+            })
+        }
+EOF
+}
+`, testAccApigApplication_base(rName), rName)
+}
+
+func testAccApigCustomAuthorizer_front(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_custom_authorizer" "test" {
+  instance_id  = flexibleengine_apig_instance.test.id
+  name         = "%s"
+  function_urn = flexibleengine_fgs_function.test.urn
+  type         = "FRONTEND"
+  is_body_send = true
+  cache_age    = 60
+  
+  identity {
+    name     = "user_name"
+    location = "QUERY"
+  }
+}
+`, testAccApigCustomAuthorizer_base(rName), rName)
+}
+
+func testAccApigCustomAuthorizer_frontUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_custom_authorizer" "test" {
+  instance_id  = flexibleengine_apig_instance.test.id
+  name         = "%s_update"
+  function_urn = flexibleengine_fgs_function.test.urn
+  type         = "FRONTEND"
+}
+`, testAccApigCustomAuthorizer_base(rName), rName)
+}
+
+func testAccApigCustomAuthorizer_backend(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_custom_authorizer" "test" {
+  instance_id  = flexibleengine_apig_instance.test.id
+  name         = "%s"
+  function_urn = flexibleengine_fgs_function.test.urn
+  type         = "BACKEND"
+  cache_age    = 60
+}
+`, testAccApigCustomAuthorizer_base(rName), rName)
+}
+
+func testAccApigCustomAuthorizer_backendUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_custom_authorizer" "test" {
+  instance_id  = flexibleengine_apig_instance.test.id
+  name         = "%s_update"
+  function_urn = flexibleengine_fgs_function.test.urn
+  type         = "BACKEND"
+  cache_age    = 45
+}
+`, testAccApigCustomAuthorizer_base(rName), rName)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_apig_environment_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_apig_environment_test.go
@@ -1,0 +1,121 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/environments"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
+)
+
+func TestAccApigEnvironmentV2_basic(t *testing.T) {
+	var (
+		// Only letters, digits and underscores (_) are allowed in the environment name and dedicated instance name.
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "flexibleengine_apig_environment.test"
+		env          environments.Environment
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigEnvironment_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigEnvironmentExists(resourceName, &env),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by script"),
+				),
+			},
+			{
+				Config: testAccApigEnvironment_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigEnvironmentExists(resourceName, &env),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by script"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckApigEnvironmentDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.ApigV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating Flexibleengine APIG v2 client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_apig_environment" {
+			continue
+		}
+		_, err := apig.GetEnvironmentFormServer(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("APIG v2 API environment (%s) is still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckApigEnvironmentExists(name string, env *environments.Environment) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Resource %s not found", name)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No APIG V2 API group Id")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.ApigV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating Flexibleengine APIG v2 client: %s", err)
+		}
+		found, err := apig.GetEnvironmentFormServer(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("Error getting APIG v2 API environment (%s): %s", rs.Primary.ID, err)
+		}
+		*env = *found
+		return nil
+	}
+}
+
+func testAccApigEnvironment_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_environment" "test" {
+  name        = "%s"
+  instance_id = flexibleengine_apig_instance.test.id
+  description = "Created by script"
+}
+`, testAccApigApplication_base(rName), rName)
+}
+
+func testAccApigEnvironment_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_environment" "test" {
+  name        = "%s_update"
+  instance_id = flexibleengine_apig_instance.test.id
+  description = "Updated by script"
+}
+`, testAccApigApplication_base(rName), rName)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_apig_group_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_apig_group_test.go
@@ -1,0 +1,258 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/apigroups"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccApigGroupV2_basic(t *testing.T) {
+	var (
+		// Only letters, digits and underscores (_) are allowed in the name.
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "flexibleengine_apig_group.test"
+		group        apigroups.Group
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigGroup_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by script"),
+				),
+			},
+			{
+				Config: testAccApigGroup_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by script"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigInstanceSubResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccApigGroupV2_variables(t *testing.T) {
+	var (
+		// Only letters, digits and underscores (_) are allowed in the name.
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "flexibleengine_apig_group.test"
+		group        apigroups.Group
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigGroup_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				// Bind two environment to group, and create some variables.
+				Config: testAccApigGroup_variables(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "environment.#", "2"),
+				),
+			},
+			{
+				// Update the variables for two environments.
+				Config: testAccApigGroup_variablesUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigGroupExists(resourceName, &group),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "environment.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigInstanceSubResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckApigGroupDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.ApigV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating Flexibleengine APIG v2 client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_apig_group" {
+			continue
+		}
+		_, err := apigroups.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("APIG v2 API group (%s) is still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckApigGroupExists(groupName string, app *apigroups.Group) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[groupName]
+		if !ok {
+			return fmt.Errorf("Resource %s not found", groupName)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No APIG V2 API group Id")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.ApigV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating Flexibleengine APIG v2 client: %s", err)
+		}
+		found, err := apigroups.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err != nil {
+			return fmt.Errorf("APIG v2 API group not exist: %s", err)
+		}
+		*app = *found
+		return nil
+	}
+}
+
+func testAccApigGroup_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_group" "test" {
+  name        = "%s"
+  instance_id = flexibleengine_apig_instance.test.id
+  description = "Created by script"
+}
+`, testAccApigApplication_base(rName), rName)
+}
+
+func testAccApigGroup_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_group" "test" {
+  name        = "%s_update"
+  instance_id = flexibleengine_apig_instance.test.id
+  description = "Updated by script"
+}
+`, testAccApigApplication_base(rName), rName)
+}
+
+func testAccApigGroup_variablesBase(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_apig_environment" "test1" {
+  name        = "%s_1"
+  instance_id = flexibleengine_apig_instance.test.id
+  description = "Created by script"
+}
+
+resource "flexibleengine_apig_environment" "test2" {
+  name        = "%s_2"
+  instance_id = flexibleengine_apig_instance.test.id
+  description = "Created by script"
+}
+`, rName, rName)
+}
+
+// Create two environments for the group, and add a total of three variables to the two environments.
+// Each of the two environments has a variable with the same name and different value.
+func testAccApigGroup_variables(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "flexibleengine_apig_group" "test" {
+  name        = "%s"
+  instance_id = flexibleengine_apig_instance.test.id
+  description = "Created by script"
+
+  environment {
+    environment_id = flexibleengine_apig_environment.test1.id
+
+    variable {
+      name  = "TERRAFORM"
+      value = "/stage/terraform"
+    }
+  }
+  environment {
+    environment_id = flexibleengine_apig_environment.test2.id
+
+    variable {
+      name  = "TERRAFORM"
+      value = "/res/terraform"
+    }
+    variable {
+      name  = "DEMO"
+      value = "/stage/demo"
+    }
+  }
+}
+`, testAccApigApplication_base(rName), testAccApigGroup_variablesBase(rName), rName)
+}
+
+func testAccApigGroup_variablesUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "flexibleengine_apig_group" "test" {
+  name        = "%s"
+  instance_id = flexibleengine_apig_instance.test.id
+  description = "Created by script"
+
+  environment {
+    environment_id = flexibleengine_apig_environment.test1.id
+
+    variable {
+      name  = "TERRAFORM"
+      value = "/stage/terraform"
+    }
+    variable {
+      name  = "TEST"
+      value = "/stage/test"
+    }
+  }
+  environment {
+    environment_id = flexibleengine_apig_environment.test2.id
+
+    variable {
+      name  = "TERRAFORM"
+      value = "/stage/terraform"
+    }
+  }
+}
+`, testAccApigApplication_base(rName), testAccApigGroup_variablesBase(rName), rName)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_apig_instance_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_apig_instance_test.go
@@ -1,0 +1,426 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/instances"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+)
+
+func TestAccApigInstanceV2_basic(t *testing.T) {
+	var resourceName = "flexibleengine_apig_instance.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	var instance instances.Instance
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigInstance_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "edition", "BASIC"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "14:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "18:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by acc test"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_ingress_address"),
+				),
+			},
+			{
+				Config: testAccApigInstance_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "edition", "BASIC"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "18:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_end", "22:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "description", "updated by acc test"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_ingress_address"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccApigInstanceV2_egress(t *testing.T) {
+	var resourceName = "flexibleengine_apig_instance.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	var instance instances.Instance
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigInstance_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "edition", "BASIC"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "14:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by acc test"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_ingress_address"),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth_size", "0"),
+				),
+			},
+			{
+				Config: testAccApigInstance_egress(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_ingress_address"),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth_size", "3"),
+					resource.TestCheckResourceAttrSet(resourceName, "egress_address"),
+				),
+			},
+			{
+				Config: testAccApigInstance_egressUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_ingress_address"),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth_size", "5"),
+					resource.TestCheckResourceAttrSet(resourceName, "egress_address"),
+				),
+			},
+			{
+				Config: testAccApigInstance_basic(rName), // Unbind egress nat
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_ingress_address"),
+					resource.TestCheckResourceAttr(resourceName, "bandwidth_size", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccApigInstanceV2_ingress(t *testing.T) {
+	var resourceName = "flexibleengine_apig_instance.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	var instance instances.Instance
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigInstance_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "edition", "BASIC"),
+					resource.TestCheckResourceAttr(resourceName, "maintain_begin", "14:00:00"),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by acc test"),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_ingress_address"),
+				),
+			},
+			{
+				Config: testAccApigInstance_ingress(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_ingress_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "eip_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "ingress_address"),
+				),
+			},
+			{
+				Config: testAccApigInstance_ingressUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_ingress_address"),
+					resource.TestCheckResourceAttrSet(resourceName, "eip_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "ingress_address"),
+				),
+			},
+			{
+				Config: testAccApigInstance_basic(rName), // Unbind ingress eip
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrSet(resourceName, "vpc_ingress_address"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckApigInstanceDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.ApigV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmtp.Errorf("Error creating Flexibleengine APIG v2 client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_apig_instance" {
+			continue
+		}
+		_, err := instances.Get(client, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmtp.Errorf("APIG v2 instance (%s) is still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckApigInstanceExists(n string, instance *instances.Instance) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmtp.Errorf("Resource %s not found", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmtp.Errorf("No ID is set")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.ApigV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmtp.Errorf("Error creating Flexibleengine APIG v2 client: %s", err)
+		}
+
+		found, err := instances.Get(client, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+		*instance = *found
+		return nil
+	}
+}
+
+func testAccApigInstance_base(rName string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_availability_zones" "test" {}
+
+resource "flexibleengine_vpc_v1" "test" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test" {
+  name       = "%s"
+  vpc_id     = flexibleengine_vpc_v1.test.id
+  gateway_ip = "192.168.0.1"
+  cidr       = "192.168.0.0/24"
+}
+`, rName, rName)
+}
+
+func testAccApigInstance_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_networking_secgroup_v2" "test" {
+  name = "%s"
+}
+
+resource "flexibleengine_apig_instance" "test" {
+  name                  = "%s"
+  edition               = "BASIC"
+  vpc_id                = flexibleengine_vpc_v1.test.id
+  subnet_id             = flexibleengine_vpc_subnet_v1.test.id
+  security_group_id     = flexibleengine_networking_secgroup_v2.test.id
+  maintain_begin        = "14:00:00"
+  description           = "created by acc test"
+  enterprise_project_id = "0"
+
+  available_zones = [
+    data.flexibleengine_availability_zones.test.names[0],
+  ]
+}
+`, testAccApigInstance_base(rName), rName, rName)
+}
+
+func testAccApigInstance_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_networking_secgroup_v2" "test" {
+  name = "%s"
+}
+
+resource "flexibleengine_networking_secgroup_v2" "update" {
+  name = "%s-update"
+}
+
+resource "flexibleengine_apig_instance" "test" {
+  name                  = "%s-update"
+  edition               = "BASIC"
+  vpc_id                = flexibleengine_vpc_v1.test.id
+  subnet_id             = flexibleengine_vpc_subnet_v1.test.id
+  security_group_id     = flexibleengine_networking_secgroup_v2.update.id
+  maintain_begin        = "18:00:00"
+  description           = "updated by acc test"
+  enterprise_project_id = "0"
+
+  available_zones = [
+    data.flexibleengine_availability_zones.test.names[0],
+  ]
+}
+`, testAccApigInstance_base(rName), rName, rName, rName)
+}
+
+func testAccApigInstance_egress(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_networking_secgroup_v2" "test" {
+  name = "%s"
+}
+
+resource "flexibleengine_apig_instance" "test" {
+  name                  = "%s"
+  edition               = "BASIC"
+  vpc_id                = flexibleengine_vpc_v1.test.id
+  subnet_id             = flexibleengine_vpc_subnet_v1.test.id
+  security_group_id     = flexibleengine_networking_secgroup_v2.test.id
+  maintain_begin        = "14:00:00"
+  description           = "created by acc test"
+  bandwidth_size        = 3
+  enterprise_project_id = "0"
+
+  available_zones = [
+    data.flexibleengine_availability_zones.test.names[0],
+  ]
+}
+`, testAccApigInstance_base(rName), rName, rName)
+}
+
+func testAccApigInstance_egressUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_networking_secgroup_v2" "test" {
+  name = "%s"
+}
+
+resource "flexibleengine_apig_instance" "test" {
+  name                  = "%s"
+  edition               = "BASIC"
+  vpc_id                = flexibleengine_vpc_v1.test.id
+  subnet_id             = flexibleengine_vpc_subnet_v1.test.id
+  security_group_id     = flexibleengine_networking_secgroup_v2.test.id
+  maintain_begin        = "14:00:00"
+  description           = "created by acc test"
+  bandwidth_size        = 5
+  enterprise_project_id = "0"
+
+  available_zones = [
+    data.flexibleengine_availability_zones.test.names[0],
+  ]
+}
+`, testAccApigInstance_base(rName), rName, rName)
+}
+
+func testAccApigInstance_ingress(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "%s"
+    size        = 3
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "flexibleengine_networking_secgroup_v2" "test" {
+  name = "%s"
+}
+
+resource "flexibleengine_apig_instance" "test" {
+  name                  = "%s"
+  edition               = "BASIC"
+  vpc_id                = flexibleengine_vpc_v1.test.id
+  subnet_id             = flexibleengine_vpc_subnet_v1.test.id
+  security_group_id     = flexibleengine_networking_secgroup_v2.test.id
+  maintain_begin        = "14:00:00"
+  description           = "created by acc test"
+  eip_id                = flexibleengine_vpc_eip.test.id
+  enterprise_project_id = "0"
+
+  available_zones = [
+    data.flexibleengine_availability_zones.test.names[0],
+  ]
+}
+`, testAccApigInstance_base(rName), rName, rName, rName)
+}
+
+func testAccApigInstance_ingressUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpc_eip" "update" {
+  publicip {
+    type = "5_bgp"
+  }
+  bandwidth {
+    name        = "%s-update"
+    size        = 4
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "flexibleengine_networking_secgroup_v2" "test" {
+  name = "%s"
+}
+
+resource "flexibleengine_apig_instance" "test" {
+  name                  = "%s"
+  edition               = "BASIC"
+  vpc_id                = flexibleengine_vpc_v1.test.id
+  subnet_id             = flexibleengine_vpc_subnet_v1.test.id
+  security_group_id     = flexibleengine_networking_secgroup_v2.test.id
+  maintain_begin        = "14:00:00"
+  description           = "created by acc test"
+  eip_id                = flexibleengine_vpc_eip.update.id
+  enterprise_project_id = "0"
+
+  available_zones = [
+    data.flexibleengine_availability_zones.test.names[0],
+  ]
+}
+`, testAccApigInstance_base(rName), rName, rName, rName)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_apig_response_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_apig_response_test.go
@@ -1,0 +1,258 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/responses"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccApigResponseV2_basic(t *testing.T) {
+	var (
+		// Only letters, digits and underscores (_) are allowed in the name.
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "flexibleengine_apig_response.test"
+		resp         responses.Response
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigResponseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigResponse_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigResponseExists(resourceName, &resp),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				Config: testAccApigResponse_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigResponseExists(resourceName, &resp),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigGroupSubResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccApigResponseV2_customRules(t *testing.T) {
+	var (
+		// Only letters, digits and underscores (_) are allowed in the name.
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "flexibleengine_apig_response.test"
+		resp         responses.Response
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigResponseDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigResponse_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigResponseExists(resourceName, &resp),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				// Add two custom rule.
+				Config: testAccApigResponse_rules(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigResponseExists(resourceName, &resp),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "2"),
+				),
+			},
+			{
+				// Remove one and update another.
+				Config: testAccApigResponse_rulesUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigResponseExists(resourceName, &resp),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "rule.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigGroupSubResourceImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckApigResponseDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.ApigV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating Flexibleengine APIG v2 client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_apig_response" {
+			continue
+		}
+		_, err := responses.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["group_id"],
+			rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("APIG v2 API custom response (%s) is still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckApigResponseExists(n string, resp *responses.Response) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Resource %s not found", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No APIG V2 API custom response Id")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.ApigV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating Flexibleengine APIG v2 client: %s", err)
+		}
+		found, err := responses.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["group_id"],
+			rs.Primary.ID).Extract()
+		if err != nil {
+			return fmt.Errorf("APIG v2 API custom response not exist: %s", err)
+		}
+		*resp = *found
+		return nil
+	}
+}
+
+func isResponseImportIdValid(rs *terraform.ResourceState) bool {
+	if rs.Primary.Attributes["instance_id"] == "" || rs.Primary.Attributes["group_id"] == "" ||
+		rs.Primary.Attributes["name"] == "" {
+		return false
+	}
+	return true
+}
+
+func testAccApigGroupSubResourceImportStateIdFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("Resource (%s) not found: %s", name, rs)
+		}
+		if isResponseImportIdValid(rs) {
+			return fmt.Sprintf("%s/%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["group_id"],
+				rs.Primary.Attributes["name"]), nil
+		}
+		return "", fmt.Errorf("resource not found: %s/%s/%s", rs.Primary.Attributes["instance_id"],
+			rs.Primary.Attributes["group_id"], rs.Primary.Attributes["name"])
+	}
+}
+
+func testAccApigResponse_base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_group" "test" {
+  name        = "%s"
+  instance_id = flexibleengine_apig_instance.test.id
+  description = "Created by script"
+}
+`, testAccApigApplication_base(rName), rName)
+}
+
+func testAccApigResponse_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_response" "test" {
+  name        = "%s"
+  instance_id = flexibleengine_apig_instance.test.id
+  group_id    = flexibleengine_apig_group.test.id
+
+  rule {
+    error_type  = "AUTHORIZER_FAILURE"
+    body        = "{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}"
+    status_code = 401
+  }
+}
+`, testAccApigResponse_base(rName), rName)
+}
+
+func testAccApigResponse_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_response" "test" {
+  name        = "%s_update"
+  instance_id = flexibleengine_apig_instance.test.id
+  group_id    = flexibleengine_apig_group.test.id
+
+  rule {
+    error_type  = "AUTHORIZER_FAILURE"
+    body        = "{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}"
+    status_code = 401
+  }
+}
+`, testAccApigResponse_base(rName), rName)
+}
+
+func testAccApigResponse_rules(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_response" "test" {
+  name        = "%s"
+  instance_id = flexibleengine_apig_instance.test.id
+  group_id    = flexibleengine_apig_group.test.id
+
+  rule {
+    error_type  = "ACCESS_DENIED"
+    body        = "{\"error_code\":\"$context.error.code\",\"error_msg\":\"$context.error.message\"}"
+    status_code = 400
+  }
+  rule {
+    error_type  = "AUTHORIZER_FAILURE"
+    body        = "{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}"
+    status_code = 401
+  }
+}
+`, testAccApigResponse_base(rName), rName)
+}
+
+func testAccApigResponse_rulesUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_response" "test" {
+  name        = "%s"
+  instance_id = flexibleengine_apig_instance.test.id
+  group_id    = flexibleengine_apig_group.test.id
+
+  rule {
+    error_type  = "AUTHORIZER_FAILURE"
+    body        = "{\"code\":\"$context.authorizer.frontend.code\",\"message\":\"$context.authorizer.frontend.message\"}"
+    status_code = 403
+  }
+}
+`, testAccApigResponse_base(rName), rName)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_apig_throttling_policy_associate_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_apig_throttling_policy_associate_test.go
@@ -1,0 +1,138 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/throttles"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getAssociateFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.ApigV2Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating APIG v2 client: %s", err)
+	}
+	opt := throttles.ListBindOpts{
+		InstanceId: state.Primary.Attributes["instance_id"],
+		ThrottleId: state.Primary.Attributes["policy_id"],
+	}
+	return throttles.ListBind(c, opt)
+}
+
+func TestAccThrottlingPolicyAssociate_basic(t *testing.T) {
+	var apiDetails []throttles.ApiForThrottle
+
+	// The dedicated instance name only allow letters, digits and underscores (_).
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_apig_throttling_policy_associate.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&apiDetails,
+		getAssociateFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccThrottlingPolicyAssociate_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id",
+						"flexibleengine_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "policy_id",
+						"flexibleengine_apig_throttling_policy.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "publish_ids.#", "1"),
+				),
+			}, {
+				Config: testAccThrottlingPolicyAssociate_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "instance_id",
+						"flexibleengine_apig_instance.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "policy_id",
+						"flexibleengine_apig_throttling_policy.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "publish_ids.#", "1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccThrottlingPolicyAssociate_base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_environment" "test" {
+  count = 2
+
+  name        = "%s_${count.index}"
+  instance_id = flexibleengine_apig_instance.test.id
+}
+
+resource "flexibleengine_apig_api_publishment" "test" {
+  count = 2
+
+  instance_id = flexibleengine_apig_instance.test.id
+  api_id      = flexibleengine_apig_api.test.id
+  env_id      = flexibleengine_apig_environment.test[count.index].id
+}
+
+resource "flexibleengine_apig_throttling_policy" "test" {
+  instance_id       = flexibleengine_apig_instance.test.id
+  name              = "%s"
+  type              = "API-based"
+  period            = 15000
+  period_unit       = "SECOND"
+  max_api_requests  = 100
+  max_user_requests = 60
+  max_app_requests  = 60
+  max_ip_requests   = 60
+  description       = "Created by script"
+}
+`, testAccApigAPI_basic(rName), rName, rName)
+}
+
+func testAccThrottlingPolicyAssociate_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_throttling_policy_associate" "test" {
+  instance_id = flexibleengine_apig_instance.test.id
+  policy_id   = flexibleengine_apig_throttling_policy.test.id
+
+  publish_ids = [
+    flexibleengine_apig_api_publishment.test[0].publish_id
+  ]
+}
+`, testAccThrottlingPolicyAssociate_base(rName))
+}
+
+func testAccThrottlingPolicyAssociate_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_throttling_policy_associate" "test" {
+  instance_id = flexibleengine_apig_instance.test.id
+  policy_id   = flexibleengine_apig_throttling_policy.test.id
+
+  publish_ids = [
+    flexibleengine_apig_api_publishment.test[1].publish_id
+  ]
+}
+`, testAccThrottlingPolicyAssociate_base(rName))
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_apig_throttling_policy_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_apig_throttling_policy_test.go
@@ -1,0 +1,278 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/throttles"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func TestAccApigThrottlingPolicyV2_basic(t *testing.T) {
+	var (
+		// The dedicated instance name only allow letters, digits and underscores (_).
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "flexibleengine_apig_throttling_policy.test"
+		policy       throttles.ThrottlingPolicy
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigThrottlingPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigThrottlingPolicy_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigThrottlingPolicyExists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by script"),
+					resource.TestCheckResourceAttr(resourceName, "type", "API-based"),
+					resource.TestCheckResourceAttr(resourceName, "period", "15000"),
+					resource.TestCheckResourceAttr(resourceName, "period_unit", "SECOND"),
+					resource.TestCheckResourceAttr(resourceName, "max_api_requests", "100"),
+					resource.TestCheckResourceAttr(resourceName, "max_user_requests", "60"),
+					resource.TestCheckResourceAttr(resourceName, "max_app_requests", "60"),
+					resource.TestCheckResourceAttr(resourceName, "max_ip_requests", "60"),
+				),
+			},
+			{
+				Config: testAccApigThrottlingPolicy_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigThrottlingPolicyExists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by script"),
+					resource.TestCheckResourceAttr(resourceName, "type", "API-shared"),
+					resource.TestCheckResourceAttr(resourceName, "period", "10"),
+					resource.TestCheckResourceAttr(resourceName, "period_unit", "MINUTE"),
+					resource.TestCheckResourceAttr(resourceName, "max_api_requests", "70"),
+					resource.TestCheckResourceAttr(resourceName, "max_user_requests", "45"),
+					resource.TestCheckResourceAttr(resourceName, "max_app_requests", "45"),
+					resource.TestCheckResourceAttr(resourceName, "max_ip_requests", "45"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccApigThrottlingPolicyV2_spec(t *testing.T) {
+	var (
+		// The dedicated instance name only allow letters, digits and underscores (_).
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "flexibleengine_apig_throttling_policy.test"
+		policy       throttles.ThrottlingPolicy
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigThrottlingPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigThrottlingPolicy_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigThrottlingPolicyExists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Created by script"),
+					resource.TestCheckResourceAttr(resourceName, "type", "API-based"),
+					resource.TestCheckResourceAttr(resourceName, "period", "15000"),
+					resource.TestCheckResourceAttr(resourceName, "period_unit", "SECOND"),
+					resource.TestCheckResourceAttr(resourceName, "max_api_requests", "100"),
+					resource.TestCheckResourceAttr(resourceName, "max_user_requests", "60"),
+					resource.TestCheckResourceAttr(resourceName, "max_app_requests", "60"),
+					resource.TestCheckResourceAttr(resourceName, "max_ip_requests", "60"),
+					resource.TestCheckResourceAttr(resourceName, "app_throttles.#", "0"),
+				),
+			},
+			{
+				Config: testAccApigThrottlingPolicy_spec(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigThrottlingPolicyExists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by script"),
+					resource.TestCheckResourceAttr(resourceName, "app_throttles.#", "1"),
+				),
+			},
+			{
+				Config: testAccApigThrottlingPolicy_specUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigThrottlingPolicyExists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "Updated by script"),
+					resource.TestCheckResourceAttr(resourceName, "app_throttles.#", "1"),
+				),
+			},
+			{
+				Config: testAccApigThrottlingPolicy_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigThrottlingPolicyExists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "app_throttles.#", "0"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckApigThrottlingPolicyDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.ApigV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating Flexibleengine APIG v2 client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_apig_throttling_policy" {
+			continue
+		}
+		_, err := throttles.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("APIG v2 throttling policy (%s) is still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckApigThrottlingPolicyExists(n string, app *throttles.ThrottlingPolicy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("resource %s not found", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no throttling policy id")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.ApigV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating Flexibleengine APIG v2 client: %s", err)
+		}
+		found, err := throttles.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+		*app = *found
+		return nil
+	}
+}
+
+func testAccApigThrottlingPolicy_base(rName, code string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_application" "test" {
+  name        = "%s"
+  instance_id = flexibleengine_apig_instance.test.id
+
+  app_codes = ["%s"]
+}
+`, testAccApigApplication_base(rName), rName, utils.EncodeBase64String(code))
+}
+
+func testAccApigThrottlingPolicy_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_throttling_policy" "test" {
+  instance_id       = flexibleengine_apig_instance.test.id
+  name              = "%s"
+  type              = "API-based"
+  period            = 15000
+  period_unit       = "SECOND"
+  max_api_requests  = 100
+  max_user_requests = 60
+  max_app_requests  = 60
+  max_ip_requests   = 60
+  description       = "Created by script"
+}
+`, testAccApigApplication_base(rName), rName)
+}
+
+func testAccApigThrottlingPolicy_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_throttling_policy" "test" {
+  instance_id       = flexibleengine_apig_instance.test.id
+  name              = "%s_update"
+  type              = "API-shared"
+  period            = 10
+  period_unit       = "MINUTE"
+  max_api_requests  = 70
+  max_user_requests = 45
+  max_app_requests  = 45
+  max_ip_requests   = 45
+  description       = "Updated by script"
+}
+`, testAccApigApplication_base(rName), rName)
+}
+
+func testAccApigThrottlingPolicy_spec(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_throttling_policy" "test" {
+  instance_id       = flexibleengine_apig_instance.test.id
+  name              = "%s"
+  type              = "API-based"
+  period            = 15000
+  period_unit       = "SECOND"
+  max_api_requests  = 100
+  max_user_requests = 60
+  max_app_requests  = 60
+  max_ip_requests   = 60
+  description       = "Updated by script"
+  
+  app_throttles {
+    max_api_requests     = 30
+    throttling_object_id = flexibleengine_apig_application.test.id
+  }
+}
+`, testAccApigThrottlingPolicy_base(rName, acctest.RandString(64)), rName)
+}
+
+func testAccApigThrottlingPolicy_specUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_throttling_policy" "test" {
+  instance_id       = flexibleengine_apig_instance.test.id
+  name              = "%s"
+  type              = "API-based"
+  period            = 15000
+  period_unit       = "SECOND"
+  max_api_requests  = 100
+  max_user_requests = 60
+  max_app_requests  = 60
+  max_ip_requests   = 60
+  description       = "Updated by script"
+
+  app_throttles {
+    max_api_requests     = 45
+    throttling_object_id = flexibleengine_apig_application.test.id
+  }
+}
+`, testAccApigThrottlingPolicy_base(rName, acctest.RandString(64)), rName)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_apig_vpc_channel_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_apig_vpc_channel_test.go
@@ -1,0 +1,334 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/apigw/dedicated/v2/channels"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccApigVpcChannelV2_basic(t *testing.T) {
+	var (
+		// The dedicated instance name only allow letters, digits and underscores (_).
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "flexibleengine_apig_vpc_channel.test"
+		channel      channels.VpcChannel
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigVpcChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigVpcChannel_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigVpcChannelExists(resourceName, &channel),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "member_type", "ECS"),
+					resource.TestCheckResourceAttr(resourceName, "algorithm", "WRR"),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "path", "/"),
+					resource.TestCheckResourceAttr(resourceName, "members.#", "1"),
+				),
+			},
+			{
+				Config: testAccApigVpcChannel_update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigVpcChannelExists(resourceName, &channel),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
+					resource.TestCheckResourceAttr(resourceName, "port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "member_type", "ECS"),
+					resource.TestCheckResourceAttr(resourceName, "algorithm", "WLC"),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "path", "/terraform/"),
+					resource.TestCheckResourceAttr(resourceName, "members.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
+			},
+		},
+	})
+}
+
+func TestAccApigVpcChannelV2_withEipMembers(t *testing.T) {
+	var (
+		// The dedicated instance name only allow letters, digits and underscores (_).
+		rName        = fmt.Sprintf("tf_acc_test_%s", acctest.RandString(5))
+		resourceName = "flexibleengine_apig_vpc_channel.test"
+		channel      channels.VpcChannel
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckApigVpcChannelDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApigVpcChannel_withEipMembers(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigVpcChannelExists(resourceName, &channel),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "port", "80"),
+					resource.TestCheckResourceAttr(resourceName, "member_type", "EIP"),
+					resource.TestCheckResourceAttr(resourceName, "algorithm", "WRR"),
+					resource.TestCheckResourceAttr(resourceName, "protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "path", "/"),
+					resource.TestCheckResourceAttr(resourceName, "members.#", "1"),
+				),
+			},
+			{
+				Config: testAccApigVpcChannel_withEipMembersUpdate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApigVpcChannelExists(resourceName, &channel),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "members.#", "2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccApigSubResNameImportStateFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccCheckApigVpcChannelDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.ApigV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating Flexibleengine APIG v2 client: %s", err)
+	}
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_apig_vpc_channel" {
+			continue
+		}
+		_, err := channels.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("APIG v2 Vpc Channel (%s) is still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}
+
+func testAccCheckApigVpcChannelExists(n string, app *channels.VpcChannel) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("resource %s not found", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no vpc channel id")
+		}
+
+		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		client, err := config.ApigV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating Flexibleengine APIG v2 client: %s", err)
+		}
+		found, err := channels.Get(client, rs.Primary.Attributes["instance_id"], rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+		*app = *found
+		return nil
+	}
+}
+
+func testAccApigSubResNameImportStateFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("Resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.ID == "" || rs.Primary.Attributes["instance_id"] == "" {
+			return "", fmt.Errorf("resource not found: %s/%s", rs.Primary.Attributes["instance_id"],
+				rs.Primary.Attributes["name"])
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.Attributes["name"]), nil
+	}
+}
+
+func testAccApigVpcChannel_base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_images_image_v2" "test" {
+  name        = "OBS Ubuntu 18.04"
+  most_recent = true
+}
+
+data "flexibleengine_compute_flavors_v2" "test" {
+  performance_type = "normal"
+  cpu_core         = 2
+  memory_size      = 4
+}
+
+resource "flexibleengine_compute_instance_v2" "test" {
+  name               = "%s"
+  image_id           = data.flexibleengine_images_image_v2.test.id
+  flavor_id          = data.flexibleengine_compute_flavors_v2.test.flavors[0]
+  security_groups    = [flexibleengine_networking_secgroup_v2.test.name]
+  availability_zone  = data.flexibleengine_availability_zones.test.names[0]
+
+  network {
+    uuid = flexibleengine_vpc_subnet_v1.test.id
+  }
+}
+`, testAccApigApplication_base(rName), rName)
+}
+
+func testAccApigVpcChannel_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_apig_vpc_channel" "test" {
+  name        = "%s"
+  instance_id = flexibleengine_apig_instance.test.id
+  port        = 80
+  algorithm   = "WRR"
+  protocol    = "HTTP"
+  path        = "/"
+  http_code   = "201"
+
+  members {
+    id = flexibleengine_compute_instance_v2.test.id
+  }
+}
+`, testAccApigVpcChannel_base(rName), rName)
+}
+
+func testAccApigVpcChannel_update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_compute_instance_v2" "newone" {
+  name               = "%s"
+  image_id           = data.flexibleengine_images_image_v2.test.id
+  flavor_id          = data.flexibleengine_compute_flavors_v2.test.flavors[0]
+  security_groups    = [flexibleengine_networking_secgroup_v2.test.name]
+  availability_zone  = data.flexibleengine_availability_zones.test.names[0]
+
+  network {
+    uuid = flexibleengine_vpc_subnet_v1.test.id
+  }
+}
+
+resource "flexibleengine_apig_vpc_channel" "test" {
+  name        = "%s_update"
+  instance_id = flexibleengine_apig_instance.test.id
+  port        = 8080
+  algorithm   = "WLC"
+  protocol    = "HTTPS"
+  path        = "/terraform/"
+  http_code   = "201,202,203"
+
+  members {
+    id     = flexibleengine_compute_instance_v2.test.id
+    weight = 30
+  }
+  members {
+    id     = flexibleengine_compute_instance_v2.newone.id
+    weight = 70
+  }
+}
+`, testAccApigVpcChannel_base(rName), rName, rName)
+}
+
+func testAccApigVpcChannel_eipBase(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    name        = "%s"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+`, rName)
+}
+
+func testAccApigVpcChannel_withEipMembers(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "flexibleengine_apig_vpc_channel" "test" {
+  name        = "%s"
+  instance_id = flexibleengine_apig_instance.test.id
+  port        = 80
+  member_type = "EIP"
+  algorithm   = "WRR"
+  protocol    = "HTTP"
+  path        = "/"
+  http_code   = "201"
+
+  members {
+    ip_address = flexibleengine_vpc_eip.test.address
+  }
+}
+`, testAccApigApplication_base(rName), testAccApigVpcChannel_eipBase(rName), rName)
+}
+
+func testAccApigVpcChannel_withEipMembersUpdate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+%s
+
+resource "flexibleengine_vpc_eip" "newone" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    name        = "%s_newone"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "flexibleengine_apig_vpc_channel" "test" {
+  name        = "%s"
+  instance_id = flexibleengine_apig_instance.test.id
+  port        = 80
+  member_type = "EIP"
+  algorithm   = "WRR"
+  protocol    = "HTTP"
+  path        = "/"
+  http_code   = "201"
+
+  members {
+    ip_address = flexibleengine_vpc_eip.test.address
+    weight     = 30
+  }
+  members {
+    ip_address = flexibleengine_vpc_eip.newone.address
+    weight     = 70
+  }
+}
+`, testAccApigApplication_base(rName), testAccApigVpcChannel_eipBase(rName), rName, rName)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -13,6 +13,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cce"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cse"
@@ -262,6 +263,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_elb_flavors":               dataSourceElbFlavorsV3(),
 
 			// importing data source
+			"flexibleengine_apig_environments":  apig.DataSourceEnvironments(),
 			"flexibleengine_enterprise_project": eps.DataSourceEnterpriseProject(),
 			"flexibleengine_cbr_vaults":         cbr.DataSourceCbrVaultsV3(),
 			"flexibleengine_elb_certificate":    elb.DataSourceELBCertificateV3(),
@@ -411,6 +413,18 @@ func Provider() *schema.Provider {
 			"flexibleengine_dli_queue":                          ResourceDliQueueV1(),
 
 			// importing resource
+			"flexibleengine_apig_api":                         apig.ResourceApigAPIV2(),
+			"flexibleengine_apig_api_publishment":             apig.ResourceApigApiPublishment(),
+			"flexibleengine_apig_instance":                    apig.ResourceApigInstanceV2(),
+			"flexibleengine_apig_application":                 apig.ResourceApigApplicationV2(),
+			"flexibleengine_apig_custom_authorizer":           apig.ResourceApigCustomAuthorizerV2(),
+			"flexibleengine_apig_environment":                 apig.ResourceApigEnvironmentV2(),
+			"flexibleengine_apig_group":                       apig.ResourceApigGroupV2(),
+			"flexibleengine_apig_response":                    apig.ResourceApigResponseV2(),
+			"flexibleengine_apig_throttling_policy_associate": apig.ResourceThrottlingPolicyAssociate(),
+			"flexibleengine_apig_throttling_policy":           apig.ResourceApigThrottlingPolicyV2(),
+			"flexibleengine_apig_vpc_channel":                 apig.ResourceApigVpcChannelV2(),
+
 			"flexibleengine_api_gateway_api":   huaweicloud.ResourceAPIGatewayAPI(),
 			"flexibleengine_api_gateway_group": huaweicloud.ResourceAPIGatewayGroup(),
 


### PR DESCRIPTION
**add new data_source**:
flexibleengine_apig_environments

**add new resources**:
flexibleengine_apig_api_publishment
flexibleengine_apig_api
flexibleengine_apig_application
flexibleengine_apig_custom_authorizer
flexibleengine_apig_environment
flexibleengine_apig_group
flexibleengine_apig_instance
flexibleengine_apig_response
flexibleengine_apig_throttling_policy_associate
flexibleengine_apig_throttling_policy
flexibleengine_apig_vpc_channel

**Test results**:
```
make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccDataEnvironments_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccDataEnvironments_basic -timeout 720m
=== RUN   TestAccDataEnvironments_basic
=== PAUSE TestAccDataEnvironments_basic
=== CONT  TestAccDataEnvironments_basic
--- PASS: TestAccDataEnvironments_basic (607.96s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      608.087s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccApigApiPublishmentV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccApigApiPublishmentV2_basic -timeout 720m
=== RUN   TestAccApigApiPublishmentV2_basic
=== PAUSE TestAccApigApiPublishmentV2_basic
=== CONT  TestAccApigApiPublishmentV2_basic
--- PASS: TestAccApigApiPublishmentV2_basic (443.46s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      443.664s 

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccApigAPIV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccApigAPIV2_basic -timeout 720m
=== RUN   TestAccApigAPIV2_basic
=== PAUSE TestAccApigAPIV2_basic
=== CONT  TestAccApigAPIV2_basic
--- PASS: TestAccApigAPIV2_basic (469.56s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      469.682s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccApigApplicationV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccApigApplicationV2_basic -timeout 720m
=== RUN   TestAccApigApplicationV2_basic
=== PAUSE TestAccApigApplicationV2_basic
=== CONT  TestAccApigApplicationV2_basic
--- PASS: TestAccApigApplicationV2_basic (444.60s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      444.725s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccApigCustomAuthorizerV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccApigCustomAuthorizerV2_basic -timeout 720m
=== RUN   TestAccApigCustomAuthorizerV2_basic
=== PAUSE TestAccApigCustomAuthorizerV2_basic
=== CONT  TestAccApigCustomAuthorizerV2_basic
--- PASS: TestAccApigCustomAuthorizerV2_basic (461.24s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      461.352s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccApigEnvironmentV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccApigEnvironmentV2_basic -timeout 720m
=== RUN   TestAccApigEnvironmentV2_basic
=== PAUSE TestAccApigEnvironmentV2_basic
=== CONT  TestAccApigEnvironmentV2_basic
--- PASS: TestAccApigEnvironmentV2_basic (602.20s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      602.359s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccApigGroupV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccApigGroupV2_basic -timeout 720m
=== RUN   TestAccApigGroupV2_basic
=== PAUSE TestAccApigGroupV2_basic
=== CONT  TestAccApigGroupV2_basic
--- PASS: TestAccApigGroupV2_basic (805.59s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      805.788s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccApigInstanceV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccApigInstanceV2_basic -timeout 720m
=== RUN   TestAccApigInstanceV2_basic
=== PAUSE TestAccApigInstanceV2_basic
=== CONT  TestAccApigInstanceV2_basic
--- PASS: TestAccApigInstanceV2_basic (471.22s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      471.380s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccThrottlingPolicyAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccThrottlingPolicyAssociate_basic -timeout 720m
=== RUN   TestAccThrottlingPolicyAssociate_basic
=== PAUSE TestAccThrottlingPolicyAssociate_basic
=== CONT  TestAccThrottlingPolicyAssociate_basic
--- PASS: TestAccThrottlingPolicyAssociate_basic (658.16s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      658.321s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccApigThrottlingPolicyV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccApigThrottlingPolicyV2_basic -timeout 720m
=== RUN   TestAccApigThrottlingPolicyV2_basic
=== PAUSE TestAccApigThrottlingPolicyV2_basic
=== CONT  TestAccApigThrottlingPolicyV2_basic
--- PASS: TestAccApigThrottlingPolicyV2_basic (611.12s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      611.443s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccApigVpcChannelV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccApigVpcChannelV2_basic -timeout 720m
=== RUN   TestAccApigVpcChannelV2_basic
=== PAUSE TestAccApigVpcChannelV2_basic
=== CONT  TestAccApigVpcChannelV2_basic
--- PASS: TestAccApigVpcChannelV2_basic (689.32s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      689.428s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccApigResponseV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccApigResponseV2_basic -timeout 720m
=== RUN   TestAccApigResponseV2_basic
=== PAUSE TestAccApigResponseV2_basic
=== CONT  TestAccApigResponseV2_basic
    resource_flexibleengine_apig_response_test.go:23: Step 1/3 error: Error running apply: exit status 1
        
        Error: Error creating FlexibleEngine APIG group: Action forbidden: [POST https://apig.eu-west-0.prod-cloud-ocb.orange-business.com/v2/16812e5f4aef455c8eb0161c1e6a56c2/apigw/instances/5a1c2121c0aa4ec3a6594ab0c4d9f685/api-groups/3ed9fd72b2774f68b25d16173fb574d6/gateway-responses], error message: Request not authorized
        
          with flexibleengine_apig_response.test,
          on terraform_plugin_test.tf line 45, in resource "flexibleengine_apig_response" "test":
          45: resource "flexibleengine_apig_response" "test" {
        
--- FAIL: TestAccApigResponseV2_basic (421.14s)
FAIL
FAIL    github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      421.244s
FAIL
GNUmakefile:17: recipe for target 'testacc' failed
make: *** [testacc] Error 1

due to service problem, creating api response failed
```