### PR TITLE
feat(dcs): support more filters in data source

### DIFF
--- a/docs/data-sources/dcs_product_v1.md
+++ b/docs/data-sources/dcs_product_v1.md
@@ -4,17 +4,56 @@ subcategory: "Distributed Cache Service (DCS)"
 
 # flexibleengine_dcs_product_v1
 
-Use this data source to get the ID of an available Flexibleengine dcs product.
+Use this data source to get the ID of an available Flexibleengine DCS product.
 
 ## Example Usage
 
 ```hcl
+# product of Redis 4.0/5.0 with Redis Cluster type
 data "flexibleengine_dcs_product_v1" "product1" {
-  engine = "redis"
+  engine         = "redis"
+  engine_version = "4.0;5.0"
+  cache_mode     = "cluster"
+  capacity       = 8
+  replica_count  = 2
 }
 
+# product of Redis 4.0/5.0 with Master/Standby type
 data "flexibleengine_dcs_product_v1" "product2" {
-  spec_code = "redis.cluster.xu1.large.r1.8"
+  engine         = "redis"
+  engine_version = "4.0;5.0"
+  cache_mode     = "ha"
+  capacity       = 0.125
+  replica_count  = 2
+}
+
+# product of Redis 4.0/5.0 with Single-node type
+data "flexibleengine_dcs_product_v1" "product3" {
+  engine         = "redis"
+  engine_version = "4.0;5.0"
+  cache_mode     = "single"
+  capacity       = 1
+}
+
+# product of Redis 4.0/5.0 with Proxy Cluster type
+data "flexibleengine_dcs_product_v1" "product4" {
+  engine         = "redis"
+  engine_version = "4.0;5.0"
+  cache_mode     = "proxy"
+  capacity       = 4
+}
+
+# product of Redis 3.0 instance
+data "flexibleengine_dcs_product_v1" "product5" {
+  engine         = "redis"
+  engine_version = "3.0"
+  cache_mode     = "ha"
+}
+
+# product of Memcached instance
+data "flexibleengine_dcs_product_v1" "product6" {
+  engine     = "memcached"
+  cache_mode = "single"
 }
 ```
 
@@ -26,22 +65,28 @@ data "flexibleengine_dcs_product_v1" "product2" {
 * `engine_version` - (Optional, String) The version of a cache engine.
   It is valid when the engine is *redis*, the value can be `3.0`or `4.0;5.0`.
 
-* `spec_code` - (Optional, String) Specifies the DCS instance specification code. You can log in to the DCS console,
-  click *Buy DCS Instance*, and find the corresponding instance specification.
-
 * `cache_mode` - (Optional, String) The mode of a cache engine. The valid values are as follows:
   + `single` - Single-node.
   + `ha` - Master/Standby.
-  + `cluster` - Redis Cluster.
-  + `proxy` - Proxy Cluster.
+  + `cluster` - Redis Cluster, it is valid when the engine is *redis*.
+  + `proxy` - Proxy Cluster, it is valid when the engine is *redis*.
 
+* `capacity` - (Optional, Float) The total memory of the cache, in GB.
+  It is valid when the engine is redis 4.0/5.0.
+  + Single-node and Master/Standby instances support:
+    `0.125`, `0.25`, `0.5`, `1`, `2`, `4`, `8`, `16`, `24`, `32`, `48` and `64`.
+  + Redis Cluster and Proxy Cluster instances support:
+    `4`, `8`, `16`, `24`, `32`, `48`, `64`, `96`, `128`, `192`, `256`, `384`, `512`, `768` and `1024`.
+
+* `replica_count` - (Optional, Int) The number of replicas includes the master.
+  It is valid when the engine is redis 4.0/5.0 with **Master/Standby** or **Redis Cluster** type.
+
+* `spec_code` - (Optional, String) Specifies the DCS instance specification code. You can log in to the DCS console,
+  click *Buy DCS Instance*, and find the corresponding instance specification.
 
 ## Attributes Reference
 
-`id` is set to the ID of the found product. In addition, the following attributes
-are exported:
+In addition to all arguments above, the following attributes are exported:
 
-* `engine` - See Argument Reference above.
-* `engine_version` - See Argument Reference above.
-* `spec_code` - See Argument Reference above.
-* `cache_mode` - See Argument Reference above.
+* `id` - The found product ID.
+* `cpu_architecture` - The CPU architecture of DCS instance.

--- a/flexibleengine/data_source_flexibleengine_dcs_product_v1.go
+++ b/flexibleengine/data_source_flexibleengine_dcs_product_v1.go
@@ -3,33 +3,35 @@ package flexibleengine
 import (
 	"fmt"
 	"log"
+	"strconv"
 
-	"github.com/chnsz/golangsdk/openstack/dcs/v1/products"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk/openstack/dcs/v2/flavors"
 	hw_utils "github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
 func dataSourceDcsProductV1() *schema.Resource {
 	return &schema.Resource{
-		Read: dataSourceDcsProductV1Read,
+		Read: dataSourceDcsProductRead,
 
 		Schema: map[string]*schema.Schema{
-			"spec_code": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
 			"engine": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "redis",
 				ValidateFunc: validation.StringInSlice([]string{
 					"redis", "memcached",
-				}, false),
+				}, true),
 			},
 			"engine_version": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"3.0", "4.0;5.0",
+				}, false),
 				Computed: true,
 			},
 			"cache_mode": {
@@ -37,45 +39,96 @@ func dataSourceDcsProductV1() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"capacity": {
+				Type:     schema.TypeFloat,
+				Optional: true,
+				Computed: true,
+			},
+			"replica_count": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"spec_code": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"cpu_architecture": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
 
-func dataSourceDcsProductV1Read(d *schema.ResourceData, meta interface{}) error {
+func dataSourceDcsProductRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	dcsV1Client, err := config.DcsV1Client(GetRegion(d, config))
+	dcsV2Client, err := config.DcsV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error get dcs product client: %s", err)
+		return fmt.Errorf("Error get DCS v2 client: %s", err)
 	}
 
-	v, err := products.Get(dcsV1Client).Extract()
+	var capacity string
+	if v, ok := d.GetOk("capacity"); ok {
+		capacity = strconv.FormatFloat(v.(float64), 'f', -1, 64)
+	}
+
+	// build a list options
+	opts := flavors.ListOpts{
+		CacheMode:     d.Get("cache_mode").(string),
+		Engine:        d.Get("engine").(string),
+		EngineVersion: d.Get("engine_version").(string),
+		Capacity:      capacity,
+		SpecCode:      d.Get("spec_code").(string),
+	}
+	log.Printf("[DEBUG] The options of list DCS flavors: %#v", opts)
+
+	list, err := flavors.List(dcsV2Client, opts).Extract()
 	if err != nil {
-		return err
+		return fmt.Errorf("Error while filtering data: %s", err)
 	}
-	log.Printf("[DEBUG] get %d DCS products", len(v.Products))
-
-	filteredPds, err := hw_utils.FilterSliceWithField(v.Products, map[string]interface{}{
-		"SpecCode":      d.Get("spec_code").(string),
-		"Engine":        d.Get("engine").(string),
-		"EngineVersion": d.Get("engine_version").(string),
-		"CacheMode":     d.Get("cache_mode").(string),
-	})
-	if err != nil {
-		return fmt.Errorf("Error while filtering data : %s", err)
+	if len(list) < 1 {
+		return fmt.Errorf("Your query returned no results. " +
+			"Please change your search criteria and try again.")
 	}
 
-	if len(filteredPds) < 1 {
-		return fmt.Errorf("Your query returned no results. Please change your filters and try again")
+	var pd flavors.Flavor
+	if v, ok := d.GetOk("replica_count"); ok {
+		filteredPds, err := hw_utils.FilterSliceWithField(list, map[string]interface{}{
+			"ReplicaCount": v.(int),
+		})
+		if err != nil {
+			return fmt.Errorf("Error while filtering data: %s", err)
+		}
+
+		if len(filteredPds) < 1 {
+			return fmt.Errorf("Your query returned no results with replica_count=%d. "+
+				"Please change your search criteria and try again.", v)
+		}
+		pd = filteredPds[0].(flavors.Flavor)
+	} else {
+		pd = list[0]
 	}
 
-	pd := filteredPds[0].(products.Product)
-	log.Printf("[DEBUG] DCS product : %+v", pd)
+	log.Printf("[DEBUG] querying DCS product: %+v", pd)
+	productID := pd.SpecCode + "-h"
+	d.SetId(productID)
 
-	d.SetId(pd.ProductID)
-	d.Set("spec_code", pd.SpecCode)
-	d.Set("engine", pd.Engine)
-	d.Set("engine_version", pd.EngineVersion)
-	d.Set("cache_mode", pd.CacheMode)
+	cap, _ := strconv.ParseFloat(pd.Capacity[0], 64)
+	mErr := multierror.Append(nil,
+		d.Set("capacity", cap),
+		d.Set("spec_code", pd.SpecCode),
+		d.Set("engine", pd.Engine),
+		d.Set("engine_version", pd.EngineVersion),
+		d.Set("cache_mode", pd.CacheMode),
+		d.Set("replica_count", pd.ReplicaCount),
+		d.Set("cpu_architecture", pd.CPUType),
+	)
+
+	if mErr.ErrorOrNil() != nil {
+		return fmt.Errorf("error setting DCS product attributes: %s", mErr)
+	}
 
 	return nil
 }

--- a/flexibleengine/data_source_flexibleengine_dcs_product_v1_test.go
+++ b/flexibleengine/data_source_flexibleengine_dcs_product_v1_test.go
@@ -8,29 +8,36 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccDcsProductV1DataSource_basic(t *testing.T) {
-	dataSourceName := "data.flexibleengine_dcs_product_v1.product1"
+func TestAccDcsProductDataSource_basic(t *testing.T) {
+	dataSourceName := "data.flexibleengine_dcs_product_v1.product_spec"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDcsProductV1DataSource_basic,
+				Config: testAccDcsProductDataSource_multi,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDcsProductV1DataSourceID(dataSourceName),
+					testAccCheckDcsProductDataSourceID(dataSourceName),
 					resource.TestCheckResourceAttr(dataSourceName, "spec_code", "dcs.single_node"),
+					resource.TestCheckResourceAttr(dataSourceName, "engine", "redis"),
+					resource.TestCheckResourceAttrSet("data.flexibleengine_dcs_product_v1.product1", "spec_code"),
+					resource.TestCheckResourceAttrSet("data.flexibleengine_dcs_product_v1.product2", "spec_code"),
+					resource.TestCheckResourceAttrSet("data.flexibleengine_dcs_product_v1.product3", "spec_code"),
+					resource.TestCheckResourceAttrSet("data.flexibleengine_dcs_product_v1.product4", "spec_code"),
+					resource.TestCheckResourceAttrSet("data.flexibleengine_dcs_product_v1.product5", "spec_code"),
+					resource.TestCheckResourceAttrSet("data.flexibleengine_dcs_product_v1.product6", "spec_code"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckDcsProductV1DataSourceID(n string) resource.TestCheckFunc {
+func testAccCheckDcsProductDataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Can't find Dcs product data source: %s", n)
+			return fmt.Errorf("Can't find DCS product data source: %s", n)
 		}
 
 		if rs.Primary.ID == "" {
@@ -41,8 +48,56 @@ func testAccCheckDcsProductV1DataSourceID(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccDcsProductV1DataSource_basic = fmt.Sprintf(`
+var testAccDcsProductDataSource_multi = fmt.Sprintf(`
+# product of Redis 4.0/5.0 with Redis Cluster type
 data "flexibleengine_dcs_product_v1" "product1" {
+  engine         = "redis"
+  engine_version = "4.0;5.0"
+  cache_mode     = "cluster"
+  capacity       = 8
+  replica_count  = 2
+}
+
+# product of Redis 4.0/5.0 with Master/Standby type
+data "flexibleengine_dcs_product_v1" "product2" {
+  engine         = "redis"
+  engine_version = "4.0;5.0"
+  cache_mode     = "ha"
+  capacity       = 0.125
+  replica_count  = 2
+}
+
+# product of Redis 4.0/5.0 with Single-node type
+data "flexibleengine_dcs_product_v1" "product3" {
+  engine         = "redis"
+  engine_version = "4.0;5.0"
+  cache_mode     = "single"
+  capacity       = 1
+}
+
+# product of Redis 4.0/5.0 with Proxy Cluster type
+data "flexibleengine_dcs_product_v1" "product4" {
+  engine         = "redis"
+  engine_version = "4.0;5.0"
+  cache_mode     = "proxy"
+  capacity       = 4
+}
+
+# product of Redis 3.0 instance
+data "flexibleengine_dcs_product_v1" "product5" {
+  engine         = "redis"
+  engine_version = "3.0"
+  cache_mode     = "ha"
+}
+
+# product of Memcached instance
+data "flexibleengine_dcs_product_v1" "product6" {
+  engine     = "memcached"
+  cache_mode = "single"
+}
+
+# product with spec_code
+data "flexibleengine_dcs_product_v1" "product_spec" {
   spec_code = "dcs.single_node"
 }
 `)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.25.3
-	github.com/chnsz/golangsdk v0.0.0-20221010082948-5094d5b1b788
+	github.com/chnsz/golangsdk v0.0.0-20221025063414-ec58687a8de7
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXH
 github.com/chnsz/golangsdk v0.0.0-20220927110738-5a265800849c/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chnsz/golangsdk v0.0.0-20221010082948-5094d5b1b788 h1:wwJOM3bQ3fVRCrSexYwijEkEVNJMmPXdyn2mT7hTjXo=
 github.com/chnsz/golangsdk v0.0.0-20221010082948-5094d5b1b788/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20221025063414-ec58687a8de7 h1:J5cx68P0UIrLiD6uiisvtZV1ZMJbaCYTX0CwHSGaCyM=
+github.com/chnsz/golangsdk v0.0.0-20221025063414-ec58687a8de7/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=


### PR DESCRIPTION
related to #814 

the acceptance testing as follows:

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run=TestAccDcsInstancesV1'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run=TestAccDcsInstancesV1 -timeout 720m
=== RUN   TestAccDcsInstancesV1_basic
=== PAUSE TestAccDcsInstancesV1_basic
=== RUN   TestAccDcsInstancesV1_redisV5
=== PAUSE TestAccDcsInstancesV1_redisV5
=== RUN   TestAccDcsInstancesV1_memcached
=== PAUSE TestAccDcsInstancesV1_memcached
=== CONT  TestAccDcsInstancesV1_basic
=== CONT  TestAccDcsInstancesV1_memcached
=== CONT  TestAccDcsInstancesV1_redisV5
--- PASS: TestAccDcsInstancesV1_basic (483.43s)
--- PASS: TestAccDcsInstancesV1_memcached (484.24s)
--- PASS: TestAccDcsInstancesV1_redisV5 (506.36s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 506.404s

$ make testacc TEST='./flexibleengine' TESTARGS='-run=TestAccDcsProductDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run=TestAccDcsProductDataSource_basic -timeout 720m
=== RUN   TestAccDcsProductDataSource_basic
--- PASS: TestAccDcsProductDataSource_basic (20.10s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 20.174s
```