### PR TITLE
feat(dds): add dds database role and user

### DIFF
--- a/docs/resources/dds_database_role.md
+++ b/docs/resources/dds_database_role.md
@@ -1,0 +1,106 @@
+---
+subcategory: "Document Database Service (DDS)"
+---
+
+# flexibleengine_dds_database_role
+
+Manages a database role resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "role_name" {}
+variable "db_name" {}
+variable "owned_role_name" {}
+variable "owned_role_db_name" {}
+
+resource "flexibleengine_dds_database_role" "test" {
+  instance_id = var.instance_id
+
+  name    = var.role_name
+  db_name = var.db_name
+
+  roles {
+    name    = var.owned_role_name
+    db_name = var.owned_role_db_name
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the DDS instance is located.
+  Changing this parameter will create a new role.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the DDS instance ID to which the role belongs.
+  Changing this parameter will create a new role.
+
+* `name` - (Required, String, ForceNew) Specifies the role name.
+  The name can contain `1` to `64` characters, only letters, digits, underscores (_), hyphens (-) and dots (.) are
+  allowed. Changing this parameter will create a new role.
+
+* `db_name` - (Required, String, ForceNew) Specifies the database name to which the role belongs.
+  The name can contain `1` to `64` characters, only letters, digits and underscores (_) are allowed.
+  Changing this parameter will create a new role.
+
+  -> After a DDS instances is created, the default database is **admin**.
+
+* `roles` - (Optional, List, ForceNew) Specifies the list of roles owned by the current role.
+  The [object](#dds_database_owned_roles) structure is documented below.
+  Changing this parameter will create a new role.
+
+<a name="dds_database_owned_roles"></a>
+The `roles` block supports:
+
+* `name` - (Required, String, ForceNew) Specifies the name of role owned by the current role.
+  The name can contain `1` to `64` characters, only letters, digits, underscores (_), hyphens (-) and dots (.) are
+  allowed. Changing this parameter will create a new role.
+
+* `db_name` - (Required, String, ForceNew) Specifies the database name to which this owned role belongs.
+  Changing this parameter will create a new role.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `privileges` - The list of database privileges owned by the current role.
+  The [object](#dds_database_privileges) structure is documented below.
+
+* `inherited_privileges` - The list of database privileges owned by the current role, includes all privileges
+  inherited by owned roles. The [object](#dds_database_privileges) structure is documented below.
+
+<a name="dds_database_privileges"></a>
+The `privileges` and `inherited_privileges` block supports:
+
+* `resources` - The details of the resource to which the privilege belongs.
+  The [object](#dds_database_resources) structure is documented below.
+
+* `actions` - The operation permission list.
+
+<a name="dds_database_resources"></a>
+The `resources` block supports:
+
+* `collection` - The database collection type.
+
+* `db_name` - The database name.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 2 minute.
+* `delete` - Default is 2 minute.
+
+## Import
+
+Database roles can be imported using their `id` (combination of `instance_id`, `db_name` and `name`), separated by a
+slash (/), e.g.
+
+```
+terraform import flexibleengine_dds_database_role.test &ltinstance_id&gt/&ltdb_name&gt/&ltname&gt
+```

--- a/docs/resources/dds_database_user.md
+++ b/docs/resources/dds_database_user.md
@@ -1,0 +1,130 @@
+---
+subcategory: "Document Database Service (DDS)"
+---
+
+# flexibleengine_dds_database_user
+
+Manages a database user resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "user_name" {}
+variable "user_password" {}
+variable "owned_role_name" {}
+variable "owned_role_db_name" {}
+
+resource "flexibleengine_dds_database_user" "test" {
+  instance_id = var.instance_id
+
+  name     = var.user_name
+  password = var.user_password
+  db_name  = var.db_name
+
+  roles {
+    name    = var.owned_role_name
+    db_name = var.owned_role_db_name
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the DDS instance is located.
+  Changing this parameter will create a new user.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the DDS instance ID to which the user belongs.
+  Changing this parameter will create a new user.
+
+* `name` - (Required, String, ForceNew) Specifies the user name.
+  The name can contain `1` to `64` characters, only letters, digits, underscores (_), hyphens (-) and dots (.) are
+  allowed. And cannot use reserved names: **drsFull** or **drsIncremental**.
+  Changing this parameter will create a new user.
+
+* `password` - (Required, String) Specifies the user password.
+  The assword content must meet the following conditions:
+  + `8` to `32` characters long.
+  + Must contains uppercase and lowercase letters, digits, and at least one special character (`~!@#%^*-_=+?`).
+
+* `db_name` - (Required, String, ForceNew) Specifies the database name to which the user belongs.
+  The name can contain `1` to `64` characters, only letters, digits and underscores (_) are allowed.
+  Changing this parameter will create a new user.
+
+  -> After a DDS instances is created, the default database is **admin**.
+
+* `roles` - (Required, List, ForceNew) Specifies the list of roles owned by the current user.
+  The [object](#dds_database_owned_roles) structure is documented below. Changing this parameter will create a new user.
+
+<a name="dds_database_owned_roles"></a>
+The `roles` block supports:
+
+* `name` - (Required, String, ForceNew) Specifies the name of role owned by the current user.
+  The name can contain `1` to `64` characters, only letters, digits, underscores (_), hyphens (-) and dots (.) are
+  allowed. Changing this parameter will create a new user.
+
+* `db_name` - (Required, String, ForceNew) Specifies the database name to which this owned role belongs.
+  Changing this parameter will create a new user.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `privileges` - The list of database privileges owned by the current user.
+  The [object](#dds_database_privileges) structure is documented below.
+
+* `inherited_privileges` - The list of database privileges owned by the current user, includes all privileges
+  inherited by owned roles. The [object](#dds_database_privileges) structure is documented below.
+
+<a name="dds_database_privileges"></a>
+The `privileges` and `inherited_privileges` block supports:
+
+* `resources` - The details of the resource to which the privilege belongs.
+  The [object](#dds_database_resources) structure is documented below.
+
+* `actions` - The operation permission list.
+
+<a name="dds_database_resources"></a>
+The `resources` block supports:
+
+* `collection` - The database collection type.
+
+* `db_name` - The database name.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 2 minute.
+* `update` - Default is 2 minute.
+* `delete` - Default is 2 minute.
+
+## Import
+
+Database users can be imported using their `id` (combination of `instance_id`, `db_name` and `name`), separated by a
+slash (/), e.g.
+
+```
+terraform import flexibleengine_dds_database_user.test &ltinstance_id&gt/&ltdb_name&gt/&ltname&gt
+```
+
+Due to security reason, the imported state may not be identical to your resource definition (`password` parameter).
+It is generally recommended running `terraform plan` after importing a user resource.
+You can then decide if changes should be applied to the user, or the resource definition should be updated to align with
+the user. Also you can ignore changes as below.
+
+```
+resource "flexibleengine_dds_database_user" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      password,
+    ]
+  }
+}
+```

--- a/flexibleengine/acceptance/resource_flexibleengine_dds_database_role_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_dds_database_role_test.go
@@ -1,0 +1,190 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/dds/v3/roles"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getDatabaseRoleFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.DdsV3Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DDS v3 client: %s ", err)
+	}
+
+	instanceId := state.Primary.Attributes["instance_id"]
+	name := state.Primary.Attributes["name"]
+	opts := roles.ListOpts{
+		Name:   state.Primary.Attributes["name"],
+		DbName: state.Primary.Attributes["db_name"],
+	}
+	resp, err := roles.List(client, instanceId, opts)
+	if err != nil {
+		return nil, fmt.Errorf("error getting role (%s) from DDS instance (%s): %v", name, instanceId, err)
+	}
+	if len(resp) < 1 {
+		return nil, fmt.Errorf("unable to find role (%s) from DDS instance (%s)", name, instanceId)
+	}
+	role := resp[0]
+	return &role, nil
+}
+
+func TestAccDatabaseRole_basic(t *testing.T) {
+	var role roles.Role
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_dds_database_role.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&role,
+		getDatabaseRoleFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseRole_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "roles.0.name",
+						"flexibleengine_dds_database_role.base", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "inherited_privileges",
+						"flexibleengine_dds_database_role.base", "inherited_privileges"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccDatabaseRoleImportStateIdFunc(),
+			},
+		},
+	})
+}
+
+func testAccDatabaseRoleImportStateIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var instanceId, dbName, name string
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "flexibleengine_dds_database_role" {
+				instanceId = rs.Primary.Attributes["instance_id"]
+				dbName = rs.Primary.Attributes["db_name"]
+				name = rs.Primary.Attributes["name"]
+			}
+		}
+		if instanceId == "" || dbName == "" || name == "" {
+			return "", fmt.Errorf("resource not found: %s/%s/%s", instanceId, dbName, name)
+		}
+		return fmt.Sprintf("%s/%s/%s", instanceId, dbName, name), nil
+	}
+}
+
+func testAccDatabaseRole_base(rName string) string {
+	randCidr := acceptance.RandomCidr()
+
+	return fmt.Sprintf(`
+data "flexibleengine_availability_zones" "test" {}
+
+resource "flexibleengine_vpc_v1" "test" {
+  name = "%[1]s"
+  cidr = "%[2]s"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test" {
+  vpc_id = flexibleengine_vpc_v1.test.id
+
+  name       = "%[1]s"
+  cidr       = cidrsubnet(flexibleengine_vpc_v1.test.cidr, 4, 1)
+  gateway_ip = cidrhost(cidrsubnet(flexibleengine_vpc_v1.test.cidr, 4, 1), 1)
+
+  timeouts {
+    delete = "20m"
+  }
+}
+
+resource "flexibleengine_networking_secgroup_v2" "test" {
+  name = "%[1]s"
+}
+
+resource "flexibleengine_dds_instance_v3" "test" {
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+  vpc_id            = flexibleengine_vpc_v1.test.id
+  subnet_id         = flexibleengine_vpc_subnet_v1.test.id
+  security_group_id = flexibleengine_networking_secgroup_v2.test.id
+
+  name     = "%[1]s"
+  mode     = "Sharding"
+  password = "Test@12345678"
+
+  datastore {
+    type           = "DDS-Community"
+    version        = "3.4"
+    storage_engine = "wiredTiger"
+  }
+
+  flavor {
+    type      = "mongos"
+    num       = 2
+    spec_code = "dds.mongodb.c6.large.2.mongos"
+  }
+  flavor {
+    type      = "shard"
+    num       = 2
+    storage   = "ULTRAHIGH"
+    size      = 20
+    spec_code = "dds.mongodb.c6.large.2.shard"
+  }
+  flavor {
+    type      = "config"
+    num       = 1
+    storage   = "ULTRAHIGH"
+    size      = 20
+    spec_code = "dds.mongodb.c6.large.2.config"
+  }
+}
+`, rName, randCidr)
+}
+
+func testAccDatabaseRole_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_dds_database_role" "base" {
+  instance_id = flexibleengine_dds_instance_v3.test.id
+
+  name    = "%[2]s-base"
+  db_name = "admin"
+
+  timeouts {
+    create = "10m"
+    delete = "10m"
+  }
+}
+
+resource "flexibleengine_dds_database_role" "test" {
+  instance_id = flexibleengine_dds_instance_v3.test.id
+
+  name    = "%[2]s"
+  db_name = "admin"
+
+  roles {
+    name    = flexibleengine_dds_database_role.base.name
+    db_name = "admin"
+  }
+
+  timeouts {
+    create = "10m"
+    delete = "10m"
+  }
+}
+`, testAccDatabaseRole_base(rName), rName)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_dds_database_user_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_dds_database_user_test.go
@@ -1,0 +1,128 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/dds/v3/users"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getDatabaseUserFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.DdsV3Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DDS v3 client: %s ", err)
+	}
+
+	instanceId := state.Primary.Attributes["instance_id"]
+	name := state.Primary.Attributes["name"]
+	opts := users.ListOpts{
+		Name:   state.Primary.Attributes["name"],
+		DbName: state.Primary.Attributes["db_name"],
+	}
+	resp, err := users.List(client, instanceId, opts)
+	if err != nil {
+		return nil, fmt.Errorf("error getting user (%s) from DDS instance (%s): %v", name, instanceId, err)
+	}
+	if len(resp) < 1 {
+		return nil, fmt.Errorf("unable to find user (%s) from DDS instance (%s)", name, instanceId)
+	}
+	user := resp[0]
+	return &user, nil
+}
+
+func TestAccDatabaseUser_basic(t *testing.T) {
+	var user users.UserResp
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_dds_database_user.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&user,
+		getDatabaseUserFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatabaseUser_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttrPair(resourceName, "roles.0.name",
+						"flexibleengine_dds_database_role.test", "name"),
+					resource.TestCheckResourceAttrPair(resourceName, "inherited_privileges",
+						"flexibleengine_dds_database_role.test", "inherited_privileges"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccDatabaseUserImportStateIdFunc(),
+				ImportStateVerifyIgnore: []string{
+					"password",
+				},
+			},
+		},
+	})
+}
+
+func testAccDatabaseUserImportStateIdFunc() resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		var instanceId, dbName, userName string
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type == "flexibleengine_dds_database_user" {
+				instanceId = rs.Primary.Attributes["instance_id"]
+				dbName = rs.Primary.Attributes["db_name"]
+				userName = rs.Primary.Attributes["name"]
+			}
+		}
+		if instanceId == "" || dbName == "" || userName == "" {
+			return "", fmt.Errorf("resource not found: %s/%s/%s", instanceId, dbName, userName)
+		}
+		return fmt.Sprintf("%s/%s/%s", instanceId, dbName, userName), nil
+	}
+}
+
+func testAccDatabaseUser_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_dds_database_role" "test" {
+  instance_id = flexibleengine_dds_instance_v3.test.id
+
+  name    = "%[2]s"
+  db_name = "admin"
+
+  timeouts {
+    create = "10m"
+    delete = "10m"
+  }
+}
+
+resource "flexibleengine_dds_database_user" "test" {
+  instance_id = flexibleengine_dds_instance_v3.test.id
+
+  name     = "%[2]s"
+  password = "HuaweiTest@12345678"
+  db_name  = "admin"
+
+  roles {
+    name    = flexibleengine_dds_database_role.test.name
+    db_name = "admin"
+  }
+
+  timeouts {
+    create = "10m"
+    delete = "10m"
+  }
+}
+`, testAccDatabaseRole_base(rName), rName)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -17,6 +17,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cce"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cse"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dds"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/drs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/elb"
@@ -439,6 +440,8 @@ func Provider() *schema.Provider {
 			"flexibleengine_cse_microservice":          cse.ResourceMicroservice(),
 			"flexibleengine_cse_microservice_engine":   cse.ResourceMicroserviceEngine(),
 			"flexibleengine_cse_microservice_instance": cse.ResourceMicroserviceInstance(),
+			"flexibleengine_dds_database_role":         dds.ResourceDatabaseRole(),
+			"flexibleengine_dds_database_user":         dds.ResourceDatabaseUser(),
 			"flexibleengine_drs_job":                   drs.ResourceDrsJob(),
 			"flexibleengine_fgs_dependency":            fgs.ResourceFgsDependency(),
 			"flexibleengine_fgs_function":              fgs.ResourceFgsFunctionV2(),


### PR DESCRIPTION
**Test result**:
```
make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccDatabaseRole_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccDatabaseRole_basic -timeout 720m
=== RUN   TestAccDatabaseRole_basic
=== PAUSE TestAccDatabaseRole_basic
=== CONT  TestAccDatabaseRole_basic
--- PASS: TestAccDatabaseRole_basic (826.74s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      826.858s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccDatabaseUser_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccDatabaseUser_basic -timeout 720m
=== RUN   TestAccDatabaseUser_basic
=== PAUSE TestAccDatabaseUser_basic
=== CONT  TestAccDatabaseUser_basic
--- PASS: TestAccDatabaseUser_basic (725.30s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      725.414s
```