### PR TITLE
chore: move deprecated resource into a dir

### DIFF
--- a/flexibleengine/deprecated/doc.go
+++ b/flexibleengine/deprecated/doc.go
@@ -1,0 +1,5 @@
+/*
+Package deprecated includes files of resources and data sources that
+imported directly from huaweicloud, so we should deprecate them.
+*/
+package deprecated

--- a/flexibleengine/deprecated/utils.go
+++ b/flexibleengine/deprecated/utils.go
@@ -1,0 +1,97 @@
+package deprecated
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"regexp"
+	"strings"
+)
+
+func validateName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if len(value) > 64 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 64 characters: %q", k, value))
+	}
+
+	pattern := `^[\.\-_A-Za-z0-9]+$`
+	if !regexp.MustCompile(pattern).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q doesn't comply with restrictions (%q): %q",
+			k, pattern, value))
+	}
+
+	return
+}
+
+func validateIP(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	ipnet := net.ParseIP(value)
+
+	if ipnet == nil || value != ipnet.String() {
+		errors = append(errors, fmt.Errorf(
+			"%q must contain a valid network IP address, got %q", k, value))
+	}
+
+	return
+}
+
+func validateCIDR(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	_, ipnet, err := net.ParseCIDR(value)
+	if err != nil {
+		errors = append(errors, fmt.Errorf(
+			"%q must contain a valid CIDR, got error parsing: %s", k, err))
+		return
+	}
+
+	if ipnet == nil || strings.ToLower(value) != ipnet.String() {
+		errors = append(errors, fmt.Errorf(
+			"%q must contain a valid network CIDR, got %q", k, value))
+	}
+
+	return
+}
+
+func navigateValue(d interface{}, index []string, arrayIndex map[string]int) (interface{}, error) {
+	for n, i := range index {
+		if d == nil {
+			return nil, nil
+		}
+		if d1, ok := d.(map[string]interface{}); ok {
+			d, ok = d1[i]
+			if !ok {
+				msg := fmt.Sprintf("navigate value with index(%s)", strings.Join(index, "."))
+				return nil, fmt.Errorf("%s: '%s' may not exist", msg, i)
+			}
+		} else {
+			msg := fmt.Sprintf("navigate value with index(%s)", strings.Join(index, "."))
+			return nil, fmt.Errorf("%s: Can not convert (%s) to map", msg, reflect.TypeOf(d))
+		}
+
+		if arrayIndex != nil {
+			if j, ok := arrayIndex[strings.Join(index[:n+1], ".")]; ok {
+				if d == nil {
+					return nil, nil
+				}
+				if d2, ok := d.([]interface{}); ok {
+					if len(d2) == 0 {
+						return nil, nil
+					}
+					if j >= len(d2) {
+						msg := fmt.Sprintf("navigate value with index(%s)", strings.Join(index, "."))
+						return nil, fmt.Errorf("%s: The index is out of array", msg)
+					}
+
+					d = d2[j]
+				} else {
+					msg := fmt.Sprintf("navigate value with index(%s)", strings.Join(index, "."))
+					return nil, fmt.Errorf("%s: Can not convert (%s) to array, index=%s.%v", msg, reflect.TypeOf(d), i, j)
+				}
+			}
+		}
+	}
+
+	return d, nil
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -415,7 +415,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_waf_rule_web_tamper_protection":     resourceWafRuleWebTamperProtection(),
 			"flexibleengine_dli_queue":                          ResourceDliQueueV1(),
 
-			// importing resource
+			// importing new resource
 			"flexibleengine_apig_api":                         apig.ResourceApigAPIV2(),
 			"flexibleengine_apig_api_publishment":             apig.ResourceApigApiPublishment(),
 			"flexibleengine_apig_instance":                    apig.ResourceApigInstanceV2(),
@@ -445,7 +445,6 @@ func Provider() *schema.Provider {
 			"flexibleengine_fgs_trigger":               fgs.ResourceFunctionGraphTrigger(),
 			"flexibleengine_rds_account":               rds.ResourceRdsAccount(),
 			"flexibleengine_rds_database":              rds.ResourceRdsDatabase(),
-			"flexibleengine_rds_instance_v3":           rds.ResourceRdsInstance(),
 			"flexibleengine_rds_database_privilege":    rds.ResourceRdsDatabasePrivilege(),
 			"flexibleengine_swr_organization":          swr.ResourceSWROrganization(),
 			"flexibleengine_swr_organization_users":    swr.ResourceSWROrganizationPermissions(),
@@ -453,9 +452,6 @@ func Provider() *schema.Provider {
 			"flexibleengine_swr_repository_sharing":    swr.ResourceSWRRepositorySharing(),
 
 			"flexibleengine_tms_tags": tms.ResourceTmsTag(),
-
-			"flexibleengine_vpc_v1":        vpc.ResourceVirtualPrivateCloudV1(),
-			"flexibleengine_vpc_subnet_v1": vpc.ResourceVpcSubnetV1(),
 
 			"flexibleengine_vpc_eip_associate": eip.ResourceEIPAssociate(),
 
@@ -466,6 +462,11 @@ func Provider() *schema.Provider {
 
 			"flexibleengine_modelarts_dataset":         modelarts.ResourceDataset(),
 			"flexibleengine_modelarts_dataset_version": modelarts.ResourceDatasetVersion(),
+
+			// importing existing resource
+			"flexibleengine_rds_instance_v3": rds.ResourceRdsInstance(),           // v1.29.0
+			"flexibleengine_vpc_v1":          vpc.ResourceVirtualPrivateCloudV1(), // v1.29.0
+			"flexibleengine_vpc_subnet_v1":   vpc.ResourceVpcSubnetV1(),           // v1.31.0
 
 			// Deprecated resource
 			"flexibleengine_elb_loadbalancer":  resourceELoadBalancer(),


### PR DESCRIPTION
Package deprecated includes files of resources and data sources that imported directly from HWC, so we should deprecate them.

the testing results are as follows:

```
$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run=TestAccVpcV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run=TestAccVpcV1_basic -timeout 720m
=== RUN   TestAccVpcV1_basic
=== PAUSE TestAccVpcV1_basic
=== CONT  TestAccVpcV1_basic
--- PASS: TestAccVpcV1_basic (65.18s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      65.255s

$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run=TestAccVpcSubnetV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run=TestAccVpcSubnetV1_basic -timeout 720m
=== RUN   TestAccVpcSubnetV1_basic
--- PASS: TestAccVpcSubnetV1_basic (87.67s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      87.742s

$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run=TestAccRdsInstanceV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run=TestAccRdsInstanceV3_basic -timeout 720m
=== RUN   TestAccRdsInstanceV3_basic
=== PAUSE TestAccRdsInstanceV3_basic
=== CONT  TestAccRdsInstanceV3_basic
--- PASS: TestAccRdsInstanceV3_basic (969.95s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      970.033s

$ make testacc TEST='./flexibleengine' TESTARGS='-run=TestAccRdsReplicaInstanceV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run=TestAccRdsReplicaInstanceV3_basic -timeout 720m
=== RUN   TestAccRdsReplicaInstanceV3_basic
=== PAUSE TestAccRdsReplicaInstanceV3_basic
=== CONT  TestAccRdsReplicaInstanceV3_basic
--- PASS: TestAccRdsReplicaInstanceV3_basic (841.41s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 841.446s
```