### PR TITLE
feat(dms/kafka): add new resource user

### DIFF
--- a/docs/resources/dms_kafka_user.md
+++ b/docs/resources/dms_kafka_user.md
@@ -1,0 +1,49 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+# flexibleengine_dms_kafka_user
+
+Manages a DMS kafka user resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+variable "kafka_instance_id" {}
+
+resource "flexibleengine_dms_kafka_user" "user" {
+  instance_id = var.kafka_instance_id
+  name        = "user_1"
+  password    = "Test@123"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the DMS kafka user resource. If omitted, the
+  provider-level region will be used. Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the DMS kafka instance to which the user belongs.
+  Changing this creates a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the user. Changing this creates a new resource.
+
+* `password` - (Required, String) Specifies the password of the user. The parameter must be 8 to 32 characters
+  long and contain only letters(case-sensitive), digits, and special characters(`~!@#$%^&*()-_=+|[{}]:'",<.>/?).
+  The value must be different from name.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID which is formatted `<instance_id>/<user_name>`.
+
+## Import
+
+DMS kafka users can be imported using the kafka instance ID and user name separated by a slash, e.g.
+
+```
+terraform import flexibleengine_dms_kafka_user.user c8057fe5-23a8-46ef-ad83-c0055b4e0c5c/user_1
+```

--- a/flexibleengine/acceptance/resource_flexibleengine_dms_kafka_user_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_dms_kafka_user_test.go
@@ -1,0 +1,162 @@
+package acceptance
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/huaweicloud-sdk-go-v3/services/kafka/v2/model"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getDmsKafkaUserFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.HcDmsV2Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating DMS client: %s", err)
+	}
+
+	// Split instance_id and user from resource id
+	parts := strings.SplitN(state.Primary.ID, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid id format, must be <instance_id>/<user>")
+	}
+	instanceId := parts[0]
+	instanceUser := parts[1]
+
+	// List all instance users
+	request := &model.ShowInstanceUsersRequest{
+		InstanceId: instanceId,
+	}
+
+	response, err := client.ShowInstanceUsers(request)
+	if err != nil {
+		return nil, fmt.Errorf("error listing DMS kafka users in %s, error: %s", instanceId, err)
+	}
+	if response.Users != nil && len(*response.Users) != 0 {
+		users := *response.Users
+		for _, user := range users {
+			if *user.UserName == instanceUser {
+				return user, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("can not found DMS kafka user")
+}
+
+func TestAccDmsKafkaUser_basic(t *testing.T) {
+	var user model.ShowInstanceUsersEntity
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "flexibleengine_dms_kafka_user.test"
+	password := acceptance.RandomPassword()
+	passwordUpdate := password + "update"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&user,
+		getDmsKafkaUserFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDmsKafkaUser_basic(rName, password),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				Config: testAccDmsKafkaUser_basic(rName, passwordUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}
+
+func testAccDmsKafkaInstance_base(resName string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_dms_product" "product_1" {
+  bandwidth = "300MB"
+}
+
+resource "flexibleengine_vpc_v1" "vpc_1" {
+  name = "%s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "vpc_subnet_1" {
+  name       = "%s"
+  cidr       = "192.168.10.0/24"
+  gateway_ip = "192.168.10.1"
+  vpc_id     = flexibleengine_vpc_v1.vpc_1.id
+}
+
+resource "flexibleengine_networking_secgroup_v2" "secgroup_1" {
+  name        = "%s"
+  description = "secgroup for DMS"
+}`, resName, resName, resName)
+}
+
+func testAccDmsKafkaInstance_basic(resName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_dms_kafka_instance" "instance_1" {
+  name               = "%s"
+  manager_user       = "admin"
+  manager_password   = "Dmstest@123"
+  access_user        = "user"
+  password           = "Dmstest@123"
+  vpc_id             = flexibleengine_vpc_v1.vpc_1.id
+  network_id         = flexibleengine_vpc_subnet_v1.vpc_subnet_1.id
+  security_group_id  = flexibleengine_networking_secgroup_v2.secgroup_1.id
+  availability_zones = data.flexibleengine_dms_product.product_1.availability_zones
+  bandwidth          = data.flexibleengine_dms_product.product_1.bandwidth
+  product_id         = data.flexibleengine_dms_product.product_1.id
+  storage_space      = data.flexibleengine_dms_product.product_1.storage_space
+  engine_version     = data.flexibleengine_dms_product.product_1.engine_version
+}
+`, testAccDmsKafkaInstance_base(resName), resName)
+}
+
+func testAccDmsKafkaTopic_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_dms_kafka_topic" "topic" {
+  instance_id = flexibleengine_dms_kafka_instance.instance_1.id
+  name        = "%s"
+  partitions  = 10
+  aging_time  = 36
+}
+`, testAccDmsKafkaInstance_basic(rName), rName)
+}
+
+func testAccDmsKafkaUser_basic(rName, password string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_dms_kafka_user" "test" {
+  instance_id = flexibleengine_dms_kafka_instance.instance_1.id
+  name        = "%s"
+  password    = "%s"
+}
+`, testAccDmsKafkaTopic_basic(rName), rName, password)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cce"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cse"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dds"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/drs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/elb"
@@ -444,6 +445,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_cse_microservice_instance": cse.ResourceMicroserviceInstance(),
 			"flexibleengine_dds_database_role":         dds.ResourceDatabaseRole(),
 			"flexibleengine_dds_database_user":         dds.ResourceDatabaseUser(),
+			"flexibleengine_dms_kafka_user":            dms.ResourceDmsKafkaUser(),
 			"flexibleengine_drs_job":                   drs.ResourceDrsJob(),
 			"flexibleengine_fgs_dependency":            fgs.ResourceFgsDependency(),
 			"flexibleengine_fgs_function":              fgs.ResourceFgsFunctionV2(),


### PR DESCRIPTION
**Test result**:
```
make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccDmsKafkaUser_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccDmsKafkaUser_basic -timeout 720m
=== RUN   TestAccDmsKafkaUser_basic
=== PAUSE TestAccDmsKafkaUser_basic
=== CONT  TestAccDmsKafkaUser_basic
--- PASS: TestAccDmsKafkaUser_basic (999.82s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      999.935s
```