### PR TITLE
feat(dcs/instance): support port customization

### DIFF
--- a/docs/resources/dcs_instance_v1.md
+++ b/docs/resources/dcs_instance_v1.md
@@ -157,6 +157,10 @@ The following arguments are supported:
 
     Changing this creates a new instance.
 
+* `port` - (Optional) Port customization, which is supported only by Redis 4.0 and Redis 5.0 instances and not by
+  Redis 3.0 and Memcached instances. The values ranges from **1** to **65535**. The default value is **6379**.
+  Changing this creates a new instance.
+
 * `maintain_begin` - (Optional) Indicates the time at which a maintenance time window starts.
     Format: HH:mm:ss.
     The start time and end time of a maintenance time window must indicate the time segment of

--- a/flexibleengine/resource_flexibleengine_dcs_instance_v1.go
+++ b/flexibleengine/resource_flexibleengine_dcs_instance_v1.go
@@ -140,6 +140,12 @@ func resourceDcsInstanceV1() *schema.Resource {
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeInt},
 			},
+			"port": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 			"vpc_name": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -154,10 +160,6 @@ func resourceDcsInstanceV1() *schema.Resource {
 			},
 			"ip": {
 				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"port": {
-				Type:     schema.TypeInt,
 				Computed: true,
 			},
 			"resource_spec_code": {
@@ -278,6 +280,7 @@ func resourceDcsInstancesV1Create(d *schema.ResourceData, meta interface{}) erro
 		AvailableZones:   getAllAvailableZones(d),
 		MaintainBegin:    d.Get("maintain_begin").(string),
 		MaintainEnd:      d.Get("maintain_end").(string),
+		Port:             d.Get("port").(int),
 	}
 
 	product_id, product_ok := d.GetOk("product_id")

--- a/flexibleengine/resource_flexibleengine_dcs_instance_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_dcs_instance_v1_test.go
@@ -53,12 +53,13 @@ func TestAccDcsInstancesV1_redisV5(t *testing.T) {
 		CheckDestroy: testAccCheckDcsV1InstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDcsV1Instance_basic(randName),
+				Config: testAccDcsV1Instance_redisV5(randName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDcsV1InstanceExists(resourceName, instance),
 					resource.TestCheckResourceAttr(resourceName, "name", randName),
 					resource.TestCheckResourceAttr(resourceName, "engine", "Redis"),
 					resource.TestCheckResourceAttr(resourceName, "status", "RUNNING"),
+					resource.TestCheckResourceAttr(resourceName, "port", "9999"),
 				),
 			},
 			{
@@ -222,6 +223,7 @@ resource "flexibleengine_dcs_instance_v1" "instance_1" {
   vpc_id          = flexibleengine_vpc_v1.vpc_1.id
   network_id      = flexibleengine_vpc_subnet_v1.subnet_1.id
   available_zones = ["eu-west-0a", "eu-west-0c"]
+  port            = "9999"
 
   save_days   = 1
   backup_type = "manual"

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.25.3
-	github.com/chnsz/golangsdk v0.0.0-20221025063414-ec58687a8de7
+	github.com/chnsz/golangsdk v0.0.0-20221028063210-22000d297e48
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -72,10 +72,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chnsz/golangsdk v0.0.0-20220927110738-5a265800849c/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
-github.com/chnsz/golangsdk v0.0.0-20221010082948-5094d5b1b788 h1:wwJOM3bQ3fVRCrSexYwijEkEVNJMmPXdyn2mT7hTjXo=
-github.com/chnsz/golangsdk v0.0.0-20221010082948-5094d5b1b788/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
-github.com/chnsz/golangsdk v0.0.0-20221025063414-ec58687a8de7 h1:J5cx68P0UIrLiD6uiisvtZV1ZMJbaCYTX0CwHSGaCyM=
-github.com/chnsz/golangsdk v0.0.0-20221025063414-ec58687a8de7/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20221028063210-22000d297e48 h1:GXPNQopzwj8FWvpPLX0RaSFtI0DowM74VT6QXfTg41w=
+github.com/chnsz/golangsdk v0.0.0-20221028063210-22000d297e48/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=


### PR DESCRIPTION
**Test result**:
```
make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDcsInstancesV1_redisV5'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDcsInstancesV1_redisV5 -timeout 720m
=== RUN   TestAccDcsInstancesV1_redisV5
=== PAUSE TestAccDcsInstancesV1_redisV5
=== CONT  TestAccDcsInstancesV1_redisV5
--- PASS: TestAccDcsInstancesV1_redisV5 (181.39s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 181.468s
```