### PR TITLE
feat(dms/kafka): support enable_auto_topic in kafka instance

### DIFF
--- a/docs/resources/dms_kafka_instance.md
+++ b/docs/resources/dms_kafka_instance.md
@@ -121,6 +121,10 @@ The following arguments are supported:
 
   -> **NOTE:**  The start time and end time of a maintenance time window must be set in pairs.
 
+* `enable_auto_topic` - (Optional, Bool, ForceNew) Specifies whether to enable automatic topic creation. If automatic
+  topic creation is enabled, a topic will be automatically created with 3 partitions and 3 replicas when a message is
+  produced to or consumed from a topic that does not exist. Changing this creates a new instance resource.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.25.3
-	github.com/chnsz/golangsdk v0.0.0-20221025063414-ec58687a8de7
+	github.com/chnsz/golangsdk v0.0.0-20221029025000-a162e6601009
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -72,10 +72,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chnsz/golangsdk v0.0.0-20220927110738-5a265800849c/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
-github.com/chnsz/golangsdk v0.0.0-20221010082948-5094d5b1b788 h1:wwJOM3bQ3fVRCrSexYwijEkEVNJMmPXdyn2mT7hTjXo=
-github.com/chnsz/golangsdk v0.0.0-20221010082948-5094d5b1b788/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
-github.com/chnsz/golangsdk v0.0.0-20221025063414-ec58687a8de7 h1:J5cx68P0UIrLiD6uiisvtZV1ZMJbaCYTX0CwHSGaCyM=
-github.com/chnsz/golangsdk v0.0.0-20221025063414-ec58687a8de7/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20221029025000-a162e6601009 h1:9yQXbcrOGLvttuBygp8VM3WJeeUbJ1+gFhAqHDpUzsg=
+github.com/chnsz/golangsdk v0.0.0-20221029025000-a162e6601009/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=


### PR DESCRIPTION
**Test result**:
```
make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDmsKafkaInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDmsKafkaInstance_basic -timeout 720m
=== RUN   TestAccDmsKafkaInstance_basic
=== PAUSE TestAccDmsKafkaInstance_basic
=== CONT  TestAccDmsKafkaInstance_basic
--- PASS: TestAccDmsKafkaInstance_basic (961.45s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 961.544s
```