### PR TITLE
fix(cce/node_pool): repalce scall_enable with scale_enable

### DIFF
--- a/docs/resources/cce_node_pool_v3.md
+++ b/docs/resources/cce_node_pool_v3.md
@@ -21,7 +21,7 @@ resource "flexibleengine_cce_node_pool_v3" "node_pool" {
   flavor_id                = "s3.large.4"
   availability_zone        = var.availability_zone
   key_pair                 = var.keypair
-  scall_enable             = true
+  scale_enable             = true
   min_node_count           = 1
   max_node_count           = 10
   scale_down_cooldown_time = 100
@@ -78,7 +78,7 @@ The following arguments are supported:
 * `postinstall` - (Optional, String, ForceNew) Script required after the installation. The input value can be
     a Base64 encoded string or not. Changing this parameter will create a new resource.
 
-* `scall_enable` - (Optional, Bool) Whether to enable auto scaling. If Autoscaler is enabled, install the autoscaler
+* `scale_enable` - (Optional, Bool) Whether to enable auto scaling. If Autoscaler is enabled, install the autoscaler
     add-on to use the auto scaling feature.
 
 * `min_node_count` - (Optional, Int) Minimum number of nodes allowed if auto scaling is enabled.

--- a/flexibleengine/resource_flexibleengine_cce_node_pool.go
+++ b/flexibleengine/resource_flexibleengine_cce_node_pool.go
@@ -218,9 +218,15 @@ func resourceCCENodePool() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"scale_enable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
 			"scall_enable": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
 			},
 			"min_node_count": {
 				Type:     schema.TypeInt,
@@ -314,7 +320,7 @@ func resourceCCENodePoolCreate(d *schema.ResourceData, meta interface{}) error {
 				UserTags:    resourceCCENodeUserTags(d),
 			},
 			Autoscaling: nodepools.AutoscalingSpec{
-				Enable:                d.Get("scall_enable").(bool),
+				Enable:                d.Get("scale_enable").(bool) || d.Get("scall_enable").(bool),
 				MinNodeCount:          d.Get("min_node_count").(int),
 				MaxNodeCount:          d.Get("max_node_count").(int),
 				ScaleDownCooldownTime: d.Get("scale_down_cooldown_time").(int),
@@ -390,6 +396,7 @@ func resourceCCENodePoolRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("billing_mode", s.Spec.NodeTemplate.BillingMode),
 		d.Set("key_pair", s.Spec.NodeTemplate.Login.SshKey),
 		d.Set("initial_node_count", s.Spec.InitialNodeCount),
+		d.Set("scale_enable", s.Spec.Autoscaling.Enable),
 		d.Set("scall_enable", s.Spec.Autoscaling.Enable),
 		d.Set("min_node_count", s.Spec.Autoscaling.MinNodeCount),
 		d.Set("max_node_count", s.Spec.Autoscaling.MaxNodeCount),
@@ -450,7 +457,7 @@ func resourceCCENodePoolUpdate(d *schema.ResourceData, meta interface{}) error {
 		Spec: nodepools.UpdateSpec{
 			InitialNodeCount: &initialNodeCount,
 			Autoscaling: nodepools.AutoscalingSpec{
-				Enable:                d.Get("scall_enable").(bool),
+				Enable:                d.Get("scale_enable").(bool) || d.Get("scall_enable").(bool),
 				MinNodeCount:          d.Get("min_node_count").(int),
 				MaxNodeCount:          d.Get("max_node_count").(int),
 				ScaleDownCooldownTime: d.Get("scale_down_cooldown_time").(int),

--- a/flexibleengine/resource_flexibleengine_cce_node_pool_test.go
+++ b/flexibleengine/resource_flexibleengine_cce_node_pool_test.go
@@ -30,7 +30,7 @@ func TestAccCCENodePool_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCCENodePoolExists(resourceName, clusterName, &nodePool),
 					resource.TestCheckResourceAttr(resourceName, "name", rName),
-					resource.TestCheckResourceAttr(resourceName, "scall_enable", "false"),
+					resource.TestCheckResourceAttr(resourceName, "scale_enable", "false"),
 					resource.TestCheckResourceAttr(resourceName, "initial_node_count", "1"),
 					resource.TestCheckResourceAttr(resourceName, "min_node_count", "0"),
 					resource.TestCheckResourceAttr(resourceName, "max_node_count", "0"),
@@ -47,7 +47,7 @@ func TestAccCCENodePool_basic(t *testing.T) {
 				Config: testAccCCENodePool_update(rName, updateName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "name", updateName),
-					resource.TestCheckResourceAttr(resourceName, "scall_enable", "true"),
+					resource.TestCheckResourceAttr(resourceName, "scale_enable", "true"),
 					resource.TestCheckResourceAttr(resourceName, "initial_node_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "min_node_count", "2"),
 					resource.TestCheckResourceAttr(resourceName, "max_node_count", "9"),
@@ -157,6 +157,8 @@ func testAccCheckCCENodePoolExists(n string, cluster string, nodePool *nodepools
 
 func testAccCCENodePool_Base(rName string) string {
 	return fmt.Sprintf(`
+%s
+
 data "flexibleengine_availability_zones" "test" {}
 
 resource "flexibleengine_compute_keypair_v2" "test" {
@@ -166,13 +168,15 @@ resource "flexibleengine_compute_keypair_v2" "test" {
 
 resource "flexibleengine_cce_cluster_v3" "test" {
   name                   = "%s"
+  description            = "a description"
   cluster_type           = "VirtualMachine"
+  cluster_version        = "v1.17.9-r0"
   flavor_id              = "cce.s1.small"
-  vpc_id                 = "%s"
-  subnet_id              = "%s"
+  vpc_id                 = flexibleengine_vpc_v1.test.id
+  subnet_id              = flexibleengine_vpc_subnet_v1.test.id
   container_network_type = "overlay_l2"
 }
-`, rName, rName, OS_VPC_ID, OS_NETWORK_ID)
+`, testAccCCEClusterV3_Base(rName), rName, rName)
 }
 
 func testAccCCENodePool_basic(rName string) string {
@@ -180,20 +184,20 @@ func testAccCCENodePool_basic(rName string) string {
 %s
 
 resource "flexibleengine_cce_node_pool_v3" "test" {
-  cluster_id         = flexibleengine_cce_cluster_v3.test.id
-  name               = "%s"
-  os                 = "EulerOS 2.5"
-  flavor_id          = "s3.large.2"
-  availability_zone  = data.flexibleengine_availability_zones.test.names[0]
-  key_pair           = flexibleengine_compute_keypair_v2.test.name
-  scall_enable       = false
-  initial_node_count = 1
-  min_node_count     = 0
-  max_node_count     = 0
-  max_pods           = 200
+  cluster_id               = flexibleengine_cce_cluster_v3.test.id
+  name                     = "%s"
+  os                       = "EulerOS 2.5"
+  flavor_id                = "s3.large.2"
+  availability_zone        = data.flexibleengine_availability_zones.test.names[0]
+  key_pair                 = flexibleengine_compute_keypair_v2.test.name
+  scale_enable             = false
+  initial_node_count       = 1
+  min_node_count           = 0
+  max_node_count           = 0
+  max_pods                 = 200
   scale_down_cooldown_time = 0
-  priority          = 0
-  type              = "vm"
+  priority                 = 0
+  type                     = "vm"
 
   root_volume {
     size       = 40
@@ -225,19 +229,20 @@ func testAccCCENodePool_update(rName, updateName string) string {
 %s
 
 resource "flexibleengine_cce_node_pool_v3" "test" {
-  cluster_id         = flexibleengine_cce_cluster_v3.test.id
-  name               = "%s"
-  os                 = "EulerOS 2.5"
-  flavor_id          = "s3.large.2"
-  availability_zone  = data.flexibleengine_availability_zones.test.names[0]
-  key_pair           = flexibleengine_compute_keypair_v2.test.name
-  scall_enable       = true
-  initial_node_count = 2
-  min_node_count     = 2
-  max_node_count     = 9
+  cluster_id               = flexibleengine_cce_cluster_v3.test.id
+  name                     = "%s"
+  os                       = "EulerOS 2.5"
+  flavor_id                = "s3.large.2"
+  availability_zone        = data.flexibleengine_availability_zones.test.names[0]
+  key_pair                 = flexibleengine_compute_keypair_v2.test.name
+  scale_enable             = true
+  initial_node_count       = 2
+  min_node_count           = 2
+  max_node_count           = 9
+  max_pods                 = 200
   scale_down_cooldown_time = 100
-  priority          = 1
-  type              = "vm"
+  priority                 = 1
+  type                     = "vm"
 
   root_volume {
     size       = 40


### PR DESCRIPTION
fixes #819 

**Test result**:
```
make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCCENodePool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCCENodePool_basic -timeout 720m
=== RUN   TestAccCCENodePool_basic
=== PAUSE TestAccCCENodePool_basic
=== CONT  TestAccCCENodePool_basic
--- PASS: TestAccCCENodePool_basic (878.98s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 879.062s
```