### PR TITLE
fix: fix elb v2 pool

### DIFF
--- a/docs/resources/lb_pool_v2.md
+++ b/docs/resources/lb_pool_v2.md
@@ -25,14 +25,14 @@ resource "flexibleengine_lb_pool_v2" "pool_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to obtain the V2 Networking client.
+* `region` - (Optional, String, ForceNew) The region in which to obtain the V2 Networking client.
     A Networking client is needed to create an . If omitted, the
     `region` argument of the provider is used. Changing this creates a new
     pool.
 
-* `name` - (Optional) Human-readable name for the pool.
+* `name` - (Optional, String) Human-readable name for the pool.
 
-* `description` - (Optional) Human-readable description for the pool.
+* `description` - (Optional, String) Human-readable description for the pool.
 
 * `protocol` = (Required) The protocol - can either be TCP, UDP or HTTP.
 
@@ -42,43 +42,43 @@ The following arguments are supported:
 
     Changing this creates a new pool.
 
-* `loadbalancer_id` - (Optional) The load balancer on which to provision this
+* `loadbalancer_id` - (Optional, String, ForceNew) The load balancer on which to provision this
     pool. Changing this creates a new pool.
     Note:  One of LoadbalancerID or ListenerID must be provided.
 
-* `listener_id` - (Optional) The Listener on which the members of the pool
+* `listener_id` - (Optional, String, ForceNew) The Listener on which the members of the pool
     will be associated with. Changing this creates a new pool.
 	Note:  One of LoadbalancerID or ListenerID must be provided.
 
-* `lb_method` - (Required) The load balancing algorithm to
+* `lb_method` - (Required, String) The load balancing algorithm to
     distribute traffic to the pool's members. Must be one of
     ROUND_ROBIN, LEAST_CONNECTIONS, or SOURCE_IP.
 
-* `persistence` - Omit this field to prevent session persistence.  Indicates
+* `persistence` - (Optional, List, ForceNew) Omit this field to prevent session persistence.  Indicates
     whether connections in the same session will be processed by the same Pool
     member or not. Changing this creates a new pool.
 
-* `tenant_id` - (Optional) The UUID of the tenant who owns the pool.
-    Only administrative users can specify a tenant UUID other than their own.
-    Changing this creates a new pool.
-
-* `admin_state_up` - (Optional) The administrative state of the pool.
+* `admin_state_up` - (Optional, Bool) The administrative state of the pool.
     A valid value is true (UP) or false (DOWN).
 
 The `persistence` argument supports:
 
-* `type` - (Required) The type of persistence mode. The current specification
+* `type` - (Required, String, ForceNew) The type of persistence mode. The current specification
     supports SOURCE_IP, HTTP_COOKIE, and APP_COOKIE.
 
-* `cookie_name` - (Optional) The name of the cookie if persistence mode is set
+* `cookie_name` - (Optional, String, ForceNew) The name of the cookie if persistence mode is set
     appropriately. Required if `type = APP_COOKIE`.
+
+* `timeout` - (Optional, Int, ForceNew) Specifies the sticky session timeout duration in minutes. This parameter is
+  invalid when type is set to APP_COOKIE. The value range varies depending on the protocol of the backend server group:
+  + When the protocol of the backend server group is TCP or UDP, the value ranges from 1 to 60.
+  + When the protocol of the backend server group is HTTP or HTTPS, the value ranges from 1 to 1440.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `id` - The unique ID for the pool.
-* `tenant_id` - See Argument Reference above.
 * `name` - See Argument Reference above.
 * `description` - See Argument Reference above.
 * `protocol` - See Argument Reference above.

--- a/flexibleengine/acceptance/resource_flexibleengine_lb_pool_v2_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_lb_pool_v2_test.go
@@ -1,0 +1,113 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/elb/v2/pools"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getPoolResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.LoadBalancerClient(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating flexibleengine LB v2 client: %s", err)
+	}
+	resp, err := pools.Get(c, state.Primary.ID).Extract()
+	if resp == nil && err == nil {
+		return resp, fmt.Errorf("unable to find the pool (%s)", state.Primary.ID)
+	}
+	return resp, err
+}
+
+func TestAccLBV2Pool_basic(t *testing.T) {
+	var pool pools.Pool
+	rName := acceptance.RandomAccResourceNameWithDash()
+	rNameUpdate := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "flexibleengine_lb_pool_v2.pool_1"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&pool,
+		getPoolResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLBV2PoolConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "lb_method", "ROUND_ROBIN"),
+				),
+			},
+			{
+				Config: testAccLBV2PoolConfig_update(rName, rNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "lb_method", "LEAST_CONNECTIONS"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccLBV2PoolConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
+  name          = "%[1]s"
+  vip_subnet_id = "%[2]s"
+}
+
+resource "flexibleengine_lb_listener_v2" "listener_1" {
+  name            = "%[1]s"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
+}
+
+resource "flexibleengine_lb_pool_v2" "pool_1" {
+  name        = "%[1]s"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = flexibleengine_lb_listener_v2.listener_1.id
+}
+`, rName, OS_SUBNET_ID)
+}
+
+func testAccLBV2PoolConfig_update(rName, rNameUpdate string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
+  name          = "%[1]s"
+  vip_subnet_id = "%[3]s"
+}
+
+resource "flexibleengine_lb_listener_v2" "listener_1" {
+  name            = "%[1]s"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
+}
+
+resource "flexibleengine_lb_pool_v2" "pool_1" {
+  name           = "%[2]s"
+  protocol       = "HTTP"
+  lb_method      = "LEAST_CONNECTIONS"
+  admin_state_up = "true"
+  listener_id    = flexibleengine_lb_listener_v2.listener_1.id
+}
+`, rName, rNameUpdate, OS_SUBNET_ID)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -25,6 +25,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eps"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/modelarts"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/sfs"
@@ -319,7 +320,6 @@ func Provider() *schema.Provider {
 			"flexibleengine_kms_key_v1":                         resourceKmsKeyV1(),
 			"flexibleengine_lb_loadbalancer_v2":                 resourceLoadBalancerV2(),
 			"flexibleengine_lb_listener_v2":                     resourceListenerV2(),
-			"flexibleengine_lb_pool_v2":                         resourcePoolV2(),
 			"flexibleengine_lb_member_v2":                       resourceMemberV2(),
 			"flexibleengine_lb_monitor_v2":                      resourceMonitorV2(),
 			"flexibleengine_lb_whitelist_v2":                    resourceWhitelistV2(),
@@ -475,6 +475,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_rds_instance_v3": rds.ResourceRdsInstance(),           // v1.29.0
 			"flexibleengine_vpc_v1":          vpc.ResourceVirtualPrivateCloudV1(), // v1.29.0
 			"flexibleengine_vpc_subnet_v1":   vpc.ResourceVpcSubnetV1(),           // v1.31.0
+			"flexibleengine_lb_pool_v2":      lb.ResourcePoolV2(),                 // v1.35.0
 
 			// Deprecated resource
 			"flexibleengine_elb_loadbalancer":  resourceELoadBalancer(),


### PR DESCRIPTION
fixes https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/issues/821

Test result:

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccLBV2Pool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccLBV2Pool_basic -timeout 720m
=== RUN   TestAccLBV2Pool_basic
=== PAUSE TestAccLBV2Pool_basic
=== CONT  TestAccLBV2Pool_basic
--- PASS: TestAccLBV2Pool_basic (141.50s) 
PASS 
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      141.599s