### PR TITLE
fix: add elb pool v3

### DIFF
--- a/docs/resources/lb_pool_v3.md
+++ b/docs/resources/lb_pool_v3.md
@@ -1,0 +1,85 @@
+---
+subcategory: "Elastic Load Balance (ELB)"
+---
+
+# flexibleengine_lb_pool_v3
+
+Manages an ELB pool resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_lb_pool_v3" "pool_1" {
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = "{{ listener_id }}"
+
+  persistence {
+    type        = "HTTP_COOKIE"
+    cookie_name = "testCookie"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the ELB pool resource. If omitted, the the
+  provider-level region will be used. Changing this creates a new pool.
+
+* `name` - (Optional, String) Human-readable name for the pool.
+
+* `description` - (Optional, String) Human-readable description for the pool.
+
+* `protocol` - (Required, String, ForceNew) The protocol - can either be TCP, UDP, HTTP, HTTPS or QUIC.
+
+    + When the protocol used by the listener is UDP, the protocol of the backend pool must be UDP or QUIC.
+    + When the protocol used by the listener is TCP, the protocol of the backend pool must be TCP.
+    + When the protocol used by the listener is HTTP, the protocol of the backend pool must be HTTP.
+    + When the protocol used by the listener is HTTPS, the protocol of the backend pool must be HTTPS.
+    + When the protocol used by the listener is TERMINATED_HTTPS, the protocol of the backend pool must be HTTP.
+
+      Changing this creates a new pool.
+
+* `loadbalancer_id` - (Optional, String, ForceNew) The load balancer on which to provision this pool. Changing this
+  creates a new pool. Note:  Exactly one of LoadbalancerID or ListenerID must be provided.
+
+* `listener_id` - (Optional, String, ForceNew) The Listener on which the members of the pool will be associated with.
+  Changing this creates a new pool. Note:  Exactly one of LoadbalancerID or ListenerID must be provided.
+
+* `lb_method` - (Required, String) The load balancing algorithm to distribute traffic to the pool's members. Must be one
+  of ROUND_ROBIN, LEAST_CONNECTIONS, or SOURCE_IP.
+
+* `persistence` - (Optional, List, ForceNew) Omit this field to prevent session persistence. Indicates whether
+  connections in the same session will be processed by the same Pool member or not. Changing this creates a new pool.
+
+The `persistence` argument supports:
+
+* `type` - (Required, String, ForceNew) The type of persistence mode. The current specification supports SOURCE_IP,
+  HTTP_COOKIE, and APP_COOKIE.
+
+* `cookie_name` - (Optional, String, ForceNew) The name of the cookie if persistence mode is set appropriately. Required
+  if `type = APP_COOKIE`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes is exported:
+
+* `id` - The unique ID for the pool.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `update` - Default is 10 minute.
+* `delete` - Default is 10 minute.
+
+## Import
+
+ELB pool can be imported using the pool ID, e.g.
+
+```
+$ terraform import flexibleengine_lb_pool_v3.pool_1 5c20fdad-7288-11eb-b817-0255ac10158b
+```

--- a/flexibleengine/acceptance/resource_flexibleengine_lb_pool_v3_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_lb_pool_v3_test.go
@@ -1,0 +1,119 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/elb/v3/pools"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccElbV3Pool_basic(t *testing.T) {
+	var pool pools.Pool
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rNameUpdate := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "flexibleengine_lb_pool_v3.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&pool,
+		getPoolResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccElbV3PoolConfig_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "lb_method", "ROUND_ROBIN"),
+				),
+			},
+			{
+				Config: testAccElbV3PoolConfig_update(rName, rNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "lb_method", "LEAST_CONNECTIONS"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccPoolV3Config_base(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc_v1" "test" {
+  name = "vpc_%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test" {
+  name        = "subnet_%[1]s"
+  cidr        = "192.168.0.0/24"
+  gateway_ip  = "192.168.0.1"
+  vpc_id      = flexibleengine_vpc_v1.test.id
+  ipv6_enable = true
+}
+
+resource "flexibleengine_lb_loadbalancer_v3" "test" {
+  name            = "%[1]s"
+  ipv4_subnet_id  = flexibleengine_vpc_subnet_v1.test.subnet_id
+  ipv6_network_id = flexibleengine_vpc_subnet_v1.test.id
+
+  availability_zone = [
+    "%[2]s"
+  ]
+}
+
+resource "flexibleengine_lb_listener_v3" "test" {
+  name            = "%[1]s"
+  description     = "test description"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v3.test.id
+
+  forward_eip = true
+
+  idle_timeout     = 60
+  request_timeout  = 60
+  response_timeout = 60
+}
+`, rName, OS_AVAILABILITY_ZONE)
+}
+
+func testAccElbV3PoolConfig_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_lb_pool_v3" "test" {
+  name        = "%s"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = flexibleengine_lb_listener_v3.test.id
+}
+`, testAccPoolV3Config_base(rName), rName)
+}
+
+func testAccElbV3PoolConfig_update(rName, rNameUpdate string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_lb_pool_v3" "test" {
+  name        = "%s"
+  protocol    = "HTTP"
+  lb_method   = "LEAST_CONNECTIONS"
+  listener_id = flexibleengine_lb_listener_v3.test.id
+}
+`, testAccPoolV3Config_base(rName), rNameUpdate)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -476,6 +476,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_vpc_v1":          vpc.ResourceVirtualPrivateCloudV1(), // v1.29.0
 			"flexibleengine_vpc_subnet_v1":   vpc.ResourceVpcSubnetV1(),           // v1.31.0
 			"flexibleengine_lb_pool_v2":      lb.ResourcePoolV2(),                 // v1.35.0
+			"flexibleengine_lb_pool_v3":      elb.ResourcePoolV3(),                // v1.35.0
 
 			// Deprecated resource
 			"flexibleengine_elb_loadbalancer":  resourceELoadBalancer(),


### PR DESCRIPTION
fixes https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/issues/801

Test result:

make testacc TE
ST='./flexibleengine/acceptance' TESTARGS='-run TestAccElbV3Pool_basic'                                                      
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccElbV3Pool_basic -timeout 720m 
=== RUN   TestAccElbV3Pool_basic 
=== PAUSE TestAccElbV3Pool_basic 
=== CONT  TestAccElbV3Pool_basic 
--- PASS: TestAccElbV3Pool_basic (157.77s) 
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      157.838s
