### PR TITLE
feat(vpc): add new resources route_table and route

### DIFF
--- a/docs/data-sources/vpc_route_ids_v2.md
+++ b/docs/data-sources/vpc_route_ids_v2.md
@@ -1,8 +1,10 @@
 ---
-subcategory: "Virtual Private Cloud (VPC)"
+subcategory: "Deprecated"
 ---
 
 # Data Source: flexibleengine_vpc_route_ids_v2
+
+!> **WARNING:** It has been deprecated, use `flexibleengine_vpc_route_table` to get the route details.
 
 `flexibleengine_vpc_route_ids_v2` provides a list of route ids for a vpc_id.
 
@@ -34,4 +36,3 @@ output "route_nexthop" {
 ## Attributes Reference
 
 * `ids` - A list of all the route ids found. This data source will fail if none are found.
-

--- a/docs/data-sources/vpc_route_table.md
+++ b/docs/data-sources/vpc_route_table.md
@@ -1,0 +1,57 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# flexibleengine_vpc_route_table
+
+Provides details about a specific VPC route table.
+
+## Example Usage
+
+```hcl
+variable "vpc_id" {}
+
+# get the default route table
+data "flexibleengine_vpc_route_table" "default" {
+  vpc_id = var.vpc_id
+}
+
+# get a custom route table
+data "flexibleengine_vpc_route_table" "custom" {
+  vpc_id = var.vpc_id
+  name   = "demo"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to query the vpc route table.
+  If omitted, the provider-level region will be used.
+
+* `vpc_id` (Required, String) - Specifies the VPC ID where the route table resides.
+
+* `name` (Optional, String) - Specifies the name of the route table.
+
+* `id` (Optional, String) - Specifies the ID of the route table.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `default` (Bool) - Whether the route table is default or not.
+
+* `description` (String) - The supplementary information about the route table.
+
+* `subnets` (List) - An array of one or more subnets associating with the route table.
+
+* `route` (List) - The route object list. The [route object](#route_object) is documented below.
+
+<a name="route_object"></a>
+The `route` block supports:
+
+* `type` (String) - The route type.
+* `destination` (String) - The destination address in the CIDR notation format
+* `nexthop` (String) - The next hop.
+* `description` (String) - The description about the route.

--- a/docs/data-sources/vpc_route_v2.md
+++ b/docs/data-sources/vpc_route_v2.md
@@ -1,8 +1,10 @@
 ---
-subcategory: "Virtual Private Cloud (VPC)"
+subcategory: "Deprecated"
 ---
 
 # Data Source: flexibleengine_vpc_route_v2
+
+!> **WARNING:** It has been deprecated, use `flexibleengine_vpc_route_table` to get the route details.
 
 `flexibleengine_vpc_route_v2` provides details about a specific VPC route.
 

--- a/docs/resources/vpc_route.md
+++ b/docs/resources/vpc_route.md
@@ -1,0 +1,98 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# flexibleengine_vpc_route
+
+Manages a VPC route resource within Flexibleengine.
+
+## Example Usage
+
+### Add route to the default route table
+
+```hcl
+variable "vpc_id" {}
+variable "nexthop" {}
+
+resource "flexibleengine_vpc_route" "vpc_route" {
+  vpc_id      = var.vpc_id
+  destination = "192.168.0.0/16"
+  type        = "peering"
+  nexthop     = var.nexthop
+}
+```
+
+### Add route to a custom route table
+
+```hcl
+variable "vpc_id" {}
+variable "nexthop" {}
+
+data "flexibleengine_vpc_route_table" "rtb" {
+  vpc_id = var.vpc_id
+  name   = "demo"
+}
+
+resource "flexibleengine_vpc_route" "vpc_route" {
+  vpc_id         = var.vpc_id
+  route_table_id = data.flexibleengine_vpc_route_table.rtb.id
+  destination    = "172.16.8.0/24"
+  type           = "ecs"
+  nexthop        = var.nexthop
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the VPC route. If omitted, the provider-level
+  region will be used. Changing this creates a new resource.
+
+* `vpc_id` (Required, String, ForceNew) - Specifies the VPC for which a route is to be added. Changing this creates a
+  new resource.
+
+* `destination` (Required, String, ForceNew) - Specifies the destination address in the CIDR notation format,
+  for example, 192.168.200.0/24. The destination of each route must be unique and cannot overlap with any
+  subnet in the VPC. Changing this creates a new resource.
+
+* `type` (Required, String) - Specifies the route type. Currently, the value can be:
+  **ecs**, **eni**, **vip**, **nat**, **peering**, **vpn** and **dc**.
+
+* `nexthop` (Required, String) - Specifies the next hop.
+  + If the route type is **ecs**, the value is an ECS instance ID in the VPC.
+  + If the route type is **eni**, the value is the extension NIC of an ECS in the VPC.
+  + If the route type is **vip**, the value is a virtual IP address.
+  + If the route type is **nat**, the value is a VPN gateway ID.
+  + If the route type is **peering**, the value is a VPC peering connection ID.
+  + If the route type is **vpn**, the value is a VPN gateway ID.
+  + If the route type is **dc**, the value is a Direct Connect gateway ID.
+
+* `description` (Optional, String) - Specifies the supplementary information about the route.
+  The value is a string of no more than 255 characters and cannot contain angle brackets (< or >).
+
+* `route_table_id` (Optional, String, ForceNew) - Specifies the route table ID for which a route is to be added.
+  If the value is not set, the route will be added to the *default* route table.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The route ID, the format is `<route_table_id>/<destination>`
+
+* `route_table_name` - The name of route table.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `delete` - Default is 10 minute.
+
+## Import
+
+VPC routes can be imported using the route table ID and their `destination` separated by a slash, e.g.
+
+```
+$ terraform import flexibleengine_vpc_route.test &ltroute_table_id&gt/&ltdestination&gt
+```

--- a/docs/resources/vpc_route_table.md
+++ b/docs/resources/vpc_route_table.md
@@ -1,0 +1,125 @@
+---
+subcategory: "Virtual Private Cloud (VPC)"
+---
+
+# flexibleengine_vpc_route_table
+
+Manages a VPC custom route table resource within Flexibleengine.
+
+-> **NOTE:** To use a custom route table, you need to submit a service ticket to increase quota.
+
+## Example Usage
+
+### Basic Custom Route Table
+
+```hcl
+variable "vpc_id" {}
+variable "vpc_peering_id" {}
+
+resource "flexibleengine_vpc_route_table" "demo" {
+  name        = "demo"
+  vpc_id      = var.vpc_id
+  description = "a custom route table demo"
+
+  route {
+    destination = "172.16.0.0/16"
+    type        = "peering"
+    nexthop     = var.vpc_peering_id
+  }
+}
+```
+
+### Associating Subnets with a Route Table
+
+```hcl
+variable "vpc_id" {}
+variable "vpc_peering_id" {}
+
+data "flexibleengine_vpc_subnet_ids_v1" "subnet_ids" {
+  vpc_id = var.vpc_id
+}
+
+resource "flexibleengine_vpc_route_table" "demo" {
+  name    = "demo"
+  vpc_id  = var.vpc_id
+  subnets = data.flexibleengine_vpc_subnet_ids_v1.subnet_ids.ids
+
+  route {
+    destination = "172.16.0.0/16"
+    type        = "peering"
+    nexthop     = var.vpc_peering_id
+  }
+  route {
+    destination = "192.168.100.0/24"
+    type        = "vip"
+    nexthop     = "192.168.10.200"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the vpc route table.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `vpc_id` (Required, String, ForceNew) - Specifies the VPC ID for which a route table is to be added.
+  Changing this creates a new resource.
+
+* `name` (Required, String) - Specifies the route table name. The value is a string of no more than
+  64 characters that can contain letters, digits, underscores (_), hyphens (-), and periods (.).
+
+* `description` (Optional, String) - Specifies the supplementary information about the route table.
+  The value is a string of no more than 255 characters and cannot contain angle brackets (< or >).
+
+* `subnets` (Optional, List) - Specifies an array of one or more subnets associating with the route table.
+
+  -> **NOTE:** The custom route table associated with a subnet affects only the outbound traffic.
+  The default route table determines the inbound traffic.
+
+* `route` (Optional, List) - Specifies the route object list. The [route object](#route_object)
+  is documented below.
+
+<a name="route_object"></a>
+The `route` block supports:
+
+* `destination` (Required, String) - Specifies the destination address in the CIDR notation format,
+  for example, 192.168.200.0/24. The destination of each route must be unique and cannot overlap
+  with any subnet in the VPC.
+
+* `type` (Required, String) - Specifies the route type. Currently, the value can be:
+  **ecs**, **eni**, **vip**, **nat**, **peering**, **vpn** and **dc**.
+
+* `nexthop` (Required, String) - Specifies the next hop.
+  + If the route type is **ecs**, the value is an ECS instance ID in the VPC.
+  + If the route type is **eni**, the value is the extension NIC of an ECS in the VPC.
+  + If the route type is **vip**, the value is a virtual IP address.
+  + If the route type is **nat**, the value is a VPN gateway ID.
+  + If the route type is **peering**, the value is a VPC peering connection ID.
+  + If the route type is **vpn**, the value is a VPN gateway ID.
+  + If the route type is **dc**, the value is a Direct Connect gateway ID.
+
+* `description` (Optional, String) - Specifies the supplementary information about the route.
+  The value is a string of no more than 255 characters and cannot contain angle brackets (< or >).
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `delete` - Default is 10 minute.
+
+## Import
+
+vpc route tables can be imported using the `id`, e.g.
+
+```
+$ terraform import flexibleengine_vpc_route_table.demo e1b3208a-544b-42a7-84e6-5d70371dd982
+```

--- a/docs/resources/vpc_route_v2.md
+++ b/docs/resources/vpc_route_v2.md
@@ -4,6 +4,7 @@ subcategory: "Virtual Private Cloud (VPC)"
 
 # flexibleengine_vpc_route_v2
 
+!> **WARNING:** It has been deprecated, use `flexibleengine_vpc_route` instead.
 Provides a resource to create a route.
 
 ## Example Usage

--- a/flexibleengine/acceptance/data_source_flexibleengine_vpc_route_table_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_vpc_route_table_test.go
@@ -1,0 +1,86 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccVpcRouteTableDataSource_basic(t *testing.T) {
+	rName := acceptance.RandomAccResourceName()
+	dataSourceName := "data.flexibleengine_vpc_route_table.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceRouteTable_base(rName),
+			},
+			{
+				Config: testAccDataSourceRouteTable_default(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "default", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.#", "1"),
+				),
+			},
+			{
+				Config: testAccDataSourceRouteTable_custom(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "default", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "subnets.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceRouteTable_base(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc_v1" "test" {
+  name = "%s"
+  cidr = "172.16.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test" {
+  name       = "%s"
+  cidr       = "172.16.10.0/24"
+  gateway_ip = "172.16.10.1"
+  vpc_id     = flexibleengine_vpc_v1.test.id
+}
+`, rName, rName)
+}
+
+func testAccDataSourceRouteTable_default(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_vpc_route_table" "test" {
+  vpc_id = flexibleengine_vpc_v1.test.id
+}
+`, testAccDataSourceRouteTable_base(rName))
+}
+
+func testAccDataSourceRouteTable_custom(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpc_route_table" "test" {
+  name        = "%s"
+  vpc_id      = flexibleengine_vpc_v1.test.id
+  description = "created by terraform"
+}
+
+data "flexibleengine_vpc_route_table" "test" {
+  vpc_id = flexibleengine_vpc_v1.test.id
+  name   = "%s"
+
+  depends_on = [flexibleengine_vpc_route_table.test]
+}
+`, testAccDataSourceRouteTable_base(rName), rName, rName)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_vpc_route_table_route_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_vpc_route_table_route_test.go
@@ -1,0 +1,115 @@
+package acceptance
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/networking/v1/routetables"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getVpcRTBRouteResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	vpcClient, err := conf.NetworkingV1Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating VPC client: %s", err)
+	}
+
+	parts := strings.SplitN(state.Primary.ID, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("the format of resource ID %s is invalid", state.Primary.ID)
+	}
+
+	routeTableID := parts[0]
+	destination := parts[1]
+	routeTable, err := routetables.Get(vpcClient, routeTableID).Extract()
+	if err != nil {
+		return nil, fmt.Errorf("Error retrieving VPC route table %s: %s", routeTableID, err)
+	}
+
+	var route *routetables.Route
+	for _, item := range routeTable.Routes {
+		if item.DestinationCIDR == destination {
+			route = &item
+			break
+		}
+	}
+	if route == nil {
+		return nil, fmt.Errorf("can not find the vpc route %s with %s", routeTableID, destination)
+	}
+
+	return route, nil
+}
+
+func TestAccVpcRTBRoute_basic(t *testing.T) {
+	var route routetables.Route
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_vpc_route.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&route,
+		getVpcRTBRouteResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcRTBRoute_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "type", "peering"),
+					resource.TestCheckResourceAttr(resourceName, "description", "peering route"),
+					resource.TestCheckResourceAttrSet(resourceName, "route_table_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "route_table_name"),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "nexthop",
+						"${flexibleengine_vpc_peering_connection_v2.test.id}"),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "destination",
+						"${flexibleengine_vpc_v1.test2.cidr}"),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "vpc_id",
+						"${flexibleengine_vpc_v1.test1.id}"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccVpcRTBRoute_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc_v1" "test1" {
+  name = "%s_1"
+  cidr = "172.16.0.0/16"
+}
+
+resource "flexibleengine_vpc_v1" "test2" {
+  name = "%s_2"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_peering_connection_v2" "test" {
+  name        = "%s"
+  vpc_id      = flexibleengine_vpc_v1.test1.id
+  peer_vpc_id = flexibleengine_vpc_v1.test2.id
+}
+
+resource "flexibleengine_vpc_route" "test" {
+  vpc_id      = flexibleengine_vpc_v1.test1.id
+  destination = flexibleengine_vpc_v1.test2.cidr
+  type        = "peering"
+  nexthop     = flexibleengine_vpc_peering_connection_v2.test.id
+  description = "peering route"
+}
+`, rName, rName, rName)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_vpc_route_table_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_vpc_route_table_test.go
@@ -1,0 +1,264 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/networking/v1/routetables"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getRouteTableResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.NetworkingV1Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Flexibleengine Network v1 client: %s", err)
+	}
+	return routetables.Get(c, state.Primary.ID).Extract()
+}
+
+func TestAccVpcRouteTable_basic(t *testing.T) {
+	var route routetables.RouteTable
+
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_vpc_route_table.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&route,
+		getRouteTableResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcRouteTable_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by terraform"),
+					resource.TestCheckResourceAttr(resourceName, "route.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "subnets.#", "0"),
+				),
+			},
+			{
+				Config: testAccVpcRouteTable_route(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "created by terraform with routes"),
+					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "subnets.#", "0"),
+					resource.TestCheckResourceAttr(resourceName, "route.0.destination", "172.16.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "route.0.type", "peering"),
+				),
+			},
+			{
+				Config: testAccVpcRouteTable_associate(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "description", "created by terraform with subnets"),
+					resource.TestCheckResourceAttr(resourceName, "route.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "subnets.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "route.0.destination", "172.16.0.0/16"),
+					resource.TestCheckResourceAttr(resourceName, "route.0.type", "peering"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccVpcRouteTable_multiRoutes(t *testing.T) {
+	var route routetables.RouteTable
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_vpc_route_table.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&route,
+		getRouteTableResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVpcRouteTable_multiRoutes(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "created by terraform with multi routes"),
+					resource.TestCheckResourceAttr(resourceName, "route.#", "6"),
+					resource.TestCheckResourceAttr(resourceName, "subnets.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccVpcRouteTable_base(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc_v1" "test1" {
+  name = "%s-1"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test1-1" {
+  name       = "%s-1-1"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = flexibleengine_vpc_v1.test1.id
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test1-2" {
+  name       = "%s-1-2"
+  cidr       = "192.168.10.0/24"
+  gateway_ip = "192.168.10.1"
+  vpc_id     = flexibleengine_vpc_v1.test1.id
+}
+
+resource "flexibleengine_vpc_v1" "test2" {
+  name = "%s-2"
+  cidr = "172.16.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test2-1" {
+  name       = "%s-2-1"
+  cidr       = "172.16.10.0/24"
+  gateway_ip = "172.16.10.1"
+  vpc_id     = flexibleengine_vpc_v1.test2.id
+}
+`, rName, rName, rName, rName, rName)
+}
+
+func testAccVpcRouteTable_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpc_route_table" "test" {
+  name        = "%s"
+  vpc_id      = flexibleengine_vpc_v1.test1.id
+  description = "created by terraform"
+}
+`, testAccVpcRouteTable_base(rName), rName)
+}
+
+func testAccVpcRouteTable_route(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpc_peering_connection_v2" "test" {
+  name        = "%s"
+  vpc_id      = flexibleengine_vpc_v1.test1.id
+  peer_vpc_id = flexibleengine_vpc_v1.test2.id
+}
+
+resource "flexibleengine_vpc_route_table" "test" {
+  name        = "%s"
+  vpc_id      = flexibleengine_vpc_v1.test1.id
+  description = "created by terraform with routes"
+
+  route {
+    destination = "172.16.0.0/16"
+    type        = "peering"
+    nexthop     = flexibleengine_vpc_peering_connection_v2.test.id
+    description = "peering rule"
+  }
+}
+`, testAccVpcRouteTable_base(rName), rName, rName)
+}
+
+func testAccVpcRouteTable_associate(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpc_peering_connection_v2" "test" {
+  name        = "%s"
+  vpc_id      = flexibleengine_vpc_v1.test1.id
+  peer_vpc_id = flexibleengine_vpc_v1.test2.id
+}
+
+resource "flexibleengine_vpc_route_table" "test" {
+  name        = "%s"
+  vpc_id      = flexibleengine_vpc_v1.test1.id
+  description = "created by terraform with subnets"
+
+  subnets     = [
+    flexibleengine_vpc_subnet_v1.test1-1.id,
+    flexibleengine_vpc_subnet_v1.test1-2.id,
+  ]
+
+  route {
+    destination = "172.16.0.0/16"
+    type        = "peering"
+    nexthop     = flexibleengine_vpc_peering_connection_v2.test.id
+    description = "peering rule"
+  }
+}
+`, testAccVpcRouteTable_base(rName), rName, rName)
+}
+
+func testAccVpcRouteTable_multiRoutes(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpc_peering_connection_v2" "test" {
+  name        = "%s"
+  vpc_id      = flexibleengine_vpc_v1.test1.id
+  peer_vpc_id = flexibleengine_vpc_v1.test2.id
+}
+
+resource "flexibleengine_vpc_route_table" "test" {
+  name        = "%s"
+  vpc_id      = flexibleengine_vpc_v1.test1.id
+  description = "created by terraform with multi routes"
+
+  route {
+    destination = "172.16.1.0/24"
+    type        = "peering"
+    nexthop     = flexibleengine_vpc_peering_connection_v2.test.id
+    description = "peering one rule"
+  }
+  route {
+    destination = "172.16.2.0/24"
+    type        = "peering"
+    nexthop     = flexibleengine_vpc_peering_connection_v2.test.id
+    description = "peering two rule"
+  }
+  route {
+    destination = "172.16.3.0/24"
+    type        = "peering"
+    nexthop     = flexibleengine_vpc_peering_connection_v2.test.id
+    description = "peering three rule"
+  }
+  route {
+    destination = "172.16.4.0/24"
+    type        = "peering"
+    nexthop     = flexibleengine_vpc_peering_connection_v2.test.id
+    description = "peering four rule"
+  }
+  route {
+    destination = "172.16.5.0/24"
+    type        = "peering"
+    nexthop     = flexibleengine_vpc_peering_connection_v2.test.id
+    description = "peering five rule"
+  }
+  route {
+    destination = "172.16.6.0/24"
+    type        = "peering"
+    nexthop     = flexibleengine_vpc_peering_connection_v2.test.id
+    description = "peering six rule"
+  }
+}
+`, testAccVpcRouteTable_base(rName), rName, rName)
+}

--- a/flexibleengine/data_source_flexibleengine_vpc_route_ids_v2_test.go
+++ b/flexibleengine/data_source_flexibleengine_vpc_route_ids_v2_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccFlexibleEngineVpcRouteIdsV2DataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckDeprecated(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/flexibleengine/data_source_flexibleengine_vpc_route_v2_test.go
+++ b/flexibleengine/data_source_flexibleengine_vpc_route_v2_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccFlexibleEngineVpcRouteV2DataSource_basic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckDeprecated(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -279,6 +279,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_identity_users":     iam.DataSourceIdentityUsers(),
 			"flexibleengine_sfs_turbos":         sfs.DataSourceTurbos(),
 			"flexibleengine_smn_topics":         smn.DataSourceTopics(),
+			"flexibleengine_vpc_route_table":    vpc.DataSourceVPCRouteTable(),
 
 			"flexibleengine_modelarts_datasets":         modelarts.DataSourceDatasets(),
 			"flexibleengine_modelarts_dataset_versions": modelarts.DataSourceDatasetVerions(),
@@ -462,6 +463,8 @@ func Provider() *schema.Provider {
 			"flexibleengine_tms_tags": tms.ResourceTmsTag(),
 
 			"flexibleengine_vpc_eip_associate": eip.ResourceEIPAssociate(),
+			"flexibleengine_vpc_route_table":   vpc.ResourceVPCRouteTable(),
+			"flexibleengine_vpc_route":         vpc.ResourceVPCRouteTableRoute(),
 
 			"flexibleengine_lb_loadbalancer_v3": elb.ResourceLoadBalancerV3(),
 			"flexibleengine_lb_listener_v3":     elb.ResourceListenerV3(),

--- a/flexibleengine/resource_flexibleengine_vpc_route_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_vpc_route_v2_test.go
@@ -15,7 +15,7 @@ func TestAccFlexibleEngineVpcRouteV2_basic(t *testing.T) {
 	resourceName := "flexibleengine_vpc_route_v2.route_1"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckDeprecated(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckFlexibleEngineRouteV2Destroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
add new resources route_table and route
**Test results**:
```
make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccVpcRouteTable_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccVpcRouteTable_basic -timeout 720m
=== RUN   TestAccVpcRouteTable_basic
=== PAUSE TestAccVpcRouteTable_basic
=== CONT  TestAccVpcRouteTable_basic
--- PASS: TestAccVpcRouteTable_basic (123.13s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      123.301s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccVpcRouteTable_multiRoutes'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccVpcRouteTable_multiRoutes -timeout 720m
=== RUN   TestAccVpcRouteTable_multiRoutes
=== PAUSE TestAccVpcRouteTable_multiRoutes
=== CONT  TestAccVpcRouteTable_multiRoutes
--- PASS: TestAccVpcRouteTable_multiRoutes (65.45s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      65.593s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccVpcRTBRoute_basic '
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccVpcRTBRoute_basic -timeout 720m
=== RUN   TestAccVpcRTBRoute_basic
=== PAUSE TestAccVpcRTBRoute_basic
=== CONT  TestAccVpcRTBRoute_basic
--- PASS: TestAccVpcRTBRoute_basic (62.97s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      63.074s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccVpcRouteTableDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccVpcRouteTableDataSource_basic -timeout 720m
=== RUN   TestAccVpcRouteTableDataSource_basic
=== PAUSE TestAccVpcRouteTableDataSource_basic
=== CONT  TestAccVpcRouteTableDataSource_basic
--- PASS: TestAccVpcRouteTableDataSource_basic (106.03s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      106.139s
```