### PR TITLE
feat(dli): add new dli resources

### DIFF
--- a/docs/resources/dli_database.md
+++ b/docs/resources/dli_database.md
@@ -1,0 +1,53 @@
+---
+subcategory: "Data Lake Insight (DLI)"
+---
+
+# flexibleengine_dli_database
+
+Manages DLI SQL database resource within Flexibleengine.
+
+## Example Usage
+
+### Create a database
+
+```hcl
+variable "database_name" {}
+
+resource "flexibleengine_dli_database" "test" {
+  name = var.database_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the DLI database resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new database resource.
+
+* `name` - (Required, String, ForceNew) Specifies the database name. The name consists of 1 to 128 characters, starting
+  with a letter or digit. Only letters, digits and underscores (_) are allowed and the name cannot be all digits.
+  Changing this parameter will create a new database resource.
+
+* `description` - (Optional, String, ForceNew) Specifies the description of a queue.
+  Changing this parameter will create a new database resource.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID.
+  The value 0 indicates the default enterprise project. Changing this parameter will create a new database resource.
+
+* `owner` - (Optional, String) Specifies the name of the SQL database owner.
+  The owner must be IAM user.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Resource ID. For database resources, the ID is the database name.
+
+## Import
+
+DLI SQL databases can be imported by their `name`, e.g.
+
+```
+$ terraform import flexibleengine_dli_database.test terraform_test
+```

--- a/docs/resources/dli_flinksql_job.md
+++ b/docs/resources/dli_flinksql_job.md
@@ -1,0 +1,140 @@
+---
+subcategory: "Data Lake Insight (DLI)"
+---
+
+# flexibleengine_dli_flinksql_job
+
+Manages a flink sql job resource within Flexibleengine DLI.
+
+## Example Usage
+
+### Create a flink job
+
+```hcl
+variable "sql" {}
+variable "jobName" {}
+
+resource "flexibleengine_dli_flinksql_job" "test" {
+  name = var.jobName
+  type = "flink_sql_job"
+  sql  = var.sql
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the DLI flink job resource. If omitted, the
+  provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the name of the job. Length range: 1 to 57 characters.
+ which may consist of letters, digits, underscores (_) and hyphens (-).
+
+* `type` - (Optional, String, ForceNew) Specifies the type of the job. The valid values are `flink_sql_job`,
+ `flink_opensource_sql_job` and `flink_sql_edge_job`. Default value is `flink_sql_job`.
+  Changing this parameter will create a new resource.
+
+* `run_mode` - (Optional, String) Specifies job running mode. The options are as follows:
+
+  + **shared_cluster**: indicates that the job is running on a shared cluster.
+  + **exclusive_cluster**: indicates that the job is running on an exclusive cluster.
+  + **edge_node**: indicates that the job is running on an edge node.
+  
+  The default value is `shared_cluster`.
+
+* `description` - (Optional, String) Specifies job description. Length range: 1 to 512 characters.
+
+* `queue_name` - (Optional, String) Specifies name of a queue.
+
+* `sql` - (Optional, String) Specifies stream SQL statement, which includes at least the following
+ three parts: source, query, and sink. Length range: 1024x1024 characters.
+
+* `cu_number` - (Optional, Int) Specifies number of CUs selected for a job. The default value is 2.
+
+* `parallel_number` - (Optional, Int) Specifies number of parallel for a job. The default value is 1.
+
+* `checkpoint_enabled` - (Optional, Bool) Specifies whether to enable the automatic job snapshot function.
+  + **true**: indicates to enable the automatic job snapshot function.
+  + **false**: indicates to disable the automatic job snapshot function.
+
+  Default value: false
+
+* `checkpoint_mode` - (Optional, Int) Specifies snapshot mode. There are two options:
+  + **exactly_once**: indicates that data is processed only once.
+  + **at_least_once**: indicates that data is processed at least once.
+
+  The default value is 1.
+
+* `checkpoint_interval` - (Optional, Int) Specifies snapshot interval. The unit is second.
+  The default value is 10.
+
+* `obs_bucket` - (Optional, String) Specifies OBS path. OBS path where users are authorized to save the
+  snapshot. This parameter is valid only when `checkpoint_enabled` is set to `true`. OBS path where users are authorized
+  to save the snapshot. This parameter is valid only when `log_enabled` is set to `true`.
+
+* `log_enabled` - (Optional, Bool) Specifies whether to enable the function of uploading job logs to
+  users' OBS buckets. The default value is false.
+  
+* `smn_topic` - (Optional, String) Specifies SMN topic. If a job fails, the system will send a message to
+ users subscribed to the SMN topic.
+  
+* `restart_when_exception` - (Optional, Bool) Specifies whether to enable the function of automatically
+ restarting a job upon job exceptions. The default value is false.
+  
+* `idle_state_retention` - (Optional, String) Specifies retention time of the idle state. The unit is hour.
+ The default value is 1.
+
+* `edge_group_ids` - (Optional, List) Specifies edge computing group IDs.
+  
+* `dirty_data_strategy` - (Optional, String) Specifies dirty data policy of a job.
+  + **2:obsDir**: Save the dirty data to the obs path `obsDir`. For example: `2:yourBucket/output_path`
+  + **1**: Trigger a job exception
+  + **0**: Ignore
+
+  The default value is `0`.
+  
+* `udf_jar_url` - (Optional, String) Specifies name of the resource package that has been uploaded to the
+  DLI resource management system. The UDF Jar file of the SQL job is specified by this parameter.
+  
+* `manager_cu_number` - (Optional, Int) Specifies number of CUs in the JobManager selected for a job.
+ The default value is 1.
+  
+* `tm_cus` - (Optional, Int) Specifies number of CUs for each Task Manager. The default value is 1.
+  
+* `tm_slot_num` - (Optional, Int) Specifies number of slots in each Task Manager.
+ The default value is (**parallel_number** * **tm_cus**)/(**cu_number** - **manager_cu_number**).
+  
+* `resume_checkpoint` - (Optional, Bool) Specifies whether the abnormal restart is recovered from the
+ checkpoint.
+  
+* `resume_max_num` - (Optional, Int) Specifies maximum number of retry times upon exceptions. The unit is
+ `times/hour`. Value range: `-1` or greater than `0`. The default value is `-1`, indicating that the number of times is
+ unlimited.
+
+* `runtime_config` - (Optional, Map) Specifies customizes optimization parameters when a Flink job is
+ running.
+
+* `tags` - (Optional, Map, ForceNew) Specifies the key/value pairs to associate with the resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The Job ID in Int format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `update` - Default is 20 minute.
+* `delete` - Default is 20 minute.
+
+## Import
+
+Clusters can be imported by their `id`. For example,
+
+```
+terraform import flexibleengine_dli_flinksql_job.test 12345
+```

--- a/docs/resources/dli_package.md
+++ b/docs/resources/dli_package.md
@@ -1,0 +1,63 @@
+---
+subcategory: "Data Lake Insight (DLI)"
+---
+
+# flexibleengine_dli_package
+
+Manages DLI package resource within Flexibleengine
+
+## Example Usage
+
+### Upload the specified python script as a resource package
+
+```hcl
+variable "group_name" {}
+variable "access_domain_name" {}
+
+resource "flexibleengine_dli_package" "queue" {
+  group_name  = var.group_name
+  object_path = "https://${var.access_domain_name}/dli/packages/object_file.py"
+  type        = "pyFile"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to upload packages.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will delete the current package and upload a new package.
+
+* `group_name` - (Required, String, ForceNew) Specifies the group name which the package belongs to.
+  Changing this parameter will delete the current package and upload a new package.
+
+* `type` - (Required, String, ForceNew) Specifies the package type.
+  + **jar**: `.jar` or jar related files.
+  + **pyFile**: `.py` or python related files.
+  + **file**: Other user files.
+
+  Changing this parameter will delete the current package and upload a new package.
+
+* `object_path` - (Required, String, ForceNew) Specifies the OBS storage path where the package is located.
+  For example, `https://{bucket_name}.oss.{region}.prod-cloud-ocb.orange-business.com/dli/packages/object_file.py`.
+  Changing this parameter will delete the current package and upload a new package.
+
+* `is_async` - (Optional, Bool, ForceNew) Specifies whether to upload resource packages in asynchronous mode.
+  The default value is **false**. Changing this parameter will delete the current package and upload a new package.
+
+* `owner` - (Optional, String) Specifies the name of the package owner. The owner must be IAM user.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Resource ID. The ID is constructed from the `group_name` and `object_name`, separated by slash.
+
+* `object_name` - The package name.
+
+* `status` - Status of a package group to be uploaded.
+
+* `created_at` - Time when a queue is created.
+
+* `updated_at` - The last time when the package configuration update has complated.

--- a/docs/resources/dli_spark_job.md
+++ b/docs/resources/dli_spark_job.md
@@ -1,0 +1,141 @@
+---
+subcategory: "Data Lake Insight (DLI)"
+---
+
+# flexibleengine_dli_spark_job
+
+Manages spark job resource of DLI within Flexibleengine
+
+## Example Usage
+
+### Submit a new spark job with jar packages
+
+```hcl
+variables "queue_name" {}
+variables "job_name" {}
+
+resource "flexibleengine_dli_spark_job" "default" {
+  queue_name    = var.queue_name
+  name          = var.job_name
+  app_name      = "driver_package/driver_behavior.jar"
+  main_class    = "driver_behavior"
+  specification = "B"
+  max_retries   = 20
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to submit a spark job.
+  If omitted, the provider-level region will be used.
+  Changing this parameter will submit a new spark job.
+
+* `queue_name` - (Required, String, ForceNew) Specifies the DLI queue name.
+  Changing this parameter will submit a new spark job.
+
+* `name` - (Required, String, ForceNew) Specifies the spark job name.
+  The value contains a maximum of 128 characters.
+  Changing this parameter will submit a new spark job.
+
+* `app_name` - (Required, String, ForceNew) Specifies the name of the package that is of the JAR or python file type and
+  has been uploaded to the DLI resource management system.
+  The OBS paths are allowed, for example, `obs://<bucket name>/<package name>`.
+  Changing this parameter will submit a new spark job.
+
+* `app_parameters` - (Optional, String, ForceNew) Specifies the input parameters of the main class.
+  Changing this parameter will submit a new spark job.
+
+* `main_class` - (Optional, String, ForceNew) Specifies the main class of the spark job.
+  Required if the `app_name` is the JAR type.
+  Changing this parameter will submit a new spark job.
+
+* `jars` - (Optional, List, ForceNew) Specifies a list of the jar package name which has been uploaded to the DLI
+  resource management system. The OBS paths are allowed, for example, `obs://<bucket name>/<package name>`.
+  Changing this parameter will submit a new spark job.
+
+* `python_files` - (Optional, List, ForceNew) Specifies a list of the python file name which has been uploaded to the
+  DLI resource management system. The OBS paths are allowed, for example, `obs://<bucket name>/<python file name>`.
+  Changing this parameter will submit a new spark job.
+
+* `files` - (Optional, List, ForceNew) Specifies a list of the other dependencies name which has been uploaded to the
+  DLI resource management system. The OBS paths are allowed, for example, `obs://<bucket name>/<dependent files>`.
+  Changing this parameter will submit a new spark job.
+
+* `dependent_packages` - (Optional, List, ForceNew) Specifies a list of package resource objects.
+  The object structure is documented below.
+  Changing this parameter will submit a new spark job.
+
+* `configurations` - (Optional, Map, ForceNew) Specifies the configuration items of the DLI spark.
+  Please following the document of Spark [configurations](https://spark.apache.org/docs/latest/configuration.html) for
+  this argument. If you want to enable the `access metadata` of DLI spark in Flexibleengine, please set
+  `spark.dli.metaAccess.enable` to `true`. Changing this parameter will submit a new spark job.
+
+* `modules` - (Optional, List, ForceNew) Specifies a list of modules that depend on system resources.
+  The dependent modules and corresponding services are as follows.
+  Changing this parameter will submit a new spark job.
+  + **sys.datasource.hbase**: CloudTable/MRS HBase
+  + **sys.datasource.opentsdb**: CloudTable/MRS OpenTSDB
+  + **sys.datasource.rds**: RDS MySQL
+  + **sys.datasource.css**: CSS
+
+* `specification` - (Optional, String, ForceNew) Specifies the compute resource type for spark application.
+  The available types and related specifications are as follows, default to minimum configuration (type **A**).
+  Changing this parameter will submit a new spark job.
+
+  | type | resource | driver cores | excutor cores | driver memory | executor memory | num executor |
+  | ---- | ---- | ---- | ---- | ---- | ---- | ---- |
+  | A | 8 vCPUs, 32-GB memory | 2 | 1 | 7G | 4G | 6 |
+  | B | 16 vCPUs, 64-GB memory | 2 | 2 | 7G | 8G | 7 |
+  | C | 32 vCPUs, 128-GB memory | 4 | 2 | 12G | 8G | 14 |
+
+* `executor_memory` - (Optional, String, ForceNew) Specifies the executor memory of the spark application.
+  application. The default value of this value corresponds to the configuration of the selected `specification`.
+  If you set this value instead of the default value, `specification` will be invalid.
+  Changing this parameter will submit a new spark job.
+
+  ->**NOTE:** The unit must be provided, such as **GB** or **MB**.
+
+* `executor_cores` - (Optional, Int, ForceNew) Specifies the number of CPU cores of each executor in the Spark
+  application. The default value of this value corresponds to the configuration of the selected `specification`.
+  If you set this value instead of the default value, `specification` will be invalid.
+  Changing this parameter will submit a new spark job.
+
+* `executors` - (Optional, Int, ForceNew) Specifies the number of executors in a spark application.
+  The default value of this value corresponds to the configuration of the selected `specification`.
+  If you set this value instead of the default value, `specification` will be invalid.
+  Changing this parameter will submit a new spark job.
+
+* `driver_memory` - (Optional, String, ForceNew) Specifies the driver memory of the spark application.
+  The default value of this value corresponds to the configuration of the selected `specification`.
+  If you set this value instead of the default value, `specification` will be invalid.
+  Changing this parameter will submit a new spark job.
+
+* `driver_cores` - (Optional, Int, ForceNew) Specifies the number of CPU cores of the Spark application driver.
+  The default value of this value corresponds to the configuration of the selected `specification`.
+  If you set this value instead of the default value, `specification` will be invalid.
+  Changing this parameter will submit a new spark job.
+
+* `max_retries` - (Optional, Int, ForceNew) Specifies the maximum retry times.
+  The default value of this value corresponds to the configuration of the selected `specification`.
+  If you set this value instead of the default value, `specification` will be invalid.
+  Changing this parameter will submit a new spark job.
+
+The `dependent_packages` block supports:
+
+* `type` - (Required, String, ForceNew) Specifies the resource type of the package.
+  Changing this parameter will submit a new spark job.
+
+* `package_name` - (Required, String, ForceNew) Specifies the resource name of the package.
+  Changing this parameter will submit a new spark job.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - ID of the spark job.
+
+* `created_at` - Time of the DLI spark job submit.
+
+* `owner` - The owner of the spark job.

--- a/docs/resources/dli_table.md
+++ b/docs/resources/dli_table.md
@@ -1,0 +1,142 @@
+---
+subcategory: "Data Lake Insight (DLI)"
+---
+
+# flexibleengine_dli_table
+
+Manages DLI Table resource within Flexibleengine
+
+## Example Usage
+
+### Create a Table
+
+```hcl
+variable "database_name" {}
+
+resource "flexibleengine_dli_database" "test" {
+  name = var.database_name
+}
+
+resource "flexibleengine_obs_bucket" "test" {
+  bucket = "test"
+  acl    = "private"
+}
+
+
+resource "flexibleengine_obs_bucket_object" "test" {
+  bucket       = flexibleengine_obs_bucket.test.bucket
+  key          = "user/data/user.csv"
+  content      = "Jason,Tokyo"
+  content_type = "text/plain"
+}
+
+resource "flexibleengine_dli_table" "test" {
+  database_name   = flexibleengine_dli_database.test.name
+  name            = "test"
+  data_location   = "OBS"
+  description     = "dli table test"
+  data_format     = "csv"
+  bucket_location = "obs://${flexibleengine_obs_bucket_object.test.bucket}/user/data"
+
+  columns {
+    name = "name"
+    type        = "string"
+    description = "person name"
+  }
+
+  columns {
+    name = "addrss"
+    type        = "string"
+    description = "home address"
+  }
+
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the dli table resource. If omitted,
+  the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the table name. The name can contain only digits, letters,
+ and underscores, but cannot contain only digits or start with an underscore. Length range: 1 to 128 characters.
+ Changing this parameter will create a new resource.
+
+* `database_name` - (Required, String, ForceNew) Specifies the database name which the table belongs to.
+ Changing this parameter will create a new resource.
+
+* `data_location` - (Required, String, ForceNew) Specifies data storage location. Changing this parameter will create
+  a newresource. The options are as follows:
+  + **OBS**: Data stored in OBS tables is applicable to delay-insensitive services, such as historical data statistics
+   and analysis.
+
+* `description` - (Optional, String, ForceNew) Specifies description of the table.
+  Changing this parameter will create a new resource.
+
+* `columns` - (Optional, List, ForceNew) Specifies Columns of the new table. Structure is documented below.
+  Changing this parameter will create a new resource.
+
+* `data_format` - (Optional, String, ForceNew) Specifies type of the data to be added to the OBS table.
+ The options: parquet, orc, csv, json, carbon, and avro. Changing this parameter will create a new resource.
+
+* `bucket_location` - (Optional, String, ForceNew) Specifies storage path of data which will be import to the OBS table.
+ Changing this parameter will create a new resource.
+ -> If you need to import data stored in OBS to the OBS table, set this parameter to the path of a folder. If the table
+  creation path is a file, data fails to be imported. which must be a path on OBS and must begin with obs.
+
+* `with_column_header` - (Optional, Bool, ForceNew) Specifies whether the table header is included in the data file.
+  Only data in CSV files has this attribute. Changing this parameter will create a new resource.
+
+* `delimiter` - (Optional, String, ForceNew) Specifies data delimiter. Only data in CSV files has this
+  attribute. Changing this parameter will create a new resource.
+
+* `quote_char` - (Optional, String, ForceNew) Specifies reference character. Double quotation marks (`\`)
+ are used by default. Only data in CSV files has this attribute. Changing this parameter will create a new resource.
+
+* `escape_char` - (Optional, String, ForceNew) Specifies escape character. Backslashes (`\\`) are used by
+ default. Only data in CSV files has this attribute. Changing this parameter will create a new resource.
+
+* `date_format` - (Optional, String, ForceNew) Specifies date type. `yyyy-MM-dd` is used by default. Only
+ data in CSV and JSON files has this attribute. Changing this parameter will create a new resource.
+
+* `timestamp_format` - (Optional, String, ForceNew) Specifies timestamp type. `yyyy-MM-dd HH:mm:ss` is used by default.
+ Only data in CSV and JSON files has this attribute. Changing this parameter will create a new resource.
+
+The `column` block supports:
+
+  * `name` - (Required, String, ForceNew) Specifies the name of column. Changing this parameter will create a new
+   resource.
+  * `type` - (Required, String, ForceNew) Specifies data type of column. Changing this parameter will create a new
+   resource.
+  * `description` - (Required, String, ForceNew) Specifies the description of column. Changing this parameter will
+   create a new resource.
+  * `is_partition` - (Required, Bool, ForceNew) Specifies whether the column is a partition column. The value
+    `true` indicates a partition column, and the value false indicates a non-partition column. The default value
+     is false. Changing this parameter will create a new resource.
+  
+  -> When creating a partition table, ensure that at least one column in the table is a non-partition column.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A resource ID in format of **database_name/table_name**. It is composed of the name of database which table
+ belongs and the name of table, separated by a slash.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `Delete` - Default is 10 minute.
+
+## Import
+
+DLI table can be imported by `id`. It is composed of the name of database which table belongs and the name of table,
+ separated by a slash. For example,
+
+```
+terraform import flexibleengine_dli_table.example <database_name>/<table_name>
+```

--- a/flexibleengine/acceptance/acceptance.go
+++ b/flexibleengine/acceptance/acceptance.go
@@ -20,6 +20,7 @@ var (
 	OS_REGION_NAME            = os.Getenv("OS_REGION_NAME")
 	OS_ACCESS_KEY             = os.Getenv("OS_ACCESS_KEY")
 	OS_SECRET_KEY             = os.Getenv("OS_SECRET_KEY")
+	OS_PROJECT_ID             = os.Getenv("OS_PROJECT_ID")
 
 	OS_VPC_ID     = os.Getenv("OS_VPC_ID")
 	OS_NETWORK_ID = os.Getenv("OS_NETWORK_ID")
@@ -30,9 +31,10 @@ var (
 	OS_KEYPAIR_NAME = os.Getenv("OS_KEYPAIR_NAME")
 	OS_FGS_BUCKET   = os.Getenv("OS_FGS_BUCKET")
 
-	OS_DEST_REGION         = os.Getenv("OS_DEST_REGION")
-	OS_DEST_PROJECT_ID     = os.Getenv("OS_DEST_PROJECT_ID")
-	OS_SWR_SHARING_ACCOUNT = os.Getenv("OS_SWR_SHARING_ACCOUNT")
+	OS_DEST_REGION            = os.Getenv("OS_DEST_REGION")
+	OS_DEST_PROJECT_ID        = os.Getenv("OS_DEST_PROJECT_ID")
+	OS_SWR_SHARING_ACCOUNT    = os.Getenv("OS_SWR_SHARING_ACCOUNT")
+	OS_DLI_FLINK_JAR_OBS_PATH = os.Getenv("OS_DLI_FLINK_JAR_OBS_PATH")
 )
 
 // TestAccProviderFactories is a static map containing only the main provider instance
@@ -105,5 +107,11 @@ func testAccPreCheckSWRDomian(t *testing.T) {
 	if OS_SWR_SHARING_ACCOUNT == "" {
 		t.Skip("OS_SWR_SHARING_ACCOUNT must be set for swr domian tests, " +
 			"the value of OS_SWR_SHARING_ACCOUNT should be another IAM user name")
+	}
+}
+
+func testAccPreCheckDliJarPath(t *testing.T) {
+	if OS_DLI_FLINK_JAR_OBS_PATH == "" {
+		t.Skip("OS_DLI_FLINK_JAR_OBS_PATH must be set for DLI Flink Jar job acceptance tests.")
 	}
 }

--- a/flexibleengine/acceptance/resource_flexibleengine_dli_database_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_dli_database_test.go
@@ -1,0 +1,68 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/dli/v1/databases"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
+)
+
+func getDatabaseResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.DliV1Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Flexibleengine DLI v1 client: %s", err)
+	}
+
+	return dli.GetDliSqlDatabaseByName(c, state.Primary.ID)
+}
+
+func TestAccDliDatabase_basic(t *testing.T) {
+	var database databases.Database
+
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_dli_database.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&database,
+		getDatabaseResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDliDatabase_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "description", "For terraform acc test"),
+					resource.TestCheckResourceAttrSet(resourceName, "owner"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDliDatabase_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_dli_database" "test" {
+  name                  = "%s"
+  description           = "For terraform acc test"
+}
+`, rName)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_dli_flinksql_job_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_dli_flinksql_job_test.go
@@ -1,0 +1,153 @@
+package acceptance
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/dli/v1/flinkjob"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func getDliFlinkSqlJobResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := config.DliV1Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmtp.Errorf("error creating Dli v1 client, err=%s", err)
+	}
+	jobId, _ := strconv.Atoi(state.Primary.ID)
+	return flinkjob.Get(client, jobId)
+}
+
+func TestAccResourceDliFlinkJob_basic(t *testing.T) {
+	var obj flinkjob.CreateSqlJobOpts
+	resourceName := "flexibleengine_dli_flinksql_job.test"
+	name := acceptance.RandomAccResourceName()
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&obj,
+		getDliFlinkSqlJobResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFlinkJobResource_basic(name, OS_REGION_NAME),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "status", "job_running"),
+					resource.TestCheckResourceAttr(resourceName, "type", "flink_sql_job"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{},
+			},
+		},
+	})
+}
+
+func testAccFlinkJobResource_basic(name string, region string) string {
+	return fmt.Sprintf(`
+variable "sql" {
+  type    = string
+  default = <<EOF
+CREATE SOURCE STREAM car_infos (
+  car_id STRING,
+  car_owner STRING,
+  car_brand STRING,
+  car_price INT
+)
+WITH (
+  type = "dis",
+  region = "%s",
+  channel = "%s_input",
+  partition_count = "1",
+  encode = "csv",
+  field_delimiter = ","
+);
+
+CREATE SINK STREAM audi_cheaper_than_30w (
+  car_id STRING,
+  car_owner STRING,
+  car_brand STRING,
+  car_price INT
+)
+WITH (
+  type = "dis",
+  region = "%s",
+  channel = "%s_output",
+  partition_key = "car_owner",
+  encode = "csv",
+  field_delimiter = ","
+);
+
+INSERT INTO audi_cheaper_than_30w
+SELECT *
+FROM car_infos
+WHERE car_brand = "audia4" and car_price < 30;
+
+
+CREATE SINK STREAM car_info_data (
+  car_id STRING,
+  car_owner STRING,
+  car_brand STRING,
+  car_price INT
+)
+WITH (
+  type ="dis",
+  region = "%s",
+  channel = "%s_input",
+  partition_key = "car_owner",
+  encode = "csv",
+  field_delimiter = ","
+);
+
+INSERT INTO car_info_data
+SELECT "1", "lilei", "bmw320i", 28;
+INSERT INTO car_info_data
+SELECT "2", "hanmeimei", "audia4", 27;
+EOF
+
+}
+
+
+resource "flexibleengine_dis_stream" "stream_input" {
+  name     = "%s_input"
+  partition_count = 1
+}
+
+resource "flexibleengine_dis_stream" "stream_output" {
+  name     = "%s_output"
+  partition_count = 1
+
+}
+
+resource "flexibleengine_dli_flinksql_job" "test" {
+  name           = "%s"
+  type           = "flink_sql_job"
+  sql            = var.sql
+  depends_on = [
+    flexibleengine_dis_stream.stream_input,
+    flexibleengine_dis_stream.stream_output,
+  ]
+
+  lifecycle {
+    ignore_changes = [
+      resume_max_num,
+    ]
+  }
+}
+`, region, name, region, name, region, name, name, name, name)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_dli_package_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_dli_package_test.go
@@ -1,0 +1,137 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/dli/v2/spark/resources"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
+)
+
+func getPackageResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.DliV2Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Flexibleengine DLI v2 client: %s", err)
+	}
+
+	return dli.GetDliDependentPackageInfo(c, state.Primary.ID)
+}
+
+func TestAccDliPackage_basic(t *testing.T) {
+	var pkg resources.Resource
+
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "flexibleengine_dli_package.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&pkg,
+		getPackageResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDliPackage_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "group_name", rName),
+					resource.TestCheckResourceAttr(resourceName, "type", "pyFile"),
+					resource.TestCheckResourceAttr(resourceName, "object_path", fmt.Sprintf(
+						"https://%s.oss.%s.prod-cloud-ocb.orange-business.com/dli/packages/simple_pyspark_test_DLF_refresh.py",
+						rName, OS_REGION_NAME)),
+					resource.TestCheckResourceAttr(resourceName, "object_name", "simple_pyspark_test_DLF_refresh.py"),
+					resource.TestCheckResourceAttr(resourceName, "status", "READY"),
+					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
+					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDliPackage_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_obs_bucket" "test" {
+  bucket = "%s"
+  acl    = "private"
+}
+
+resource "flexibleengine_obs_bucket_object" "test" {
+  bucket  = flexibleengine_obs_bucket.test.bucket
+  key     = "dli/packages/simple_pyspark_test_DLF_refresh.py"
+  content = <<EOF
+#!/usr/bin/env python
+# _*_ coding: utf-8 _*_
+
+import sys
+import logging
+from operator import add
+import time
+
+from pyspark.sql import SparkSession
+from pyspark.sql import SQLContext
+
+sparkSession = SparkSession.builder.appName("simple pyspark test DLF refresh").getOrCreate()
+sc = SQLContext(sparkSession.sparkContext)
+
+logging.basicConfig(format='%%(message)s', level=logging.INFO)
+logger = logging.getLogger("Whatever")
+logger.info("[DBmethods.py] HELLOOOOOOOOOOO")
+
+
+sc._jsc.hadoopConfiguration().set("fs.obs.access.key", "%s")
+sc._jsc.hadoopConfiguration().set("fs.obs.secret.key", "%s")
+sc._jsc.hadoopConfiguration().set("fs.obs.endpoint", "oss.eu-west-0.prod-cloud-ocb.orange-business.com")
+
+
+# Read private bucket with encryption using AK/SK
+private_encrypted_file = "obs://dedicated-for-terraform-acc-test/dli/spark/people.csv"
+
+df = sparkSession.read.options(header='True', inferSchema='True', delimiter=',').csv(private_encrypted_file)
+df.show()
+df.printSchema()
+print(df)
+print(df.count())
+print(time.time())
+
+
+my_string_to_print = "{} - {}".format(int(time.time()), df.count()/2)
+file_name = "my_file-{}-{}".format(int(time.time()), df.count()/2)
+
+
+print(my_string_to_print)
+print(file_name)
+
+private_encrypted_output_folder = "obs://dedicated-for-terraform-acc-test/dli/result/"
+# my_string_to_print.write.mode('overwrite').csv(private_encrypted_output_folder)
+
+final_path = "{}{}".format(private_encrypted_output_folder, file_name)
+print(final_path)
+
+
+sparkSession.sparkContext.parallelize([my_string_to_print]).coalesce(1).saveAsTextFile(final_path)
+
+
+EOF
+  content_type = "text/py"
+}
+
+resource "flexibleengine_dli_package" "test" {
+  group_name  = "%s"
+  type        = "pyFile"
+  object_path = "https://${flexibleengine_obs_bucket.test.bucket_domain_name}/dli/packages/simple_pyspark_test_DLF_refresh.py"
+
+  depends_on = [
+	flexibleengine_obs_bucket_object.test
+  ]
+}
+`, rName, OS_ACCESS_KEY, OS_SECRET_KEY, rName)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_dli_spark_job_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_dli_spark_job_test.go
@@ -1,0 +1,98 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/dli/v2/batches"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getSparkJobResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	c, err := conf.DliV2Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Flexibleengine DLI v2 client: %s", err)
+	}
+	return batches.Get(c, state.Primary.ID)
+}
+
+func TestAccDliSparkJobV2_basic(t *testing.T) {
+	var job batches.CreateResp
+
+	rName := acceptance.RandomAccResourceName()
+	dashName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "flexibleengine_dli_spark_job.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&job,
+		getSparkJobResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckDliSparkJobDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDliSparkJob_basic(rName, dashName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					acceptance.TestCheckResourceAttrWithVariable(resourceName, "queue_name",
+						"${flexibleengine_dli_queue.test.name}"),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDliSparkJobDestroy(s *terraform.State) error {
+	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	client, err := config.DliV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating Dli v2 client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_dli_spark_job" {
+			continue
+		}
+
+		resp, err := batches.GetState(client, rs.Primary.ID)
+		// If the status of the spark job is "dead" or "success", it means that the life cycle of the job has ended.
+		if err == nil && resp != nil && (resp.State != batches.StateDead && resp.State != batches.StateSuccess) {
+			return fmt.Errorf("Spark job (%s) still exists.", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccDliSparkJob_basic(name, dashName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_dli_queue" "test" {
+  name       = "%s"
+  cu_count   = 16
+  queue_type = "general"
+}
+
+%s
+
+resource "flexibleengine_dli_spark_job" "test" {
+  queue_name = flexibleengine_dli_queue.test.name
+  name       = "%s"
+  app_name   = "${flexibleengine_dli_package.test.group_name}/${flexibleengine_dli_package.test.object_name}"
+  
+ depends_on = [
+    flexibleengine_obs_bucket.test,
+    flexibleengine_obs_bucket_object.test,
+  ]
+}
+`, name, testAccDliPackage_basic(dashName), name)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_dli_table_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_dli_table_test.go
@@ -1,0 +1,108 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/dli/v1/tables"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func getDliTableResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := config.DliV1Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmtp.Errorf("error creating Dli v1 client, err=%s", err)
+	}
+	databaseName, tableName := dli.ParseTableInfoFromId(state.Primary.ID)
+	return tables.Get(client, databaseName, tableName)
+}
+
+func TestAccResourceDliTable_basic(t *testing.T) {
+	var TableObj tables.CreateTableOpts
+	resourceName := "flexibleengine_dli_table.test"
+	name := acceptance.RandomAccResourceName()
+	obsBucketName := acceptance.RandomAccResourceNameWithDash()
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&TableObj,
+		getDliTableResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckOBS(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDliTableResource_basic(name, obsBucketName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "database_name", name),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "data_location", tables.TableTypeOBS),
+					resource.TestCheckResourceAttr(resourceName, "description", "dli table test"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccDliTableResource_basic(name string, obsBucketName string) string {
+
+	return fmt.Sprintf(`
+resource "flexibleengine_obs_bucket" "test" {
+  bucket = "%s"
+  acl    = "private"
+}
+
+
+resource "flexibleengine_obs_bucket_object" "test" {
+  bucket       = flexibleengine_obs_bucket.test.bucket
+  key          = "user/data/user.csv"
+  content      = "Jason,Tokyo"
+  content_type = "text/plain"
+}
+
+resource "flexibleengine_dli_database" "test" {
+  name        = "%s"
+  description = "For terraform acc test"
+}
+
+resource "flexibleengine_dli_table" "test" {
+  database_name   = flexibleengine_dli_database.test.name
+  name            = "%s"
+  data_location   = "OBS"
+  description     = "dli table test"
+  data_format     = "csv"
+  bucket_location = "obs://${flexibleengine_obs_bucket_object.test.bucket}/user/data"
+
+  columns {
+    name = "name"
+    type        = "string"
+    description = "person name"
+  }
+
+  columns {
+    name = "addrss"
+    type        = "string"
+    description = "home address"
+  }
+
+}
+`, obsBucketName, name, name)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -18,6 +18,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cce"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cse"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dds"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/drs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip"
@@ -447,6 +448,11 @@ func Provider() *schema.Provider {
 			"flexibleengine_dds_database_role":         dds.ResourceDatabaseRole(),
 			"flexibleengine_dds_database_user":         dds.ResourceDatabaseUser(),
 			"flexibleengine_dms_kafka_user":            dms.ResourceDmsKafkaUser(),
+			"flexibleengine_dli_database":              dli.ResourceDliSqlDatabaseV1(),
+			"flexibleengine_dli_package":               dli.ResourceDliPackageV2(),
+			"flexibleengine_dli_spark_job":             dli.ResourceDliSparkJobV2(),
+			"flexibleengine_dli_table":                 dli.ResourceDliTable(),
+			"flexibleengine_dli_flinksql_job":          dli.ResourceFlinkSqlJob(),
 			"flexibleengine_drs_job":                   drs.ResourceDrsJob(),
 			"flexibleengine_fgs_dependency":            fgs.ResourceFgsDependency(),
 			"flexibleengine_fgs_function":              fgs.ResourceFgsFunctionV2(),


### PR DESCRIPTION
fixes #826 

The following resources added:
flexibleengine_dli_database
flexibleengine_dli_table
flexibleengine_dli_package
flexibleengine_dli_flinksql_job
flexibleengine_dli_spark_job

Test results:
```
make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccDliDatabase_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccDliDatabase_basic -timeout 720m
=== RUN   TestAccDliDatabase_basic
=== PAUSE TestAccDliDatabase_basic
=== CONT  TestAccDliDatabase_basic
--- PASS: TestAccDliDatabase_basic (29.43s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      29.554s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccResourceDliTable_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccResourceDliTable_basic -timeout 720m
=== RUN   TestAccResourceDliTable_basic
=== PAUSE TestAccResourceDliTable_basic
=== CONT  TestAccResourceDliTable_basic
--- PASS: TestAccResourceDliTable_basic (35.73s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      35.847s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccDliPackage_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccDliPackage_basic -timeout 720m
=== RUN   TestAccDliPackage_basic
=== PAUSE TestAccDliPackage_basic
=== CONT  TestAccDliPackage_basic
--- PASS: TestAccDliPackage_basic (31.27s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      31.390s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccResourceDliFlinkJob_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccResourceDliFlinkJob_basic -timeout 720m
=== RUN   TestAccResourceDliFlinkJob_basic
=== PAUSE TestAccResourceDliFlinkJob_basic
=== CONT  TestAccResourceDliFlinkJob_basic
--- PASS: TestAccResourceDliFlinkJob_basic (68.72s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      68.925s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccDliSparkJobV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccDliSparkJobV2_basic -timeout 720m
=== RUN   TestAccDliSparkJobV2_basic
=== PAUSE TestAccDliSparkJobV2_basic
=== CONT  TestAccDliSparkJobV2_basic
--- PASS: TestAccDliSparkJobV2_basic (171.00s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      171.241s
```