### PR TITLE
chore: deprecate networking_router_route_v2 resource

### DIFF
--- a/docs/resources/networking_router_route_v2.md
+++ b/docs/resources/networking_router_route_v2.md
@@ -1,8 +1,10 @@
 ---
-subcategory: "Virtual Private Cloud (VPC)"
+subcategory: "Deprecated"
 ---
 
 # flexibleengine_networking_router_route_v2
+
+!> **WARNING:** It has been deprecated, use `flexibleengine_vpc_route` instead.
 
 Creates a routing entry on a FlexibleEngine V2 router.
 

--- a/docs/resources/vpc_route_v2.md
+++ b/docs/resources/vpc_route_v2.md
@@ -1,10 +1,11 @@
 ---
-subcategory: "Virtual Private Cloud (VPC)"
+subcategory: "Deprecated"
 ---
 
 # flexibleengine_vpc_route_v2
 
 !> **WARNING:** It has been deprecated, use `flexibleengine_vpc_route` instead.
+
 Provides a resource to create a route.
 
 ## Example Usage

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -231,8 +231,6 @@ func Provider() *schema.Provider {
 			"flexibleengine_vpc_v1":                    dataSourceVirtualPrivateCloudVpcV1(),
 			"flexibleengine_vpc_subnet_v1":             dataSourceVpcSubnetV1(),
 			"flexibleengine_vpc_subnet_ids_v1":         dataSourceVpcSubnetIdsV1(),
-			"flexibleengine_vpc_route_v2":              dataSourceVPCRouteV2(),
-			"flexibleengine_vpc_route_ids_v2":          dataSourceVPCRouteIdsV2(),
 			"flexibleengine_vpc_peering_connection_v2": dataSourceVpcPeeringConnectionV2(),
 			"flexibleengine_vpc_eip":                   dataSourceVpcEipV1(),
 			"flexibleengine_nat_gateway_v2":            dataSourceNatGatewayV2(),
@@ -292,7 +290,9 @@ func Provider() *schema.Provider {
 			"flexibleengine_compute_availability_zones_v2":      dataSourceAvailabilityZones(),
 			"flexibleengine_blockstorage_availability_zones_v3": dataSourceBlockStorageAvailabilityZonesV3(),
 
-			"flexibleengine_vpc_eip_v1": dataSourceVpcEipV1(),
+			"flexibleengine_vpc_eip_v1":       dataSourceVpcEipV1(),
+			"flexibleengine_vpc_route_v2":     dataSourceVPCRouteV2(),
+			"flexibleengine_vpc_route_ids_v2": dataSourceVPCRouteIdsV2(),
 
 			"flexibleengine_dcs_az_v1":      dataSourceDcsAZV1(),
 			"flexibleengine_dds_flavor_v3":  dataSourceDDSFlavorV3(),
@@ -342,7 +342,6 @@ func Provider() *schema.Provider {
 			"flexibleengine_networking_port_v2":                 resourceNetworkingPortV2(),
 			"flexibleengine_networking_router_v2":               resourceNetworkingRouterV2(),
 			"flexibleengine_networking_router_interface_v2":     resourceNetworkingRouterInterfaceV2(),
-			"flexibleengine_networking_router_route_v2":         resourceNetworkingRouterRouteV2(),
 			"flexibleengine_networking_secgroup_v2":             resourceNetworkingSecGroupV2(),
 			"flexibleengine_networking_secgroup_rule_v2":        resourceNetworkingSecGroupRuleV2(),
 			"flexibleengine_identity_agency_v3":                 resourceIdentityAgencyV3(),
@@ -379,7 +378,6 @@ func Provider() *schema.Provider {
 			"flexibleengine_nat_snat_rule_v2":                   resourceNatSnatRuleV2(),
 			"flexibleengine_vpc_eip":                            resourceVpcEIPV1(),
 			"flexibleengine_vpc_flow_log_v1":                    resourceVpcFlowLogV1(),
-			"flexibleengine_vpc_route_v2":                       resourceVPCRouteV2(),
 			"flexibleengine_vpc_peering_connection_v2":          resourceVpcPeeringConnectionV2(),
 			"flexibleengine_vpc_peering_connection_accepter_v2": resourceVpcPeeringConnectionAccepterV2(),
 			"flexibleengine_sfs_file_system_v2":                 resourceSFSFileSystemV2(),
@@ -494,6 +492,9 @@ func Provider() *schema.Provider {
 			"flexibleengine_lb_certificate_v2": resourceCertificateV2(),
 			"flexibleengine_rds_instance_v1":   resourceRdsInstance(),
 			"flexibleengine_vpc_eip_v1":        resourceVpcEIPV1(),
+			"flexibleengine_vpc_route_v2":      resourceVPCRouteV2(),
+
+			"flexibleengine_networking_router_route_v2": resourceNetworkingRouterRouteV2(),
 		},
 		// configuring the provider
 		ConfigureContextFunc: configureProvider,

--- a/flexibleengine/resource_flexibleengine_networking_router_route_v2.go
+++ b/flexibleengine/resource_flexibleengine_networking_router_route_v2.go
@@ -16,6 +16,8 @@ func resourceNetworkingRouterRouteV2() *schema.Resource {
 		Read:   resourceNetworkingRouterRouteV2Read,
 		Delete: resourceNetworkingRouterRouteV2Delete,
 
+		DeprecationMessage: "It has been deprecated, using flexibleengine_vpc_route instead",
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/flexibleengine/resource_flexibleengine_networking_router_route_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_networking_router_route_v2_test.go
@@ -18,7 +18,7 @@ func TestAccNetworkingV2RouterRoute_basic(t *testing.T) {
 	var subnet [2]subnets.Subnet
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckDeprecated(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
It has been deprecated, use `flexibleengine_vpc_route` instead.

```
$ make tetacc TEST='./flexibleengine' TESTARGS='-run=TestAccNetworkingV2RouterRoute_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run=TestAccNetworkingV2RouterRoute_basic -timeout 720m
=== RUN   TestAccNetworkingV2RouterRoute_basic
    provider_test.go:111: This environment does not support deprecated tests
--- SKIP: TestAccNetworkingV2RouterRoute_basic (0.00s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 0.044s
```
