### PR TITLE
feat(waf): add dedicated certificate and policy

### DIFF
--- a/docs/resources/waf_dedicated_certificate.md
+++ b/docs/resources/waf_dedicated_certificate.md
@@ -1,0 +1,77 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# flexibleengine_waf_dedicated_certificate
+
+Manages a WAF dedicated certificate resource within Flexibleengine.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_waf_dedicated_certificate" "certificate_1" {
+  name        = "cert_1"
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIFmQl5dh2QUAeo39TIKtadgAgh4zHx09kSgayS9Wph9LEqq7MA+2042L3J9aOa
+DAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUR+SosWwALt6PkP0J9iOIxA6RW8gVsLwq
+...
++HhDvD/VeOHytX3RAs2GeTOtxyAV5XpKY5r+PkyUqPJj04t3d0Fopi0gNtLpMF=
+-----END CERTIFICATE-----
+EOT
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIJwIgYDVQQKExtEaWdpdGFsIFNpZ25hdHVyZSBUcnVzdCBDby4xFzAVBgNVBAM
+ATAwMC4GCCsGAQUFBwIBFiJodHRwOi8vY3BzLnJvb3QteDEubGV0c2VuY3J5cHQu
+...
+he8Y4IWS6wY7bCkjCWDcRQJMEhg76fsO3txE+FiYruq9RUWhiF1myv4Q6W+CyBFC
+1qoJFlcDyqSMo5iHq3HLjs
+-----END PRIVATE KEY-----
+EOT
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the WAF certificate resource. If omitted, the
+  provider-level region will be used. Changing this setting will push a new certificate.
+
+* `name` - (Required, String) Specifies the certificate name. The maximum length is 256 characters. Only digits,
+  letters, underscores(`_`), and hyphens(`-`) are allowed.
+
+* `certificate` - (Required, String, ForceNew) Specifies the certificate content. Changing this creates a new
+  certificate.
+
+* `private_key` - (Required, String, ForceNew) Specifies the private key. Changing this creates a new certificate.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The certificate ID in UUID format.
+
+* `expiration` - Indicates the time when the certificate expires.
+
+## Import
+
+Certificates can be imported using the `id`, e.g.
+
+```sh
+terraform import flexibleengine_waf_dedicated_certificate.certificate_2 3ebd3201238d41f9bfc3623b61435954
+```
+
+Note that the imported state is not identical to your resource definition, due to security reason. The missing
+attributes include `certificate`, and `private_key`. You can ignore changes as below.
+
+```
+resource "flexibleengine_waf_dedicated_certificate" "certificate_2" {
+    ...
+  lifecycle {
+    ignore_changes = [
+      certificate, private_key
+    ]
+  }
+}
+```

--- a/docs/resources/waf_dedicated_policy.md
+++ b/docs/resources/waf_dedicated_policy.md
@@ -1,0 +1,89 @@
+---
+subcategory: "Web Application Firewall (WAF)"
+---
+
+# flexibleengine_waf_dedicated_policy
+
+Manages a WAF dedicated policy resource within Flexibleengine.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_waf_dedicated_policy" "policy_1" {
+  name            = "policy_1"
+  protection_mode = "log"
+  level           = 2
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the WAF policy resource. If omitted, the
+  provider-level region will be used. Changing this setting will push a new certificate.
+
+* `name` - (Required, String) Specifies the policy name. The maximum length is 256 characters. Only digits, letters,
+  underscores(_), and hyphens(-) are allowed.
+
+* `protection_mode` - (Optional, String) Specifies the protective action after a rule is matched. Defaults to `log`.
+  Valid values are:
+  + `block`: WAF blocks and logs detected attacks.
+  + `log`: WAF logs detected attacks only.
+
+* `level` - (Optional, Int) Specifies the protection level. Defaults to `2`. Valid values are:
+  + `1`: low
+  + `2`: medium
+  + `3`: high
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The policy ID in UUID format.
+
+* `full_detection` - The detection mode in Precise Protection.
+  + `true`: full detection, Full detection finishes all threat detections before blocking requests that meet Precise
+      Protection specified conditions.
+  + `false`: instant detection. Instant detection immediately ends threat detection after blocking a request that
+      meets Precise Protection specified conditions.
+
+* `options` - The protection switches. The options object structure is documented below.
+
+The `options` block supports:
+
+* `basic_web_protection` - Indicates whether Basic Web Protection is enabled.
+
+* `general_check` - Indicates whether General Check in Basic Web Protection is enabled.
+
+* `crawler` - Indicates whether the master crawler detection switch in Basic Web Protection is enabled.
+
+* `crawler_engine` - Indicates whether the Search Engine switch in Basic Web Protection is enabled.
+
+* `crawler_scanner` - Indicates whether the Scanner switch in Basic Web Protection is enabled.
+
+* `crawler_script` - Indicates whether the Script Tool switch in Basic Web Protection is enabled.
+
+* `crawler_other` - Indicates whether detection of other crawlers in Basic Web Protection is enabled.
+
+* `webshell` - Indicates whether webshell detection in Basic Web Protection is enabled.
+
+* `cc_attack_protection` - Indicates whether CC Attack Protection is enabled.
+
+* `precise_protection` - Indicates whether Precise Protection is enabled.
+
+* `blacklist` - Indicates whether Blacklist and Whitelist is enabled.
+
+* `data_masking` - Indicates whether Data Masking is enabled.
+
+* `false_alarm_masking` - Indicates whether False Alarm Masking is enabled.
+
+* `web_tamper_protection` - Indicates whether Web Tamper Protection is enabled.
+
+## Import
+
+Policies can be imported using the `id`, e.g.
+
+```sh
+terraform import flexibleengine_waf_dedicated_policy.policy_2 25e1df831bea4022a6e22bebe678915a
+```

--- a/flexibleengine/config.go
+++ b/flexibleengine/config.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"math"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/chnsz/golangsdk"
@@ -307,6 +308,16 @@ func drsV2Client(c *Config, region string) (*golangsdk.ServiceClient, error) {
 		Region:       determineRegion(c, region),
 		Availability: PublicType,
 	})
+}
+
+// wafDedicatedv1Client is for dediacted waf certificate and policy
+func wafDedicatedv1Client(c *Config, region string) (*golangsdk.ServiceClient, error) {
+	wafClient, err := c.WafV1Client(region)
+	if err != nil {
+		return nil, err
+	}
+	wafClient.ResourceBase = strings.Replace(wafClient.ResourceBase, "waf", "premium-waf", 1)
+	return wafClient, nil
 }
 
 func determineRegion(c *Config, region string) string {

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -473,8 +473,10 @@ func Provider() *schema.Provider {
 			"flexibleengine_vpc_route_table":   vpc.ResourceVPCRouteTable(),
 			"flexibleengine_vpc_route":         vpc.ResourceVPCRouteTableRoute(),
 
-			"flexibleengine_waf_dedicated_instance": ResourceWafDedicatedInstance(),
-			"flexibleengine_waf_dedicated_domain":   waf.ResourceWafDedicatedDomainV1(),
+			"flexibleengine_waf_dedicated_instance":    ResourceWafDedicatedInstance(),
+			"flexibleengine_waf_dedicated_policy":      ResourceWafDedicatedPolicyV1(),
+			"flexibleengine_waf_dedicated_certificate": ResourceWafDedicatedCertificateV1(),
+			"flexibleengine_waf_dedicated_domain":      waf.ResourceWafDedicatedDomainV1(),
 
 			"flexibleengine_lb_loadbalancer_v3": elb.ResourceLoadBalancerV3(),
 			"flexibleengine_lb_listener_v3":     elb.ResourceListenerV3(),

--- a/flexibleengine/resource_flexibleengine_waf_dediacted_certificate.go
+++ b/flexibleengine/resource_flexibleengine_waf_dediacted_certificate.go
@@ -1,0 +1,140 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/chnsz/golangsdk/openstack/waf/v1/certificates"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func ResourceWafDedicatedCertificateV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceWafDedicatedCertificateV1Create,
+		Read:   resourceWafDedicatedCertificateV1Read,
+		Update: resourceWafDedicatedCertificateV1Update,
+		Delete: resourceWafDedicatedCertificateV1Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[\w-]{1,256}$`),
+					"The maximum length is 256 characters. Only digits, letters, underscores (_), and hyphens (-) are allowed"),
+			},
+			"certificate": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"private_key": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"expiration": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceWafDedicatedCertificateV1Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := wafDedicatedv1Client(config, config.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Client: %s", err)
+	}
+
+	createOpts := certificates.CreateOpts{
+		Name:    d.Get("name").(string),
+		Content: strings.TrimSpace(d.Get("certificate").(string)),
+		Key:     strings.TrimSpace(d.Get("private_key").(string)),
+	}
+
+	certificate, err := certificates.Create(wafClient, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("error creating WAF Certificate: %w", err)
+	}
+
+	log.Printf("[DEBUG] Waf certificate created: %#v", certificate)
+	d.SetId(certificate.Id)
+
+	return resourceWafDedicatedCertificateV1Read(d, meta)
+}
+
+func resourceWafDedicatedCertificateV1Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := wafDedicatedv1Client(config, config.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Client: %s", err)
+	}
+
+	n, err := certificates.Get(wafClient, d.Id()).Extract()
+	if err != nil {
+		return common.CheckDeleted(d, err, "Error obtain WAF certificate information")
+	}
+
+	expires := time.Unix(int64(n.ExpireTime/1000), 0).UTC().Format("2006-01-02 15:04:05 MST")
+
+	d.Set("region", config.GetRegion(d))
+	d.Set("name", n.Name)
+	d.Set("expiration", expires)
+
+	return nil
+}
+
+func resourceWafDedicatedCertificateV1Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := wafDedicatedv1Client(config, config.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Client: %s", err)
+	}
+
+	updateOpts := certificates.UpdateOpts{
+		Name: d.Get("name").(string),
+	}
+
+	_, err = certificates.Update(wafClient, d.Id(), updateOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("error updating WAF Certificate: %w", err)
+	}
+	return resourceWafDedicatedCertificateV1Read(d, meta)
+}
+
+func resourceWafDedicatedCertificateV1Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := wafDedicatedv1Client(config, config.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Client: %s", err)
+	}
+
+	err = certificates.Delete(wafClient, d.Id()).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("error deleting WAF Certificate: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/flexibleengine/resource_flexibleengine_waf_dedicated_certificate_test.go
+++ b/flexibleengine/resource_flexibleengine_waf_dedicated_certificate_test.go
@@ -1,0 +1,163 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/waf/v1/certificates"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccWafDedicatedCertificateV1_basic(t *testing.T) {
+	var certificate certificates.Certificate
+	resourceName := "flexibleengine_waf_dedicated_certificate.certificate_1"
+	name := acceptance.RandomAccResourceName()
+	updateName := name + "_update"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckWafDedicatedCertificateV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDedicatedCertificateV1_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedCertificateV1Exists(resourceName, &certificate),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+				),
+			},
+			{
+				Config: testAccWafDedicatedCertificateV1_conf(updateName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedCertificateV1Exists(resourceName, &certificate),
+					resource.TestCheckResourceAttr(resourceName, "name", updateName),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"certificate", "private_key"},
+			},
+		},
+	})
+}
+
+func testAccCheckWafDedicatedCertificateV1Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	wafClient, err := wafDedicatedv1Client(config, OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_waf_dedicated_certificate" {
+			continue
+		}
+
+		_, err := certificates.Get(wafClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Waf certificate still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckWafDedicatedCertificateV1Exists(n string, certificate *certificates.Certificate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		wafClient, err := wafDedicatedv1Client(config, OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+		}
+
+		found, err := certificates.Get(wafClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("Waf certificate not found")
+		}
+
+		*certificate = *found
+
+		return nil
+	}
+}
+
+func testAccWafDedicatedCertificateV1_conf(name string) string {
+	return fmt.Sprintf(`
+
+resource "flexibleengine_waf_dedicated_certificate" "certificate_1" {
+  name = "%s"
+
+  certificate = <<EOT
+-----BEGIN CERTIFICATE-----
+MIIDazCCAlOgAwIBAgIUehx07qc7un7IB7/X9lHCLkt/jPowDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMTA1MzEwOTI1NTJaFw0yMjA1
+MzEwOTI1NTJaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCvmuH5ViGtGOlevJ8vOoN3Ak4pp3SescdAfQa/r4cO
+z/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc8OrcaIsjns92XITVDpFW0ThGyjhT
+ZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK73OUYQY2E6l44U9G8Id763Bnws9N
+Rn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu9zu8c8i2+8qLjEsonx5PrwzNlYP3
+JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd5F4Rdxl+SAIY+6mr7qu1dAlcVMLS
+QcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iKaedPo2GfAgMBAAGjUzBRMB0GA1Ud
+DgQWBBR5yzB/GujpSlLrn0l2p+BslakGzjAfBgNVHSMEGDAWgBR5yzB/GujpSlLr
+n0l2p+BslakGzjAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCj
+TqvcIk0Au/yOxOfIGUZzVkTiORxbwATAfRN6n/+mrgWnIbHG4XFqqjmFr7gGvHeH
++BuyU06VXJgKYaPUqbYl7eBd4Spm5v3Wq7C7i96dOHmG8fVcjQnTWleyEmUsEarv
+A6/lhTqXV1+AuNUaH+9EbBUBsrCHGLkECBMKl0+cJN8lo5XncAtp7z1+O/Mn0Zi6
+XyNOyvqcmmn8HUkSIS4RlJ2ohuZN6oFC3sYX9g9Vo++IkjGl3dRbf/7JutqBGHNE
+RVKoPyaivymDDIIL/qSy/Pi2s0hzUhwc1M8td0K/AMxyeigwNG7mTH0RzX32bUkf
+ZoURg5WiRskhtHEvBsLF
+-----END CERTIFICATE-----
+EOT
+
+  private_key = <<EOT
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCvmuH5ViGtGOle
+vJ8vOoN3Ak4pp3SescdAfQa/r4cOz/bmBqBcZJTX9HODhiQzdemyLLs9aOkQXYIc
+8OrcaIsjns92XITVDpFW0ThGyjhTZdELj9LsbIcVzNPPclTcebZBlzAyX0oLqpHK
+73OUYQY2E6l44U9G8Id763Bnws9NRn3cg0qufrlUgdim/pYZ8ubjvlDJ9eEIhcsu
+9zu8c8i2+8qLjEsonx5PrwzNlYP3JqAmZ2dcbQeSPfv5U6ZceKEZfegK+Cxv4rFd
+5F4Rdxl+SAIY+6mr7qu1dAlcVMLSQcLlJLRWQ5NmqL9xju7Fbj2VZt+L6nb512iK
+aedPo2GfAgMBAAECggEAeMAvDS3uAEI2Dx/y8h3xUn9yUfBFH+6tTanrXxoK6+OT
+Kj96O64qL4l3eQRflkdJiGx74FFomglCtDXxudflfXvxurkJ2hunUySQ5xScwLQt
+mB6w8kP6a8IqD+bVdbn32ohk6u5dU0JZ+ErJlklVZRAGJAoCYox5DXwrEh6CP+bJ
+pItgjv71tEEnX5sScQwV7FMRbjsPzXoJp8vCQjlUdetM1fk9rs3R2WSeFbPgLLtC
+xY0+8Hexy0q6BLmyPZvFCaVIAzAHCYeCyzPK3xcm4odbrBmRL/amOg24CCny065N
+MU9RFhEjQsY1RaK7dgkvjsntUZvU+aDcL8o6djOTuQKBgQDlDN/j2ntpGCtbTWH0
+cVTW13Ze7U7iE3BfDO3m4VYP3Xi/v5FI8nHlmLrcl30H1dPKvMTec0dCBOqD1wzF
+KiqHy8ELowO2CbXMYJpjuPzXH40/AE3eOJVTJM8mOeuFdeFgYCd/9cB7o5jfTA5Y
+4zj8EmcRzsH1rNSnvo7/O9q6+wKBgQDERDSvP8RScEbzDKuN6uhzj1K2CAEnY6//
+rDA1so18UhAie9NcAvlKa46jQTOcYD77g5h0WSlNt9ZbK9Plq9CY9psI0KNqN3Fl
+YVKOKdD5m6Rifmg+lt8KLc/WocQ10DXpPTXzzuRlN/TaMDdN2pedEre/0AAMs8Ia
+MIUnu4oyrQKBgQC6b6BNdqi9Ak9IIdR5g0XrGbXfzolGu0vcEkoSg5fpkfuXF/bJ
+yY2rtIVkyGmc1w9tFfmol2yI8Ddy2LgsRAYaQl7/edCre3vev0LrqMck0ynE/hpj
+purkojF6i+qI10p7h8ie/wmNmbv1BZMoBst7Yf9DH2gA8IynfRQn7DA9wQKBgGaU
+M2kJDgX8UsjDbYKuLTIAzb0AMAIzUxBxIX1fRh2dEnvDdjOYBk1EK/fdoyjvENwJ
+6ouc8j6BgBKEtKpMg6j+8wbHbTGdqrHPDQPqjSN4mpEz+i4EUqySRxep0tBBc3vl
+FybHko3okhvbqXwSbL2Ww90HzI7XAPMJOv8KQO+9AoGBAJxxftNWvypBXGkPCdH2
+f3ikvT2Vef9QZjqkvtipCecAkjM6ReLshVsdqFSv/ZmsVUeNKoTHvX2GnhweJM44
+x7N2mFK4skBzVtMVbjAHVjG78UitVu+FrzqGreaJXHaduhgUH2iFWfw09joOotAM
+X7ioLbTeWGBqFM+C80PkdBNp
+-----END PRIVATE KEY-----
+EOT
+}
+`, name)
+}

--- a/flexibleengine/resource_flexibleengine_waf_dedicated_policy.go
+++ b/flexibleengine/resource_flexibleengine_waf_dedicated_policy.go
@@ -1,0 +1,281 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+
+	"github.com/chnsz/golangsdk/openstack/waf_hw/v1/policies"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+const (
+	PROTECTION_MODE_LOG   = "log"
+	PROTECTION_MODE_BLOCK = "block"
+)
+
+func ResourceWafDedicatedPolicyV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceWafDedicatedPolicyV1Create,
+		Read:   resourceWafDedicatedPolicyV1Read,
+		Update: resourceWafDedicatedPolicyV1Update,
+		Delete: resourceWafDedicatedPolicyV1Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"protection_mode": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					PROTECTION_MODE_LOG, PROTECTION_MODE_BLOCK,
+				}, false),
+			},
+			"level": {
+				Type:         schema.TypeInt,
+				Computed:     true,
+				Optional:     true,
+				ValidateFunc: validation.IntBetween(0, 3),
+			},
+			"options": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"basic_web_protection": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"general_check": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"crawler": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"crawler_engine": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"crawler_scanner": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"crawler_script": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"crawler_other": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"webshell": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"cc_attack_protection": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"precise_protection": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"blacklist": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"data_masking": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"false_alarm_masking": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+						"web_tamper_protection": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"full_detection": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceWafDedicatedPolicyV1Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := wafDedicatedv1Client(config, config.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("Error creating Flexibleengine WAF client: %s", err)
+	}
+
+	createOpts := policies.CreateOpts{
+		Name: d.Get("name").(string),
+	}
+	policy, err := policies.Create(wafClient, createOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Error creating waf policy: %s", err)
+	}
+
+	log.Printf("[DEBUG] Waf policy created: %#v", policy)
+	d.SetId(policy.Id)
+	d.Set("name", policy.Name)
+
+	level := d.Get("level").(int)
+	protectionMode := d.Get("protection_mode").(string)
+
+	// Get the policy details, then check if need to update 'protection_mode' or 'level.
+	err = resourceWafDedicatedPolicyV1Read(d, meta)
+
+	// If the vlaue of 'protection_mode' or 'level' is not equal to the value returned by the server,
+	// then update the policy.
+	err = checkAndUpdateDefaultVal(wafClient, d, protectionMode, level)
+	if err != nil {
+		return fmt.Errorf("the Waf Policy was created successfully, "+
+			"but failed to update protection_mode or level : %s", err)
+	} else {
+		d.Set("protection_mode", protectionMode)
+		d.Set("level", level)
+	}
+
+	return err
+}
+
+// checkAndUpdateDefaultVal check the vlaue of 'protection_mode' or 'level' is not equal to
+// the value returned by the server.
+// If the value is not equal to the value returned by the server, call the update API to make changes.
+func checkAndUpdateDefaultVal(wafClient *golangsdk.ServiceClient, d *schema.ResourceData,
+	protectionMode string, level int) error {
+
+	needUpdate := false
+	updateOpts := policies.UpdateOpts{}
+
+	if strings.Compare(d.Get("protection_mode").(string), protectionMode) != 0 && len(protectionMode) != 0 {
+		needUpdate = true
+		updateOpts.Action = &policies.Action{
+			Category: protectionMode,
+		}
+	}
+	if d.Get("level").(int) != level && level != 0 {
+		needUpdate = true
+		updateOpts.Level = level
+	}
+
+	if needUpdate {
+		log.Printf("[DEBUG] update default protection_mode or level: %#v", updateOpts)
+		_, err := policies.Update(wafClient, d.Id(), updateOpts).Extract()
+		return err
+	}
+	return nil
+}
+
+func resourceWafDedicatedPolicyV1Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := wafDedicatedv1Client(config, config.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	n, err := policies.Get(wafClient, d.Id()).Extract()
+	if err != nil {
+		return common.CheckDeleted(d, err, "Waf Policy")
+	}
+
+	d.Set("region", config.GetRegion(d))
+	d.Set("name", n.Name)
+	d.Set("level", n.Level)
+	d.Set("protection_mode", n.Action.Category)
+	d.Set("full_detection", n.FullDetection)
+
+	options := []map[string]interface{}{
+		{
+			"basic_web_protection":  n.Options.Webattack,
+			"general_check":         n.Options.Common,
+			"crawler":               n.Options.Crawler,
+			"crawler_engine":        n.Options.CrawlerEngine,
+			"crawler_scanner":       n.Options.CrawlerScanner,
+			"crawler_script":        n.Options.CrawlerScript,
+			"crawler_other":         n.Options.CrawlerOther,
+			"webshell":              n.Options.Webshell,
+			"cc_attack_protection":  n.Options.Cc,
+			"precise_protection":    n.Options.Custom,
+			"blacklist":             n.Options.Whiteblackip,
+			"false_alarm_masking":   n.Options.Ignore,
+			"data_masking":          n.Options.Privacy,
+			"web_tamper_protection": n.Options.Antitamper,
+		},
+	}
+	d.Set("options", options)
+	return nil
+}
+
+func resourceWafDedicatedPolicyV1Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := wafDedicatedv1Client(config, config.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF Client: %s", err)
+	}
+
+	if d.HasChanges("name", "level", "protection_mode") {
+		updateOpts := policies.UpdateOpts{
+			Name:  d.Get("name").(string),
+			Level: d.Get("level").(int),
+			Action: &policies.Action{
+				Category: d.Get("protection_mode").(string),
+			},
+		}
+
+		log.Printf("[DEBUG] updateOpts: %#v", updateOpts)
+		_, err = policies.Update(wafClient, d.Id(), updateOpts).Extract()
+		if err != nil {
+			return fmt.Errorf("error updating WAF Policy: %s", err)
+		}
+	}
+	return resourceWafDedicatedPolicyV1Read(d, meta)
+}
+
+func resourceWafDedicatedPolicyV1Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := wafDedicatedv1Client(config, config.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	err = policies.Delete(wafClient, d.Id()).ExtractErr()
+	if err != nil {
+		return fmt.Errorf("error deleting WAF Policy: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/flexibleengine/resource_flexibleengine_waf_dedicated_policy_test.go
+++ b/flexibleengine/resource_flexibleengine_waf_dedicated_policy_test.go
@@ -1,0 +1,124 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/waf_hw/v1/policies"
+)
+
+func TestAccWafDedicatedPolicyV1_basic(t *testing.T) {
+	var policy policies.Policy
+	randName := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_waf_dedicated_policy.policy_1"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafDedicatedPolicyV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDedicatedPolicyV1_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedPolicyV1Exists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "name", randName),
+					resource.TestCheckResourceAttr(resourceName, "level", "1"),
+					resource.TestCheckResourceAttr(resourceName, "full_detection", "false"),
+				),
+			},
+			{
+				Config: testAccWafDedicatedPolicyV1_update(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedPolicyV1Exists(resourceName, &policy),
+					resource.TestCheckResourceAttr(resourceName, "name", randName+"_updated"),
+					resource.TestCheckResourceAttr(resourceName, "protection_mode", "block"),
+					resource.TestCheckResourceAttr(resourceName, "level", "3"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckWafDedicatedPolicyV1Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	wafClient, err := wafDedicatedv1Client(config, OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_waf_dedicated_policy" {
+			continue
+		}
+		_, err := policies.Get(wafClient, rs.Primary.ID).Extract()
+		if err == nil {
+			return fmt.Errorf("Waf policy still exists")
+		}
+	}
+	return nil
+}
+
+func testAccCheckWafDedicatedPolicyV1Exists(n string, policy *policies.Policy) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		wafClient, err := wafDedicatedv1Client(config, OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating Flexibleengine WAF client: %s", err)
+		}
+
+		found, err := policies.Get(wafClient, rs.Primary.ID).Extract()
+		if err != nil {
+			return err
+		}
+
+		if found.Id != rs.Primary.ID {
+			return fmt.Errorf("Waf policy not found")
+		}
+
+		*policy = *found
+		return nil
+	}
+}
+
+func testAccWafDedicatedPolicyV1_basic(name string) string {
+	return fmt.Sprintf(`
+
+resource "flexibleengine_waf_dedicated_policy" "policy_1" {
+  name  = "%s"
+  level = 1
+}
+`, name)
+}
+
+func testAccWafDedicatedPolicyV1_update(name string) string {
+	return fmt.Sprintf(`
+
+resource "flexibleengine_waf_dedicated_policy" "policy_1" {
+  name            = "%s_updated"
+  protection_mode = "block"
+  level           = 3
+}
+`, name)
+}


### PR DESCRIPTION
add resources:
flexibleengine_waf_dedicated_certificate
flexibleengine_waf_dedicated_policy

**Test results**:
```
make testacc TEST='./flexibleengine/' TESTARGS='-run TestAccWafDedicatedPolicyV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/ -v -run TestAccWafDedicatedPolicyV1_basic -timeout 720m
=== RUN   TestAccWafDedicatedPolicyV1_basic
=== PAUSE TestAccWafDedicatedPolicyV1_basic
=== CONT  TestAccWafDedicatedPolicyV1_basic
--- PASS: TestAccWafDedicatedPolicyV1_basic (51.84s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 52.036s

make testacc TEST='./flexibleengine/' TESTARGS='-run TestAccWafDedicatedCertificateV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/ -v -run TestAccWafDedicatedCertificateV1_basic -timeout 720m
=== RUN   TestAccWafDedicatedCertificateV1_basic
=== PAUSE TestAccWafDedicatedCertificateV1_basic
=== CONT  TestAccWafDedicatedCertificateV1_basic
--- PASS: TestAccWafDedicatedCertificateV1_basic (46.57s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 46.816s
```