### PR TITLE
[flexibleengine_sfs_turbo] network_id instead of subnet_id

### DIFF
--- a/docs/resources/sfs_turbo.md
+++ b/docs/resources/sfs_turbo.md
@@ -9,18 +9,33 @@ Provides an Shared File System (SFS) Turbo resource.
 ## Example Usage
 
 ```hcl
-variable "vpc_id" {}
-variable "subnet_id" {}
 variable "secgroup_id" {}
 variable "test_az" {}
+
+resource "flexibleengine_vpc_v1" "vpc1" {
+  name = "vpc1"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "vpcsubnet1" {
+  name       = "vpcsubnet1"
+  cidr       = "192.168.0.0/16"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = flexibleengine_vpc_v1.vpc1.id
+}
+
+resource "flexibleengine_networking_secgroup_v2" "secgroup" {
+  name        = "sg1"
+  description = "terraform security group for sfs turbo acceptance test"
+}
 
 resource "flexibleengine_sfs_turbo" "sfs-turbo-1" {
   name        = "sfs-turbo-1"
   size        = 500
   share_proto = "NFS"
-  vpc_id      = var.vpc_id
-  subnet_id   = var.subnet_id
-  security_group_id = var.secgroup_id
+  vpc_id      = flexibleengine_vpc_v1.vpc1.id
+  network_id   = flexibleengine_vpc_subnet_v1.vpcsubnet1.id
+  security_group_id = flexibleengine_networking_secgroup_v2.secgroup.id
   availability_zone = var.test_az
 }
 ```
@@ -44,7 +59,7 @@ The following arguments are supported:
 
 * `vpc_id` - (Required) Specifies the VPC ID. Changing this will create a new resource.
 
-* `subnet_id` - (Required) Specifies the network ID of the subnet. Changing this will create a new resource.
+* `network_id` - (Required) Specifies the network ID of the subnet. Changing this will create a new resource.
 
 * `security_group_id` - (Required) Specifies the security group ID. Changing this will create a new resource.
 

--- a/flexibleengine/resource_flexibleengine_sfs_turbo.go
+++ b/flexibleengine/resource_flexibleengine_sfs_turbo.go
@@ -68,7 +68,7 @@ func resourceSFSTurbo() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"subnet_id": {
+			"network_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -117,7 +117,7 @@ func resourceSFSTurboCreate(d *schema.ResourceData, meta interface{}) error {
 		ShareProto:       d.Get("share_proto").(string),
 		ShareType:        d.Get("share_type").(string),
 		VpcID:            d.Get("vpc_id").(string),
-		SubnetID:         d.Get("subnet_id").(string),
+		SubnetID:         d.Get("network_id").(string),
 		SecurityGroupID:  d.Get("security_group_id").(string),
 		AvailabilityZone: d.Get("availability_zone").(string),
 	}
@@ -167,7 +167,7 @@ func resourceSFSTurboRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("share_proto", n.ShareProto)
 	d.Set("share_type", n.ShareType)
 	d.Set("vpc_id", n.VpcID)
-	d.Set("subnet_id", n.SubnetID)
+	d.Set("network_id", n.SubnetID)
 	d.Set("security_group_id", n.SecurityGroupID)
 	d.Set("version", n.Version)
 	d.Set("region", GetRegion(d, config))

--- a/flexibleengine/resource_flexibleengine_sfs_turbo_test.go
+++ b/flexibleengine/resource_flexibleengine_sfs_turbo_test.go
@@ -158,7 +158,7 @@ resource "flexibleengine_sfs_turbo" "sfs-turbo1" {
   size        = 500
   share_proto = "NFS"
   vpc_id      = flexibleengine_vpc_v1.test.id
-  subnet_id   = flexibleengine_vpc_subnet_v1.test.id
+  network_id   = flexibleengine_vpc_subnet_v1.test.id
   security_group_id = flexibleengine_networking_secgroup_v2.secgroup.id
   availability_zone = "%s"
 }
@@ -174,7 +174,7 @@ resource "flexibleengine_sfs_turbo" "sfs-turbo1" {
   size        = 600
   share_proto = "NFS"
   vpc_id      = flexibleengine_vpc_v1.test.id
-  subnet_id   = flexibleengine_vpc_subnet_v1.test.id
+  network_id   = flexibleengine_vpc_subnet_v1.test.id
   security_group_id = flexibleengine_networking_secgroup_v2.secgroup.id
   availability_zone = "%s"
 }
@@ -195,7 +195,7 @@ resource "flexibleengine_sfs_turbo" "sfs-turbo1" {
   share_proto  = "NFS"
   crypt_key_id = flexibleengine_kms_key_v1.key_1.id
   vpc_id       = flexibleengine_vpc_v1.test.id
-  subnet_id    = flexibleengine_vpc_subnet_v1.test.id
+  network_id    = flexibleengine_vpc_subnet_v1.test.id
   security_group_id = flexibleengine_networking_secgroup_v2.secgroup.id
   availability_zone = "%s"
 }


### PR DESCRIPTION
`subnet_id` is not really a Subnet ID but a Network ID. I propose this little change to rename this argument.

Acceptance test was passed with success.