### PR TITLE
[flexibleengine_nat_gateway_v2] network_id instead of subnet_id

### DIFF
--- a/docs/resources/nat_gateway_v2.md
+++ b/docs/resources/nat_gateway_v2.md
@@ -9,12 +9,24 @@ Manages a V2 nat gateway resource within FlexibleEngine.
 ## Example Usage
 
 ```hcl
+resource "flexibleengine_vpc_v1" "vpc_1" {
+  name = "vpc_1"
+  cidr = "172.16.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "subnet_1" {
+  name       = "subnet_1"
+  cidr       = "172.16.10.0/24"
+  gateway_ip = "172.16.10.1"
+  vpc_id     = flexibleengine_vpc_v1.vpc_1.id
+}
+
 resource "flexibleengine_nat_gateway_v2" "nat_1" {
   name        = "nat_test"
   description = "test for terraform"
   spec        = "3"
-  vpc_id      = "2c1fe4bd-ebad-44ca-ae9d-e94e63847b75"
-  subnet_id   = "dc8632e2-d9ff-41b1-aa0c-d455557314a0"
+  vpc_id      = flexibleengine_vpc_v1.vpc_1.id
+  network_id  = flexibleengine_vpc_subnet_v1.subnet_1.id
 }
 ```
 
@@ -37,7 +49,7 @@ The following arguments are supported:
 * `vpc_id` - (Required, String, ForceNew) Specifies the ID of the VPC this nat gateway belongs to.
   Changing this creates a new nat gateway.
 
-* `subnet_id` - (Required, String, ForceNew) Specifies the subnet ID of the downstream interface
+* `network_id` - (Required, String, ForceNew) Specifies the Network ID of the downstream interface
   (the next hop of the DVR) of the NAT gateway. Changing this creates a new nat gateway.
 
 * `description` - (Optional, String) Specifies the description of the nat gateway.

--- a/flexibleengine/resource_flexibleengine_nat_gateway_v2.go
+++ b/flexibleengine/resource_flexibleengine_nat_gateway_v2.go
@@ -54,7 +54,7 @@ func resourceNatGatewayV2() *schema.Resource {
 				Computed:     true,
 				ExactlyOneOf: []string{"router_id"},
 			},
-			"subnet_id": {
+			"network_id": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
@@ -83,7 +83,7 @@ func resourceNatGatewayV2() *schema.Resource {
 				Type:       schema.TypeString,
 				Optional:   true,
 				ForceNew:   true,
-				Deprecated: "use subnet_id instead",
+				Deprecated: "use network_id instead",
 			},
 			"router_id": {
 				Type:       schema.TypeString,
@@ -108,7 +108,7 @@ func resourceNatGatewayV2Create(d *schema.ResourceData, meta interface{}) error 
 	} else {
 		vpcID = d.Get("router_id").(string)
 	}
-	if v2, ok := d.GetOk("subnet_id"); ok {
+	if v2, ok := d.GetOk("network_id"); ok {
 		subnetID = v2.(string)
 	} else {
 		subnetID = d.Get("internal_network_id").(string)
@@ -165,7 +165,7 @@ func resourceNatGatewayV2Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("description", natGateway.Description)
 	d.Set("spec", natGateway.Spec)
 	d.Set("vpc_id", natGateway.RouterID)
-	d.Set("subnet_id", natGateway.InternalNetworkID)
+	d.Set("network_id", natGateway.InternalNetworkID)
 	d.Set("status", natGateway.Status)
 	d.Set("region", GetRegion(d, config))
 

--- a/flexibleengine/resource_flexibleengine_nat_gateway_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_nat_gateway_v2_test.go
@@ -123,7 +123,7 @@ resource "flexibleengine_nat_gateway_v2" "nat_1" {
   description = "test for terraform"
   spec        = "1"
   vpc_id      = flexibleengine_vpc_v1.vpc_1.id
-  subnet_id   = flexibleengine_vpc_subnet_v1.subnet_1.id
+  network_id   = flexibleengine_vpc_subnet_v1.subnet_1.id
 }
 `, testAccNatPreCondition(suffix), suffix)
 }
@@ -137,7 +137,7 @@ resource "flexibleengine_nat_gateway_v2" "nat_1" {
   description = "test for terraform updated"
   spec        = "2"
   vpc_id      = flexibleengine_vpc_v1.vpc_1.id
-  subnet_id   = flexibleengine_vpc_subnet_v1.subnet_1.id
+  network_id   = flexibleengine_vpc_subnet_v1.subnet_1.id
 }
 `, testAccNatPreCondition(suffix), suffix)
 }


### PR DESCRIPTION
subnet_id is not really a Subnet ID but a Network ID. I propose this little change to rename this argument.

Acceptance test was passed with success.