### PR TITLE
chore(vpc/subnet): add ipv4_subnet_id and deprecate subnet_id attribute

### DIFF
--- a/docs/data-sources/vpc_subnet_v1.md
+++ b/docs/data-sources/vpc_subnet_v1.md
@@ -57,7 +57,7 @@ the selected subnet.
 
 * `dhcp_enable` - DHCP function for the subnet.
 
-* `subnet_id` - Specifies the subnet (Native OpenStack API) ID.
+* `ipv4_subnet_id` - The ID of the IPv4 subnet (Native OpenStack API).
 
 * `ipv6_enable` - Whether the IPv6 is enabled.
 

--- a/docs/resources/vpc_subnet_v1.md
+++ b/docs/resources/vpc_subnet_v1.md
@@ -81,7 +81,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `status` - The status of the subnet. The value can be ACTIVE, DOWN, UNKNOWN, or ERROR.
 
-* `subnet_id` - The subnet (Native OpenStack API) ID.
+* `ipv4_subnet_id` - The ID of the IPv4 subnet (Native OpenStack API).
 
 * `ipv6_subnet_id` - The ID of the IPv6 subnet (Native OpenStack API).
 
@@ -91,7 +91,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Subnets can be imported using the `subnet id`, e.g.
+Subnets can be imported using the subnet `Network ID`, e.g.
 
 ```
  $ terraform import flexibleengine_vpc_subnet_v1 4779ab1c-7c1a-44b1-a02e-93dfc361b32d

--- a/flexibleengine/acceptance/resource_flexibleengine_vpc_subnet_v1_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_vpc_subnet_v1_test.go
@@ -36,6 +36,7 @@ func TestAccVpcSubnetV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "ipv6_enable", "false"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttrSet(resourceName, "ipv4_subnet_id"),
 				),
 			},
 			{

--- a/flexibleengine/data_source_flexibleengine_vpc_subnet_v1.go
+++ b/flexibleengine/data_source_flexibleengine_vpc_subnet_v1.go
@@ -68,6 +68,11 @@ func dataSourceVpcSubnetV1() *schema.Resource {
 				Optional: true,
 			},
 			"subnet_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "schema: Deprecated",
+			},
+			"ipv4_subnet_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -142,6 +147,7 @@ func dataSourceVpcSubnetV1Read(d *schema.ResourceData, meta interface{}) error {
 	d.Set("availability_zone", Subnets.AvailabilityZone)
 	d.Set("vpc_id", Subnets.VPC_ID)
 	d.Set("subnet_id", Subnets.SubnetId)
+	d.Set("ipv4_subnet_id", Subnets.SubnetId)
 	d.Set("ipv6_enable", Subnets.EnableIPv6)
 	d.Set("ipv6_subnet_id", Subnets.IPv6SubnetId)
 	d.Set("ipv6_cidr", Subnets.IPv6CIDR)

--- a/flexibleengine/data_source_flexibleengine_vpc_subnet_v1_test.go
+++ b/flexibleengine/data_source_flexibleengine_vpc_subnet_v1_test.go
@@ -34,6 +34,8 @@ func TestAccVpcSubnetV1DataSource_basic(t *testing.T) {
 						"data.flexibleengine_vpc_subnet_v1.by_id", "dhcp_enable", "true"),
 					resource.TestCheckResourceAttr(
 						"data.flexibleengine_vpc_subnet_v1.by_id", "ipv6_enable", "false"),
+					resource.TestCheckResourceAttrSet(
+						"data.flexibleengine_vpc_subnet_v1.by_id", "ipv4_subnet_id"),
 				),
 			},
 		},


### PR DESCRIPTION

```
$ make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccVpcSubnetV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccVpcSubnetV1_basic -timeout 720m
=== RUN   TestAccVpcSubnetV1_basic
--- PASS: TestAccVpcSubnetV1_basic (86.86s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      86.921s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccVpcSubnetV1DataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccVpcSubnetV1DataSource_basic -timeout 720m
=== RUN   TestAccVpcSubnetV1DataSource_basic
--- PASS: TestAccVpcSubnetV1DataSource_basic (64.74s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 64.803s
```