### PR TITLE
fix: update the API verison of LTS group and topic

### DIFF
--- a/docs/resources/lts_topic.md
+++ b/docs/resources/lts_topic.md
@@ -38,7 +38,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The log topic ID in UUID format.
 
-* `index_enabled` - Indicates the search switch. When index is enabled, the topic allows you to search for logs by keyword.
+* `filter_count` - The Number of metric filter.
 
 ## Import
 


### PR DESCRIPTION
using **v2** APIs instead of **v2.0** APIs

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLTSGroupV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLTSGroupV2_basic -timeout 720m
=== RUN   TestAccLTSGroupV2_basic
=== PAUSE TestAccLTSGroupV2_basic
=== CONT  TestAccLTSGroupV2_basic
--- PASS: TestAccLTSGroupV2_basic (25.91s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 25.978s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccLTSTopicV2_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLTSTopicV2_basic -timeout 720m
=== RUN   TestAccLTSTopicV2_basic
=== PAUSE TestAccLTSTopicV2_basic
=== CONT  TestAccLTSTopicV2_basic
--- PASS: TestAccLTSTopicV2_basic (27.56s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 27.638s
```