### PR TITLE
FIX import for resource flexibleengine_as_lifecycle_hook_v1

### DIFF
--- a/docs/resources/as_lifecycle_hook_v1.md
+++ b/docs/resources/as_lifecycle_hook_v1.md
@@ -69,8 +69,9 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-Lifecycle hooks can be imported using the AS group ID and hook ID separated by a slash, e.g.
+Lifecycle hooks can be imported using the Auto Scalling group ID `scaling_group_id` and hook Name `name` separated by a
+slash `/`, e.g.
 
 ```shell
-terraform import flexibleengine_as_lifecycle_hook_v1.test <as_group_id>/<id>
+terraform import flexibleengine_as_lifecycle_hook_v1.test <scaling_group_id>/<name>
 ```

--- a/flexibleengine/resource_flexibleengine_as_lifecycle_hook.go
+++ b/flexibleengine/resource_flexibleengine_as_lifecycle_hook.go
@@ -221,7 +221,7 @@ func setASLifecycleHookType(d *schema.ResourceData, hook *lifecyclehooks.Hook) e
 func resourceASLifecycleHookImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	parts := strings.SplitN(d.Id(), "/", 2)
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("Invalid format specified for lifecycle hook, must be <scaling_group_id>/<hook_id>")
+		return nil, fmt.Errorf("Invalid format specified for lifecycle hook, must be <scaling_group_id>/<hook_name>")
 	}
 	d.SetId(parts[1])
 	d.Set("scaling_group_id", parts[0])


### PR DESCRIPTION
In API documentation the import syntax is `{scaling_group_id}/{lifecycle_hook_name}` and not `{scaling_group_id}/{lifecycle_hook_id}`

Link of the documentation :
[https://docs.prod-cloud-ocb.orange-business.com/api/as/as_06_0903.html](https://docs.prod-cloud-ocb.orange-business.com/api/as/as_06_0903.html)