### PR TITLE
chore(vip): use ip_version instead of subnet_id

### DIFF
--- a/docs/resources/networking_vip_associate_v2.md
+++ b/docs/resources/networking_vip_associate_v2.md
@@ -9,72 +9,34 @@ Manages a V2 vip associate resource within FlexibleEngine.
 ## Example Usage
 
 ```hcl
-resource "flexibleengine_networking_network_v2" "network_1" {
-  name = "network_1"
-  admin_state_up = "true"
-}
+variable subnet_id{}
 
-resource "flexibleengine_networking_subnet_v2" "subnet_1" {
-  name       = "subnet_1"
-  cidr       = "192.168.199.0/24"
-  ip_version = 4
-  network_id = flexibleengine_networking_network_v2.network_1.id
-}
-
-resource "flexibleengine_networking_router_interface_v2" "router_interface_1" {
-  router_id = flexibleengine_networking_router_v2.router_1.id
-  subnet_id = flexibleengine_networking_subnet_v2.subnet_1.id
-}
-
-resource "flexibleengine_networking_router_v2" "router_1" {
-  name             = "router_1"
-  external_gateway = "0a2228f2-7f8a-45f1-8e09-9039e1d09975"
-}
-
-resource "flexibleengine_networking_port_v2" "port_1" {
-  name       = "port_1"
-  network_id = flexibleengine_networking_network_v2.network_1.id
-
-  fixed_ip {
-    subnet_id = flexibleengine_networking_subnet_v2.subnet_1.id
-  }
-}
-
-resource "flexibleengine_compute_instance_v2" "instance_1" {
-  name            = "instance_1"
-  security_groups = ["default"]
-
+resource "flexibleengine_compute_instance_v2" "server_1" {
+  name = "instance_1"
   network {
-    port = flexibleengine_networking_port_v2.port_1.id
+    uuid = var.subnet_id
   }
+  ...
 }
 
-resource "flexibleengine_networking_port_v2" "port_2" {
-  name       = "port_2"
-  network_id = flexibleengine_networking_network_v2.network_1.id
-
-  fixed_ip {
-    subnet_id = flexibleengine_networking_subnet_v2.subnet_1.id
-  }
-}
-
-resource "flexibleengine_compute_instance_v2" "instance_2" {
+resource "flexibleengine_compute_instance_v2" "server_2" {
   name = "instance_2"
-  security_groups = ["default"]
-
   network {
-    port = flexibleengine_networking_port_v2.port_1.id
+    uuid = var.subnet_id
   }
+  ...
 }
 
 resource "flexibleengine_networking_vip_v2" "vip_1" {
-  network_id = flexibleengine_networking_network_v2.network_1.id
-  subnet_id  = flexibleengine_networking_subnet_v2.subnet_1.id
+  network_id = var.subnet_id
 }
 
 resource "flexibleengine_networking_vip_associate_v2" "vip_associate_1" {
   vip_id   = flexibleengine_networking_vip_v2.vip_1.id
-  port_ids = [flexibleengine_networking_port_v2.port_1.id, flexibleengine_networking_port_v2.port_2.id]
+  port_ids = [
+    flexibleengine_compute_instance_v2.server_1.network.0.port,
+    flexibleengine_compute_instance_v2.server_2.network.0.port,
+  ]
 }
 ```
 
@@ -90,9 +52,8 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
-* `vip_id` - See Argument Reference above.
-* `port_ids` - See Argument Reference above.
+* `id` - The resource ID.
 * `vip_subnet_id` - The ID of the subnet this vip connects to.
 * `vip_ip_address` - The IP address in the subnet for this vip.

--- a/docs/resources/networking_vip_v2.md
+++ b/docs/resources/networking_vip_v2.md
@@ -9,31 +9,26 @@ Manages a V2 vip resource within FlexibleEngine.
 ## Example Usage
 
 ```hcl
-resource "flexibleengine_networking_network_v2" "network_1" {
-  name           = "network_1"
-  admin_state_up = "true"
+variable vpc_name{}
+variable vpc_cidr{}
+variable subnet_name{}
+variable subnet_cidr{}
+variable subnet_gateway_ip{}
+
+resource "flexibleengine_vpc_v1" "vpc_1" {
+  name = var.vpc_name
+  cidr = var.vpc_cidr
 }
 
-resource "flexibleengine_networking_subnet_v2" "subnet_1" {
-  name       = "subnet_1"
-  cidr       = "192.168.199.0/24"
-  ip_version = 4
-  network_id = flexibleengine_networking_network_v2.network_1.id
-}
-
-resource "flexibleengine_networking_router_interface_v2" "router_interface_1" {
-  router_id = flexibleengine_networking_router_v2.router_1.id
-  subnet_id = flexibleengine_networking_subnet_v2.subnet_1.id
-}
-
-resource "flexibleengine_networking_router_v2" "router_1" {
-  name             = "router_1"
-  external_gateway = "0a2228f2-7f8a-45f1-8e09-9039e1d09975"
+resource "flexibleengine_vpc_subnet_v1" "subnet_1" {
+  name       = var.subnet_name
+  cidr       = var.subnet_cidr
+  gateway_ip = var.subnet_gateway_ip
+  vpc_id     = flexibleengine_vpc_v1.vpc_1.id
 }
 
 resource "flexibleengine_networking_vip_v2" "vip_1" {
-  network_id = flexibleengine_networking_network_v2.network_1.id
-  subnet_id  = flexibleengine_networking_subnet_v2.subnet_1.id
+  network_id = flexibleengine_vpc_subnet_v1.subnet_1.id
 }
 ```
 
@@ -41,27 +36,43 @@ resource "flexibleengine_networking_vip_v2" "vip_1" {
 
 The following arguments are supported:
 
-* `network_id` - (Required) The ID of the network to attach the vip to.
-    Changing this creates a new vip.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the VIP.
+  If omitted, the provider-level region will be used. Changing this will create a new VIP resource.
 
-* `subnet_id` - (Required) Subnet in which to allocate IP address for this vip.
-    Changing this creates a new vip.
+* `network_id` - (Required, String, ForceNew) Specifies the *ID* of the VPC subnet to which the VIP belongs.
+  Changing this will create a new VIP resource.
 
-* `ip_address` - (Optional) IP address desired in the subnet for this vip.
-    If you don't specify `ip_address`, an available IP address from
-    the specified subnet will be allocated to this vip.
+* `ip_version` - (Optional, Int, ForceNew) Specifies the IP version, either `4` (default) or `6`.
+  Changing this will create a new VIP resource.
 
-* `name` - (Optional) A unique name for the vip.
+* `ip_address` - (Optional, String, ForceNew) Specifies the IP address desired in the subnet for this VIP.
+  Changing this will create a new VIP resource.
+
+* `name` - (Optional, String) Specifies a unique name for the VIP.
 
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
-* `network_id` - See Argument Reference above.
-* `subnet_id` - See Argument Reference above.
-* `ip_address` - See Argument Reference above.
-* `name` - See Argument Reference above.
-* `status` - The status of vip.
-* `id` - The ID of the vip.
-* `tenant_id` - The tenant ID of the vip.
-* `device_owner` - The device owner of the vip.
+* `id` - The VIP ID.
+
+* `mac_address` - The MAC address of the VIP.
+
+* `status` - The VIP status.
+
+* `device_owner` - The device owner of the VIP.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 2 minute.
+* `delete` - Default is 2 minute.
+
+## Import
+
+Network VIPs can be imported using their `id`, e.g.:
+
+```shell
+terraform import flexibleengine_networking_vip_v2.test ce595799-da26-4015-8db5-7733c6db292e
+```

--- a/flexibleengine/resource_flexibleengine_networking_vip_v2.go
+++ b/flexibleengine/resource_flexibleengine_networking_vip_v2.go
@@ -3,34 +3,58 @@ package flexibleengine
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"time"
 
-	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/networking/v2/ports"
+	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/networking/v1/ports"
+	"github.com/chnsz/golangsdk/openstack/networking/v1/subnets"
 )
 
 func resourceNetworkingVIPV2() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceNetworkingVIPV2Create,
-		Read:   resourceNetworkingVIPV2Read,
-		Delete: resourceNetworkingVIPV2Delete,
+		Create: resourceNetworkingVIPCreate,
+		Read:   resourceNetworkingVIPRead,
+		Update: resourceNetworkingVIPUpdate,
+		Delete: resourceNetworkingVIPDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(2 * time.Minute),
+			Delete: schema.DefaultTimeout(2 * time.Minute),
+		},
 
 		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
 			"network_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"subnet_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+			"ip_version": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: validation.IntInSlice([]int{4, 6}),
 			},
 			"ip_address": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 				Computed: true,
 			},
 			"name": {
@@ -38,11 +62,13 @@ func resourceNetworkingVIPV2() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+
+			// Computed
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"tenant_id": {
+			"mac_address": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -50,95 +76,165 @@ func resourceNetworkingVIPV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			// Deprecated
+			"subnet_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      true,
+				ConflictsWith: []string{"ip_version"},
+				Deprecated:    "use ip_version instead",
+			},
 		},
 	}
 }
 
-func resourceNetworkingVIPV2Create(d *schema.ResourceData, meta interface{}) error {
+func resourceNetworkingVIPCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	client, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating VPC v1 client: %s", err)
 	}
 
-	// Contruct CreateOpts
-	fixip := make([]ports.IP, 1)
-	fixip[0] = ports.IP{
-		SubnetID:  d.Get("subnet_id").(string),
-		IPAddress: d.Get("ip_address").(string),
+	networkId := d.Get("network_id").(string)
+	n, err := subnets.Get(client, networkId).Extract()
+	if err != nil {
+		return fmt.Errorf("Error retrieving subnet by network ID (%s): %s", networkId, err)
 	}
-	createOpts := ports.CreateOpts{
+
+	// Check whether the subnet ID entered by the user belongs to the same subnet as the network ID.
+	subnetId := d.Get("subnet_id").(string)
+	if subnetId != "" && subnetId != n.SubnetId && subnetId != n.IPv6SubnetId {
+		return fmt.Errorf("The subnet ID does not belong to the subnet where the network ID is located.")
+	}
+
+	// Pre-check for subnet network, the virtual IP of IPv6 must be established on the basis that the subnet supports
+	// IPv6.
+	if d.Get("ip_version").(int) == 6 {
+		if n.IPv6SubnetId == "" {
+			return fmt.Errorf("The subnet does not support IPv6, please enable IPv6 first.")
+		}
+		subnetId = n.IPv6SubnetId
+	} else {
+		subnetId = n.SubnetId
+	}
+
+	opts := ports.CreateOpts{
 		Name:        d.Get("name").(string),
-		NetworkID:   d.Get("network_id").(string),
-		FixedIPs:    fixip,
 		DeviceOwner: "neutron:VIP_PORT",
+		NetworkId:   networkId,
+		FixedIps: []ports.FixedIp{
+			{
+				SubnetId:  subnetId,
+				IpAddress: d.Get("ip_address").(string),
+			},
+		},
 	}
 
-	log.Printf("[DEBUG] Create Options: %#v", createOpts)
-	vip, err := ports.Create(networkingClient, createOpts).Extract()
+	log.Printf("[DEBUG] Creating network VIP (%s) with options: %#v", d.Id(), opts)
+	vip, err := ports.Create(client, opts)
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine Neutron network: %s", err)
+		return fmt.Errorf("Error creating network VIP: %s", err)
 	}
-	log.Printf("[DEBUG] Waiting for FlexibleEngine Neutron VIP (%s) to become available.", vip.ID)
 
+	d.SetId(vip.ID)
+	log.Printf("[DEBUG] Waiting for network VIP (%s) to become available.", vip.ID)
 	stateConf := &resource.StateChangeConf{
-		Target:     []string{"ACTIVE"},
-		Refresh:    waitForNetworkVIPActive(networkingClient, vip.ID),
+		Pending:    []string{"BUILD"},
+		Target:     []string{"DOWN", "ACTIVE"},
+		Refresh:    waitForNetworkVIPActive(client, vip.ID),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      5 * time.Second,
+		Delay:      3 * time.Second,
 		MinTimeout: 3 * time.Second,
 	}
 
 	_, err = stateConf.WaitForState()
-
-	d.SetId(vip.ID)
-
-	return resourceNetworkingVIPV2Read(d, meta)
-}
-
-func resourceNetworkingVIPV2Read(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return err
 	}
 
-	vip, err := ports.Get(networkingClient, d.Id()).Extract()
+	return resourceNetworkingVIPRead(d, meta)
+}
+
+func resourceNetworkingVIPRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	region := config.GetRegion(d)
+	client, err := config.NetworkingV1Client(region)
 	if err != nil {
-		return CheckDeleted(d, err, "vip")
+		return fmt.Errorf("Error creating VPC v1 client: %s", err)
+	}
+
+	vip, err := ports.Get(client, d.Id())
+	if err != nil {
+		return CheckDeleted(d, err, "VPC network VIP")
 	}
 
 	log.Printf("[DEBUG] Retrieved VIP %s: %+v", d.Id(), vip)
 
-	// Computed values
-	d.Set("network_id", vip.NetworkID)
-	if len(vip.FixedIPs) > 0 {
-		d.Set("subnet_id", vip.FixedIPs[0].SubnetID)
-		d.Set("ip_address", vip.FixedIPs[0].IPAddress)
-	} else {
-		d.Set("subnet_id", "")
-		d.Set("ip_address", "")
-	}
-	d.Set("name", vip.Name)
-	d.Set("status", vip.Status)
-	d.SetId(vip.ID)
-	d.Set("tenant_id", vip.TenantID)
-	d.Set("device_owner", vip.DeviceOwner)
+	mErr := multierror.Append(nil,
+		d.Set("region", region),
+		d.Set("name", vip.Name),
+		d.Set("status", normalizeNetworkVipStatus(vip.Status)),
+		d.Set("device_owner", vip.DeviceOwner),
+		d.Set("mac_address", vip.MacAddress),
+		d.Set("network_id", vip.NetworkId),
+		setVipNetworkParams(d, vip),
+	)
 
+	return mErr.ErrorOrNil()
+}
+
+func setVipNetworkParams(d *schema.ResourceData, port *ports.Port) error {
+	if len(port.FixedIps) > 0 {
+		addr := port.FixedIps[0].IpAddress
+		var ipVersion int
+		if isIPv4Address(addr) {
+			ipVersion = 4
+		} else {
+			ipVersion = 6
+		}
+		mErr := multierror.Append(nil,
+			d.Set("ip_version", ipVersion),
+			d.Set("ip_address", addr),
+			d.Set("subnet_id", port.FixedIps[0].SubnetId),
+		)
+		return mErr.ErrorOrNil()
+	}
 	return nil
 }
 
-func resourceNetworkingVIPV2Delete(d *schema.ResourceData, meta interface{}) error {
+func resourceNetworkingVIPUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	client, err := config.NetworkingV1Client(config.GetRegion(d))
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating VPC v1 client: %s", err)
+	}
+
+	opts := ports.UpdateOpts{
+		Name: d.Get("name").(string),
+	}
+
+	log.Printf("[DEBUG] Updating network VIP (%s) with options: %#v", d.Id(), opts)
+	_, err = ports.Update(client, d.Id(), opts)
+	if err != nil {
+		return fmt.Errorf("Error updating networking VIP: %s", err)
+	}
+
+	return resourceNetworkingVIPRead(d, meta)
+}
+
+func resourceNetworkingVIPDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	client, err := config.NetworkingV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("Error creating VPC v1 client: %s", err)
 	}
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"ACTIVE"},
 		Target:     []string{"DELETED"},
-		Refresh:    waitForNetworkVIPDelete(networkingClient, d.Id()),
+		Refresh:    waitForNetworkVIPDelete(client, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
 		Delay:      5 * time.Second,
 		MinTimeout: 3 * time.Second,
@@ -146,21 +242,21 @@ func resourceNetworkingVIPV2Delete(d *schema.ResourceData, meta interface{}) err
 
 	_, err = stateConf.WaitForState()
 	if err != nil {
-		return fmt.Errorf("Error deleting FlexibleEngine Neutron Network: %s", err)
+		return fmt.Errorf("Error deleting FlexibleEngine networking VIP: %s", err)
 	}
 
 	d.SetId("")
 	return nil
 }
 
-func waitForNetworkVIPActive(networkingClient *golangsdk.ServiceClient, vipid string) resource.StateRefreshFunc {
+func waitForNetworkVIPActive(vpcClient *golangsdk.ServiceClient, vipid string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		p, err := ports.Get(networkingClient, vipid).Extract()
+		p, err := ports.Get(vpcClient, vipid)
 		if err != nil {
 			return nil, "", err
 		}
 
-		log.Printf("[DEBUG] FlexibleEngine Neutron Port: %+v", p)
+		log.Printf("[DEBUG] FlexibleEngine networking VIP port: %+v", p)
 		if p.Status == "DOWN" || p.Status == "ACTIVE" {
 			return p, "ACTIVE", nil
 		}
@@ -169,11 +265,11 @@ func waitForNetworkVIPActive(networkingClient *golangsdk.ServiceClient, vipid st
 	}
 }
 
-func waitForNetworkVIPDelete(networkingClient *golangsdk.ServiceClient, vipid string) resource.StateRefreshFunc {
+func waitForNetworkVIPDelete(vpcClient *golangsdk.ServiceClient, vipid string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		log.Printf("[DEBUG] Attempting to delete FlexibleEngine Neutron VIP %s", vipid)
+		log.Printf("[DEBUG] Attempting to delete FlexibleEngine networking VIP port %s", vipid)
 
-		p, err := ports.Get(networkingClient, vipid).Extract()
+		p, err := ports.Get(vpcClient, vipid)
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
 				log.Printf("[DEBUG] Successfully deleted FlexibleEngine VIP %s", vipid)
@@ -182,7 +278,7 @@ func waitForNetworkVIPDelete(networkingClient *golangsdk.ServiceClient, vipid st
 			return p, "ACTIVE", err
 		}
 
-		err = ports.Delete(networkingClient, vipid).ExtractErr()
+		err = ports.Delete(vpcClient, vipid).ExtractErr()
 		if err != nil {
 			if _, ok := err.(golangsdk.ErrDefault404); ok {
 				log.Printf("[DEBUG] Successfully deleted FlexibleEngine VIP %s", vipid)
@@ -194,4 +290,19 @@ func waitForNetworkVIPDelete(networkingClient *golangsdk.ServiceClient, vipid st
 		log.Printf("[DEBUG] FlexibleEngine VIP %s still active.\n", vipid)
 		return p, "ACTIVE", nil
 	}
+}
+
+// isIPv4Address is used to check whether the addr string is IPv4 format
+func isIPv4Address(addr string) bool {
+	pattern := "^((25[0-5]|2[0-4]\\d|(1\\d{2}|[1-9]?\\d))\\.){3}(25[0-5]|2[0-4]\\d|(1\\d{2}|[1-9]?\\d))$"
+	matched, _ := regexp.MatchString(pattern, addr)
+	return matched
+}
+
+// For VIP ports, the status will always be 'DOWN'.
+func normalizeNetworkVipStatus(status string) string {
+	if status == "DOWN" {
+		return "ACTIVE"
+	}
+	return status
 }

--- a/flexibleengine/resource_flexibleengine_networking_vip_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_networking_vip_v2_test.go
@@ -2,17 +2,20 @@ package flexibleengine
 
 import (
 	"fmt"
-	"log"
 	"testing"
 
-	"github.com/chnsz/golangsdk/openstack/networking/v2/ports"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/networking/v1/ports"
 )
 
 // TestAccNetworkingV2VIP_basic is basic acc test.
 func TestAccNetworkingV2VIP_basic(t *testing.T) {
 	var vip ports.Port
+	resourceName := "flexibleengine_networking_vip_v2.vip_1"
+	rName := fmt.Sprintf("tf_test_%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheckFloatingIP(t) },
@@ -20,10 +23,24 @@ func TestAccNetworkingV2VIP_basic(t *testing.T) {
 		CheckDestroy: testAccCheckNetworkingV2VIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: TestAccNetworkingV2VIPConfig_basic,
+				Config: testAccNetworkingVIP_basic(rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckNetworkingV2VIPExists("flexibleengine_networking_vip_v2.vip_1", &vip),
+					testAccCheckNetworkingV2VIPExists(resourceName, &vip),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "ip_version", "4"),
+					resource.TestCheckResourceAttrSet(resourceName, "mac_address"),
 				),
+			},
+			{
+				Config: testAccNetworkingVIP_basic(rName + "_update"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"_update"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -32,9 +49,9 @@ func TestAccNetworkingV2VIP_basic(t *testing.T) {
 // testAccCheckNetworkingV2VIPDestroy checks destory.
 func testAccCheckNetworkingV2VIPDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
-	networkingClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+	vpcClient, err := config.NetworkingV1Client(OS_REGION_NAME)
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+		return fmt.Errorf("Error creating FlexibleEngine VPC v1 client: %s", err)
 	}
 
 	for _, rs := range s.RootModule().Resources {
@@ -42,13 +59,11 @@ func testAccCheckNetworkingV2VIPDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := ports.Get(networkingClient, rs.Primary.ID).Extract()
+		_, err := ports.Get(vpcClient, rs.Primary.ID)
 		if err == nil {
 			return fmt.Errorf("VIP still exists")
 		}
 	}
-
-	log.Printf("[DEBUG] testAccCheckNetworkingV2VIPDestroy success!")
 
 	return nil
 }
@@ -66,12 +81,12 @@ func testAccCheckNetworkingV2VIPExists(n string, vip *ports.Port) resource.TestC
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		networkingClient, err := config.NetworkingV2Client(OS_REGION_NAME)
+		vpcClient, err := config.NetworkingV1Client(OS_REGION_NAME)
 		if err != nil {
-			return fmt.Errorf("Error creating FlexibleEngine networking client: %s", err)
+			return fmt.Errorf("Error creating FlexibleEngine VPC v1 client: %s", err)
 		}
 
-		found, err := ports.Get(networkingClient, rs.Primary.ID).Extract()
+		found, err := ports.Get(vpcClient, rs.Primary.ID)
 		if err != nil {
 			return err
 		}
@@ -79,39 +94,29 @@ func testAccCheckNetworkingV2VIPExists(n string, vip *ports.Port) resource.TestC
 		if found.ID != rs.Primary.ID {
 			return fmt.Errorf("VIP not found")
 		}
-		log.Printf("[DEBUG] test found is: %#v", found)
-		*vip = *found
 
+		*vip = *found
 		return nil
 	}
 }
 
-// TestAccNetworkingV2VIPConfig_basic is used to create.
-var TestAccNetworkingV2VIPConfig_basic = fmt.Sprintf(`
-resource "flexibleengine_networking_network_v2" "network_1" {
-  name = "network_1"
-  admin_state_up = "true"
+func testAccNetworkingVIP_basic(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc_v1" "vpc_1" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
 }
 
-resource "flexibleengine_networking_subnet_v2" "subnet_1" {
-  name = "subnet_1"
-  cidr = "192.168.199.0/24"
-  ip_version = 4
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
-}
-
-resource "flexibleengine_networking_router_interface_v2" "router_interface_1" {
-  router_id = "${flexibleengine_networking_router_v2.router_1.id}"
-  subnet_id = "${flexibleengine_networking_subnet_v2.subnet_1.id}"
-}
-
-resource "flexibleengine_networking_router_v2" "router_1" {
-  name = "router_1"
-  external_gateway = "%s"
+resource "flexibleengine_vpc_subnet_v1" "subnet_1" {
+  name       = "%[1]s"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = flexibleengine_vpc_v1.vpc_1.id
 }
 
 resource "flexibleengine_networking_vip_v2" "vip_1" {
-  network_id = "${flexibleengine_networking_network_v2.network_1.id}"
-  subnet_id = "${flexibleengine_networking_subnet_v2.subnet_1.id}"
+  name       = "%[1]s"
+  network_id = flexibleengine_vpc_subnet_v1.subnet_1.id
 }
-`, OS_EXTGW_ID)
+`, rName)
+}


### PR DESCRIPTION
related to #857 

```
$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccNetworkingV2VIP_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccNetworkingV2VIP_basic -timeout 720m
=== RUN   TestAccNetworkingV2VIP_basic
--- PASS: TestAccNetworkingV2VIP_basic (103.70s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 103.784s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccNetworkingV2VIPAssociate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccNetworkingV2VIPAssociate_basic -timeout 720m
=== RUN   TestAccNetworkingV2VIPAssociate_basic
--- PASS: TestAccNetworkingV2VIPAssociate_basic (120.93s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 121.018s
```