### PR TITLE
feat(dds): add import for DDS Instance

### DIFF
--- a/docs/resources/as_policy_v1.md
+++ b/docs/resources/as_policy_v1.md
@@ -146,5 +146,5 @@ The following attributes are exported:
 Auto Scaling policy can be imported using the `id`, e.g.
 
 ```shell
-$ terraform import flexibleengine_as_policy_v1.hth_aspolicy 5f3b5f5e-1b5f-4b5a-8f32-53dcb9d9053a
+terraform import flexibleengine_as_policy_v1.hth_aspolicy 5f3b5f5e-1b5f-4b5a-8f32-53dcb9d9053a
 ```

--- a/docs/resources/dds_instance_v3.md
+++ b/docs/resources/dds_instance_v3.md
@@ -35,7 +35,7 @@ resource "flexibleengine_dds_instance_v3" "instance" {
   vpc_id            = flexibleengine_vpc_v1.example_vpc.id
   subnet_id         = flexibleengine_vpc_subnet_v1.example_subnet.id
   security_group_id = flexibleengine_networking_secgroup_v2.example_secgroup.id
-  password          = "Test@123"
+  password          = "Examp1e!Pa88w0rd"
   mode              = "Sharding"
 
   datastore {
@@ -79,7 +79,7 @@ resource "flexibleengine_dds_instance_v3" "instance" {
   vpc_id            = flexibleengine_vpc_v1.example_vpc.id
   subnet_id         = flexibleengine_vpc_subnet_v1.example_subnet.id
   security_group_id = flexibleengine_networking_secgroup_v2.example_secgroup.id
-  password          = "Test@123"
+  password          = "Examp1e!Pa88w0rd"
   mode              = "ReplicaSet"
 
   datastore {
@@ -168,24 +168,24 @@ The `flavor` block supports:
 
 * `spec_code` - (Required) Specifies the resource specification code. Valid values:
 
-engine_name | type | vcpus | ram | speccode
----- | --- | ---
-DDS-Community | mongos | 1 | 4 | dds.mongodb.s3.medium.4.mongos
-DDS-Community | mongos | 2 | 8 | dds.mongodb.s3.large.4.mongos
-DDS-Community | mongos | 4 | 16 | dds.mongodb.s3.xlarge.4.mongos
-DDS-Community | mongos | 8 | 32 | dds.mongodb.s3.2xlarge.4.mongos
-DDS-Community | mongos | 16 | 64 | dds.mongodb.s3.4xlarge.4.mongos
-DDS-Community | shard | 1 | 4 | dds.mongodb.s3.medium.4.shard
-DDS-Community | shard | 2 | 8 | dds.mongodb.s3.large.4.shard
-DDS-Community | shard | 4 | 16 | dds.mongodb.s3.xlarge.4.shard
-DDS-Community | shard | 8 | 32 | dds.mongodb.s3.2xlarge.4.shard
-DDS-Community | shard | 16 | 64 | dds.mongodb.s3.4xlarge.4.shard
-DDS-Community | config | 2 | 4 | dds.mongodb.s3.large.2.config
-DDS-Community | replica | 1 | 4 | dds.mongodb.s3.medium.4.repset
-DDS-Community | replica | 2 | 8 | dds.mongodb.s3.large.4.repset
-DDS-Community | replica | 4 | 16 | dds.mongodb.s3.xlarge.4.repset
-DDS-Community | replica | 8 | 32 | dds.mongodb.s3.2xlarge.4.repset
-DDS-Community | replica | 16 | 64 | dds.mongodb.s3.4xlarge.4.repset
+| engine_name   | type    | vcpus | ram | speccode                        |
+| ------------- | ------- | ----- |
+| DDS-Community | mongos  | 1     | 4   | dds.mongodb.s3.medium.4.mongos  |
+| DDS-Community | mongos  | 2     | 8   | dds.mongodb.s3.large.4.mongos   |
+| DDS-Community | mongos  | 4     | 16  | dds.mongodb.s3.xlarge.4.mongos  |
+| DDS-Community | mongos  | 8     | 32  | dds.mongodb.s3.2xlarge.4.mongos |
+| DDS-Community | mongos  | 16    | 64  | dds.mongodb.s3.4xlarge.4.mongos |
+| DDS-Community | shard   | 1     | 4   | dds.mongodb.s3.medium.4.shard   |
+| DDS-Community | shard   | 2     | 8   | dds.mongodb.s3.large.4.shard    |
+| DDS-Community | shard   | 4     | 16  | dds.mongodb.s3.xlarge.4.shard   |
+| DDS-Community | shard   | 8     | 32  | dds.mongodb.s3.2xlarge.4.shard  |
+| DDS-Community | shard   | 16    | 64  | dds.mongodb.s3.4xlarge.4.shard  |
+| DDS-Community | config  | 2     | 4   | dds.mongodb.s3.large.2.config   |
+| DDS-Community | replica | 1     | 4   | dds.mongodb.s3.medium.4.repset  |
+| DDS-Community | replica | 2     | 8   | dds.mongodb.s3.large.4.repset   |
+| DDS-Community | replica | 4     | 16  | dds.mongodb.s3.xlarge.4.repset  |
+| DDS-Community | replica | 8     | 32  | dds.mongodb.s3.2xlarge.4.repset |
+| DDS-Community | replica | 16    | 64  | dds.mongodb.s3.4xlarge.4.repset |
 
 The `backup_strategy` block supports:
 
@@ -223,3 +223,18 @@ The `nodes` block contains:
   mongos nodes of cluster instances, primary nodes and secondary nodes of replica set instances,
   and single node instances.
 * `status` - Indicates the node status.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default 30 minutes.
+* `delete` - Default 30 minutes.
+
+## Import
+
+DDS instance can be imported using the `id`, e.g.
+  
+```shell
+terraform import flexibleengine_dds_instance.instance 1a2b3c4d-5e6f-7g8h-9i0j-1a2b3c4d5e6f
+```

--- a/flexibleengine/resource_flexibleengine_dds_instance_v3.go
+++ b/flexibleengine/resource_flexibleengine_dds_instance_v3.go
@@ -3,6 +3,7 @@ package flexibleengine
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -21,6 +22,9 @@ func resourceDdsInstanceV3() *schema.Resource {
 		Read:   resourceDdsInstanceV3Read,
 		Update: resourceDdsInstanceV3Update,
 		Delete: resourceDdsInstanceV3Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
@@ -98,6 +102,13 @@ func resourceDdsInstanceV3() *schema.Resource {
 				Sensitive: true,
 				Required:  true,
 				ForceNew:  true,
+				ValidateFunc: validation.All(
+					validation.StringMatch(regexp.MustCompile(`[A-Z]`), "The password must contain at least one uppercase letter."),
+					validation.StringMatch(regexp.MustCompile(`[a-z]`), "The password must contain at least one lowercase letter."),
+					validation.StringMatch(regexp.MustCompile(`[0-9]`), "The password must contain at least one digit."),
+					validation.StringMatch(regexp.MustCompile(`[~!@#%^*-_=+?]`), "The password must contain at least one special character ( ~!@#%^*-_=+? )."),
+					validation.StringLenBetween(8, 32),
+				),
 			},
 			"disk_encryption_id": {
 				Type:      schema.TypeString,

--- a/flexibleengine/resource_flexibleengine_dds_instance_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_dds_instance_v3_test.go
@@ -31,6 +31,16 @@ func TestAccDDSV3Instance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+					"availability_zone",
+					"flavor",
+				},
+			},
 		},
 	})
 }
@@ -116,7 +126,7 @@ resource "flexibleengine_dds_instance_v3" "instance" {
   vpc_id            = "%s"
   subnet_id         = "%s"
   security_group_id = flexibleengine_networking_secgroup_v2.secgroup_1.id
-  password          = "Test@123"
+  password          = "j4!GBzt9"
   mode              = "Sharding"
 
   datastore {


### PR DESCRIPTION
Add importer for `flexibleengine_dds_instance_v3`

```diff
diff --git a/flexibleengine/resource_flexibleengine_dds_instance_v3.go b/flexibleengine/resource_flexibleengine_dds_instance_v3.go

@@ -21,6 +22,9 @@ func resourceDdsInstanceV3() *schema.Resource {
                Read:   resourceDdsInstanceV3Read,
                Update: resourceDdsInstanceV3Update,
                Delete: resourceDdsInstanceV3Delete,
+               Importer: &schema.ResourceImporter{
+                       State: schema.ImportStatePassthrough,
+               },
```

```diff
diff --git a/flexibleengine/resource_flexibleengine_dds_instance_v3_test.go b/flexibleengine/resource_flexibleengine_dds_instance_v3_test.go

@@ -31,6 +31,16 @@ func TestAccDDSV3Instance_basic(t *testing.T) {
                                        resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
                                ),
                        },
+                       {
+                               ResourceName:      resourceName,
+                               ImportState:       true,
+                               ImportStateVerify: true,
+                               ImportStateVerifyIgnore: []string{
+                                       "password",
+                                       "availability_zone",
+                                       "flavor",
+                               },
+                       },
```

Add password `ValidateFunc`

```diff
diff --git a/flexibleengine/resource_flexibleengine_dds_instance_v3.go b/flexibleengine/resource_flexibleengine_dds_instance_v3.go

@@ -98,6 +102,13 @@ func resourceDdsInstanceV3() *schema.Resource {
                                Sensitive: true,
                                Required:  true,
                                ForceNew:  true,
+                               ValidateFunc: validation.All(
+                                       validation.StringMatch(regexp.MustCompile(`[A-Z]`), "The password must contain at least one uppercase letter."),
+                                       validation.StringMatch(regexp.MustCompile(`[a-z]`), "The password must contain at least one lowercase letter."),
+                                       validation.StringMatch(regexp.MustCompile(`[0-9]`), "The password must contain at least one digit."),
+                                       validation.StringMatch(regexp.MustCompile(`[~!@#%^*-_=+?]`), "The password must contain at least one special character ( ~!@#%^*-_=+? )."),
+                                       validation.StringLenBetween(8, 32),
+                               ),
```

Improve documentation with added Timeout and Import

```diff
@@ -223,3 +223,18 @@ The `nodes` block contains:
   mongos nodes of cluster instances, primary nodes and secondary nodes of replica set instances,
   and single node instances.
 * `status` - Indicates the node status.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default 30 minutes.
+* `delete` - Default 30 minutes.
+
+## Import
+
+DDS instance can be imported using the `id`, e.g.
+  
+```shell
+terraform import flexibleengine_dds_instance.instance 1a2b3c4d-5e6f-7g8h-9i0j-1a2b3c4d5e6f
+```
```

Fix Password format in example doc and in test

```diff
diff --git a/docs/resources/dds_instance_v3.md b/docs/resources/dds_instance_v3.md

@@ -35,7 +35,7 @@ resource "flexibleengine_dds_instance_v3" "instance" {
   vpc_id            = flexibleengine_vpc_v1.example_vpc.id
   subnet_id         = flexibleengine_vpc_subnet_v1.example_subnet.id
   security_group_id = flexibleengine_networking_secgroup_v2.example_secgroup.id
-  password          = "Test@123"
+  password          = "Examp1e!Pa88w0rd"
   mode              = "Sharding"
 
   datastore {
@@ -79,7 +79,7 @@ resource "flexibleengine_dds_instance_v3" "instance" {
   vpc_id            = flexibleengine_vpc_v1.example_vpc.id
   subnet_id         = flexibleengine_vpc_subnet_v1.example_subnet.id
   security_group_id = flexibleengine_networking_secgroup_v2.example_secgroup.id
-  password          = "Test@123"
+  password          = "Examp1e!Pa88w0rd"
   mode              = "ReplicaSet"
```

```diff
diff --git a/flexibleengine/resource_flexibleengine_dds_instance_v3_test.go b/flexibleengine/resource_flexibleengine_dds_instance_v3_test.go

@@ -31,6 +31,16 @@ func TestAccDDSV3Instance_basic(t *testing.T) {
                                        resource.TestCheckResourceAttr(resourceName, "tags.owner", "terraform"),
                                ),
                        },
+                       {
+                               ResourceName:      resourceName,
+                               ImportState:       true,
+                               ImportStateVerify: true,
+                               ImportStateVerifyIgnore: []string{
+                                       "password",
+                                       "availability_zone",
+                                       "flavor",
+                               },
+                       },
                },
        })
 }
@@ -116,7 +126,7 @@ resource "flexibleengine_dds_instance_v3" "instance" {
   vpc_id            = "%s"
   subnet_id         = "%s"
   security_group_id = flexibleengine_networking_secgroup_v2.secgroup_1.id
-  password          = "Test@123"
+  password          = "j4!GBzt9"
   mode              = "Sharding"
```

if using `Test@123` in test API return this error 
```sh
=== RUN   TestAccDDSV3Instance_basic
    resource_flexibleengine_dds_instance_v3_test.go:18: Step 1/2 error: Error running apply: exit status 1
        
        Error: Error getting instance from result: Bad request with: [POST https://dds.eu-west-0.prod-cloud-ocb.orange-business.com/v3/5764591bf7ac4dd282dfbebb3e266701/instances], error message: {"error_code":"DBS.200068","error_msg":"The password is too easy to guess."} 
```