### PR TITLE
fix(dli/table): fix error returned id not found

### DIFF
--- a/flexibleengine/resource_flexibleengine_dli_table.go
+++ b/flexibleengine/resource_flexibleengine_dli_table.go
@@ -1,0 +1,368 @@
+package flexibleengine
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/chnsz/golangsdk/openstack/dli/v1/tables"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func ResourceDliTable() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceDliTableCreate,
+		ReadContext:   resourceDliTableRead,
+		DeleteContext: resourceDliTableDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"database_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"data_location": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"columns": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"description": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+						"is_partition": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"data_format": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: validation.StringInSlice([]string{"parquet", "orc", "csv", "json", "carbon", "avro"},
+					true),
+				Computed: true,
+			},
+			"bucket_location": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"with_column_header": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"delimiter": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"quote_char": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"escape_char": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"date_format": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"timestamp_format": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+	}
+}
+
+func resourceDliTableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	region := GetRegion(d, config)
+	client, err := config.DliV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating DLI v1 client, err=%s", err)
+	}
+	databaseName := d.Get("database_name").(string)
+	tableName := d.Get("name").(string)
+	opts := tables.CreateTableOpts{
+		TableName:       tableName,
+		DataLocation:    d.Get("data_location").(string),
+		Columns:         buildColumnParam(d),
+		Description:     d.Get("description").(string),
+		DataType:        d.Get("data_format").(string),
+		DataPath:        d.Get("bucket_location").(string),
+		Delimiter:       d.Get("delimiter").(string),
+		QuoteChar:       d.Get("quote_char").(string),
+		EscapeChar:      d.Get("escape_char").(string),
+		DateFormat:      d.Get("date_format").(string),
+		TimestampFormat: d.Get("timestamp_format").(string),
+	}
+
+	if v, ok := d.GetOk("with_column_header"); ok {
+		opts.WithColumnHeader = utils.Bool(v.(bool))
+	}
+
+	log.Printf("[DEBUG] Creating new DLI table opts: %#v", opts)
+
+	rst, createErr := tables.Create(client, databaseName, opts)
+	if createErr != nil {
+		return diag.Errorf("Error creating DLI table: %s", createErr)
+	}
+
+	if rst != nil && !rst.IsSuccess {
+		return diag.Errorf("Error creating DLI table: %s", rst.Message)
+	}
+
+	d.SetId(fmt.Sprintf("%s/%s", databaseName, tableName))
+	return resourceDliTableRead(ctx, d, meta)
+}
+
+func resourceDliTableRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	region := config.GetRegion(d)
+	client, err := config.DliV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating DLI v1 client, err=%s", err)
+	}
+
+	databaseName, tableName := ParseTableInfoFromId(d.Id())
+
+	detail, dErr := tables.Get(client, databaseName, tableName)
+	if dErr != nil {
+		_, errCode := parseResponseToDliError(dErr)
+		if errCode == "DLI.0002" {
+			d.SetId("")
+			log.Printf("[WARN] DLI table %s not found", d.Id())
+			return nil
+		}
+		return diag.Errorf("Error query DLI Table %q:%s", d.Id(), dErr)
+	}
+
+	if detail != nil && !detail.IsSuccess {
+		return diag.Errorf("Error query DLI Table: %s", detail.Message)
+	}
+
+	tbList, tbErr := tables.List(client, databaseName, tables.ListOpts{
+		Keyword:    tableName,
+		WithDetail: utils.Bool(true),
+		WithPriv:   utils.Bool(true),
+	})
+	if tbErr != nil {
+		return diag.Errorf("Error query DLI Table %q:%s", d.Id(), tbErr)
+	}
+
+	if tbList != nil && !tbList.IsSuccess {
+		return diag.Errorf("Error query DLI Table: %s", tbList.Message)
+	}
+
+	tb, fErr := filterByTableName(tbList.Tables, tableName)
+	if fErr != nil {
+		return diag.Errorf("Error query DLI Table: %s", tbList.Message)
+	}
+
+	mErr := multierror.Append(
+		d.Set("database_name", databaseName),
+		d.Set("name", tableName),
+		d.Set("data_location", tb.DataLocation),
+		setColumnsToState(d, detail.Columns),
+		d.Set("description", detail.TableComment),
+		d.Set("data_format", tb.DataType),
+		d.Set("bucket_location", tb.Location),
+		setStoragePropertiesToState(d, detail.StorageProperties),
+	)
+	if setSdErr := mErr.ErrorOrNil(); setSdErr != nil {
+		return diag.Errorf("Error setting vault fields: %s", setSdErr)
+	}
+
+	return nil
+}
+
+func setColumnsToState(d *schema.ResourceData, columns []tables.Column) error {
+	if len(columns) == 0 {
+		return nil
+	}
+
+	result := make([]interface{}, 0, len(columns))
+	for _, column := range columns {
+		item := map[string]interface{}{
+			"name":         column.ColumnName,
+			"type":         column.Type,
+			"description":  column.Description,
+			"is_partition": column.IsPartitionColumn,
+		}
+		result = append(result, item)
+	}
+
+	return d.Set("columns", result)
+}
+
+func setStoragePropertiesToState(d *schema.ResourceData, storageProperties []map[string]interface{}) error {
+	if len(storageProperties) == 0 {
+		return nil
+	}
+	var mErr *multierror.Error
+	for _, properties := range storageProperties {
+		switch properties["key"] {
+		case "delimiter":
+			mErr = multierror.Append(d.Set("delimiter", properties["value"]))
+		case "quote":
+			mErr = multierror.Append(d.Set("quote_char", properties["value"]))
+		case "escape":
+			mErr = multierror.Append(d.Set("escape_char", properties["value"]))
+		case "dateformat":
+			mErr = multierror.Append(d.Set("date_format", properties["value"]))
+		case "timestampformat":
+			mErr = multierror.Append(d.Set("timestamp_format", properties["value"]))
+		case "header":
+			mErr = multierror.Append(d.Set("with_column_header", properties["value"].(string) == "true"))
+		}
+	}
+	if setSdErr := mErr.ErrorOrNil(); setSdErr != nil {
+		return fmt.Errorf("Error setting vault fields: %s", setSdErr)
+	}
+	return nil
+}
+
+func resourceDliTableDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	region := config.GetRegion(d)
+	client, err := config.DliV1Client(region)
+	if err != nil {
+		return diag.Errorf("error creating DLI v1 client, err=%s", err)
+	}
+
+	databaseName, tableName := ParseTableInfoFromId(d.Id())
+
+	resp, dErr := tables.Delete(client, databaseName, tableName, false)
+	if dErr != nil {
+		return diag.Errorf("Error delete DLI Table %q:%s", d.Id(), dErr)
+	}
+
+	if resp != nil && !resp.IsSuccess {
+		return diag.Errorf("Error delete DLI Table: %s", resp.Message)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func buildColumnParam(d *schema.ResourceData) []tables.ColumnOpts {
+	var rt []tables.ColumnOpts
+	columns := d.Get("columns").([]interface{})
+	if len(columns) > 0 {
+		for _, raw := range columns {
+			config := raw.(map[string]interface{})
+			column := tables.ColumnOpts{
+				ColumnName:        config["name"].(string),
+				Type:              config["type"].(string),
+				Description:       config["description"].(string),
+				IsPartitionColumn: utils.Bool(config["is_partition"].(bool)),
+			}
+			rt = append(rt, column)
+		}
+
+	}
+
+	return rt
+}
+
+func ParseTableInfoFromId(id string) (databaseName, tableName string) {
+	idArrays := strings.Split(id, "/")
+	databaseName = idArrays[0]
+	tableName = idArrays[1]
+	return
+}
+
+func filterByTableName(tablesResp []tables.Table4List, tableName string) (*tables.Table4List, error) {
+	log.Printf("[DEBUG]The list of table from SDK:%+v", tablesResp)
+	for _, v := range tablesResp {
+		if v.TableName == tableName {
+			return &v, nil
+		}
+	}
+	return &tables.Table4List{}, fmt.Errorf("table (%s) does not existed.", tableName)
+
+}
+
+func parseResponseToDliError(data interface{}) (errCode, errMsg string) {
+
+	errorCode, err := navigateValue(data, []string{"error_code"}, nil)
+	if err != nil {
+		return "", ""
+	}
+	// ignore empty errpr_code
+	e, err := isEmptyValue(reflect.ValueOf(errorCode))
+	if err == nil && e {
+		return "", ""
+	}
+
+	errorMsg, err := navigateValue(data, []string{"error_msg"}, nil)
+	if err != nil {
+		return "", ""
+	}
+
+	return errorCode.(string), errorMsg.(string)
+}


### PR DESCRIPTION
This PR is related to this issue ([provider-flexibleengine](https://github.com/FrangipaneTeam/provider-flexibleengine/issues/26))

The current implementation of the `huaweicloud_dli_table` resource returns an HTTP 400 error when the specified table does not exist. This behavior is not consistent with the rest of the Crossplane resources, which do not return an error in this case.

This pull request fixes the issue by adding a check to determine if the table exists before attempting to retrieve it. If the table does not exist, the resource is considered to be "absent" and no error is returned.

Testing:

I have tested this change locally by running the reproduction steps listed above and verifying that no error is returned when the table does not exist.

````
make testacc TEST='./flexibleengine' TESTARGS='-run TestAccResourceDliTable_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccResourceDliTable_basic -timeout 720m
=== RUN   TestAccResourceDliTable_basic
=== PAUSE TestAccResourceDliTable_basic
=== CONT  TestAccResourceDliTable_basic
--- PASS: TestAccResourceDliTable_basic (19.21s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 19.820s
```
