### PR TITLE
docs(dns): improve documentation

### DIFF
--- a/docs/resources/dns_ptrrecord_v2.md
+++ b/docs/resources/dns_ptrrecord_v2.md
@@ -39,7 +39,7 @@ resource "flexibleengine_dns_ptrrecord_v2" "ptr_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to create the PTR record.
+* `region` - (Optional, ForceNew) The region in which to create the PTR record.
     If omitted, the `region` argument of the provider is used.
     Changing this creates a new PTR record.
 
@@ -48,7 +48,7 @@ The following arguments are supported:
 
 * `description` - (Optional) Description of the PTR record.
 
-* `floatingip_id` - (Required) The ID of the FloatingIP/EIP.
+* `floatingip_id` - (Required, ForceNew) The ID of the FloatingIP/EIP.
   Changing this creates a new PTR record.
 
 * `ttl` - (Optional) The time to live (TTL) of the record set (in seconds). The value

--- a/docs/resources/dns_ptrrecord_v2.md
+++ b/docs/resources/dns_ptrrecord_v2.md
@@ -40,8 +40,8 @@ resource "flexibleengine_dns_ptrrecord_v2" "ptr_1" {
 The following arguments are supported:
 
 * `region` - (Optional, ForceNew) The region in which to create the PTR record.
-    If omitted, the `region` argument of the provider is used.
-    Changing this creates a new PTR record.
+  If omitted, the `region` argument of the provider is used.
+  Changing this creates a new PTR record.
 
 * `name` - (Required) Domain name of the PTR record. A domain name is case insensitive.
   Uppercase letters will also be converted into lowercase letters.

--- a/docs/resources/dns_recordset_v2.md
+++ b/docs/resources/dns_recordset_v2.md
@@ -35,30 +35,26 @@ resource "flexibleengine_dns_recordset_v2" "rs_example_com" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to create the DNS record set.
+* `region` - (Optional, ForceNew) The region in which to create the DNS record set.
     If omitted, the `region` argument of the provider is used.
-    Changing this creates a new DNS record set.
 
-* `zone_id` - (Required) The ID of the zone in which to create the record set.
-  Changing this creates a new DNS  record set.
+* `zone_id` - (Required, ForceNew) The ID of the zone in which to create the record set.
 
-* `name` - (Required) The name of the record set. Note the `.` at the end of the name.
-  Changing this creates a new DNS record set.
+* `name` - (Required, ForceNew) The name of the record set. Note the `.` at the end of the name.
 
-* `type` - (Required) The type of record set. The options include `A`, `AAAA`, `MX`,
-  `CNAME`, `TXT`, `NS`, `SRV`, `CAA`, and `PTR`. Changing this creates a new DNS record set.
+* `type` - (Required, ForceNew) The type of record set. The options include `A`, `AAAA`, `MX`,
+  `CNAME`, `TXT`, `NS`, `SRV`, `CAA`, and `PTR`.
 
 * `records` - (Required) An array of DNS records.
 
 * `ttl` - (Optional) The time to live (TTL) of the record set (in seconds). The value
-  range is 300–2147483647. The default value is 300.
+  range is 300–2147483647. The default value is `300`.
 
-* `description` - (Optional) A description of the record set.
+* `description` - (Optional) A description of the record set. Max length is `255` characters.
 
 * `tags` - (Optional) The key/value pairs to associate with the record set.
 
-* `value_specs` - (Optional) Map of additional options. Changing this creates a
-  new record set.
+* `value_specs` - (Optional, ForceNew) Map of additional options.
 
 ## Attributes Reference
 
@@ -75,8 +71,8 @@ The following attributes are exported:
 
 ## Import
 
-This resource can be imported by specifying the zone ID and recordset ID,
-separated by a forward slash.
+This resource can be imported by specifying the zone ID (`zone_id`) and recordset ID (`id`),
+separated by a forward slash `/`.
 
 ```shell
 terraform import flexibleengine_dns_recordset_v2.recordset_1 <zone_id>/<recordset_id>

--- a/docs/resources/dns_recordset_v2.md
+++ b/docs/resources/dns_recordset_v2.md
@@ -36,14 +36,18 @@ resource "flexibleengine_dns_recordset_v2" "rs_example_com" {
 The following arguments are supported:
 
 * `region` - (Optional, ForceNew) The region in which to create the DNS record set.
-    If omitted, the `region` argument of the provider is used.
+  If omitted, the `region` argument of the provider is used.
+  Changing this creates a new DNS record set.
 
 * `zone_id` - (Required, ForceNew) The ID of the zone in which to create the record set.
+  Changing this creates a new DNS record set.
 
 * `name` - (Required, ForceNew) The name of the record set. Note the `.` at the end of the name.
+  Changing this creates a new DNS record set.
 
 * `type` - (Required, ForceNew) The type of record set. The options include `A`, `AAAA`, `MX`,
   `CNAME`, `TXT`, `NS`, `SRV`, `CAA`, and `PTR`.
+  Changing this creates a new DNS record set.
 
 * `records` - (Required) An array of DNS records.
 
@@ -55,6 +59,7 @@ The following arguments are supported:
 * `tags` - (Optional) The key/value pairs to associate with the record set.
 
 * `value_specs` - (Optional, ForceNew) Map of additional options.
+  Changing this creates a new DNS record set.
 
 ## Attributes Reference
 

--- a/docs/resources/dns_zone_v2.md
+++ b/docs/resources/dns_zone_v2.md
@@ -42,29 +42,30 @@ resource "flexibleengine_dns_zone_v2" "my_private_zone" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to create the DNS zone.
-    If omitted, the `region` argument of the provider is used.
-    Changing this creates a new DNS zone.
+* `region` - (Optional, ForceNew) The region in which to create the DNS zone.
+  If omitted, the `region` argument of the provider is used.
+  Changing this creates a new DNS zone.
 
-* `name` - (Required) The name of the zone. Note the `.` at the end of the name.
+* `name` - (Required, ForceNew) The name of the zone. Note the `.` at the end of the name.
   Changing this creates a new DNS zone.
 
 * `email` - (Optional) The email contact for the zone record.
 
-* `zone_type` - (Optional) The type of zone. Can either be `public` or `private`.
-  Changing this creates a new DNS zone.
+* `zone_type` - (Optional, ForceNew) The type of zone. Can either be `public` or `private`.
+  Default is `public`. Changing this creates a new DNS zone.
 
 * `router` - (Optional) Router configuration block which is required if zone_type is private.
   The router structure is documented below.
 
-* `ttl` - (Optional) The time to live (TTL) of the zone.
+* `ttl` - (Optional) The time to live (TTL) of the zone. TTL ranges from 1 to 2147483647 seconds.
+  Default is  `300`.
 
-* `description` - (Optional) A description of the zone.
+* `description` - (Optional) A description of the zone. Max length is `255` characters.
 
 * `tags` - (Optional, Map) The key/value pairs to associate with the zone.
 
-* `value_specs` - (Optional) Map of additional options. Changing this creates a
-  new DNS zone.
+* `value_specs` - (Optional, ForceNew) Map of additional options.
+  Changing this creates a new DNS zone.
 
 The `router` block supports:
 

--- a/flexibleengine/resource_flexibleengine_dns_ptrrecord_v2.go
+++ b/flexibleengine/resource_flexibleengine_dns_ptrrecord_v2.go
@@ -54,6 +54,7 @@ func resourceDNSPtrRecordV2() *schema.Resource {
 			"ttl": {
 				Type:         schema.TypeInt,
 				Optional:     true,
+				Default:      300,
 				ValidateFunc: validation.IntBetween(1, 2147483647),
 			},
 			"tags": tagsSchema(),


### PR DESCRIPTION
Hi,

I've made some updates to the DNS documentation to improve clarity and add more detail. The changes are as follows:

- docs(dns/ptrrecord): improve documentation
- docs(dns/recordset): improve documentation
- docs(dns/zone): improve documentation