### PR TITLE
feat(sms): add new sms resources

### DIFF
--- a/docs/data-sources/sms_source_servers.md
+++ b/docs/data-sources/sms_source_servers.md
@@ -1,0 +1,71 @@
+---
+subcategory: "Server Migration Service (SMS)"
+---
+
+# flexibleengine_sms_source_servers
+
+Use this data source to get a list of SMS source servers.
+
+## Example Usage
+
+```hcl
+variable "server_name" {}
+
+data "flexibleengine_sms_source_servers" "demo" {
+  name = var.server_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `id` - (Optional, String) Specifies the ID of the source server.
+
+* `name` - (Optional, String) Specifies the name of the source server.
+
+* `status` - (Optional, String) Specifies the status of the source server.
+
+* `ip` - (Optional, String) Specifies the IP address of the source server.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `servers` - An array of SMS source servers found. Structure is documented below.
+
+The `servers` block supports:
+
+* `name` - The name of the source server.
+
+* `id` - The ID of the source server.
+
+* `ip` - The IP address of the source server.
+
+* `status` - The status of the source server.
+
+* `connected` - Whether the source server is properly connected to SMS.
+
+* `os_type` -  The OS type of the source server. The value can be **WINDOWS** and **LINUX**.
+
+* `os_version` - The OS version of the source server, for example, UBUNTU_20_4_64BIT.
+
+* `registered_time` - The UTC time when the source server is registered.
+
+* `agent_version` - The version of Agent installed on the source server.
+
+* `vcpus` - The vcpus count of the source server.
+
+* `memory` - The memory size in MB.
+
+* `disks` - The disk information of the source server. Structure is documented below.
+
+The `disks` blocks support:
+
+* `name` - The disk name, for example, /dev/vda.
+
+* `size` - The disk size in MB.
+
+* `device_type` - The disk type. The value can be **BOOT**, **OS** and **NORMAL**.

--- a/docs/resources/sms_server_template.md
+++ b/docs/resources/sms_server_template.md
@@ -1,0 +1,95 @@
+---
+subcategory: "Server Migration Service (SMS)"
+---
+
+# flexibleengine_sms_server_template
+
+Manages an SMS server template resource within FlexibleEngine.
+
+## Example Usage
+
+### A template will create networks during migration
+
+```hcl
+data "flexibleengine_availability_zones" "demo" {}
+
+resource "flexibleengine_sms_server_template" "demo" {
+  name              = "demo"
+  availability_zone = data.flexibleengine_availability_zones.demo.names[0]
+}
+```
+
+### A template will use the existing networks during migration
+
+```hcl
+variable "vpc_id" {}
+variable "subent_id" {}
+variable "secgroup_id" {}
+
+data "flexibleengine_availability_zones" "demo" {}
+
+resource "flexibleengine_sms_server_template" "demo" {
+  name               = "demo"
+  availability_zone  = data.flexibleengine_availability_zones.demo.names[0]
+  vpc_id             = var.vpc_id
+  subnet_ids         = [ var.subent_id ]
+  security_group_ids = [ var.secgroup_id ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String) Specifies the server template name.
+
+* `availability_zone` - (Required, String) Specifies the availability zone where the target server is located.
+
+* `region` - (Optional, String) Specifies the region where the target server is located.
+  If omitted, the provider-level region will be used.
+
+* `project_id` - (Optional, String) Specifies the project ID where the target server is located.
+  If omitted, the default project in the region will be used.
+
+* `vpc_id` - (Optional, String) Specifies the ID of the VPC which the target server belongs to.
+  If omitted or set to "autoCreate", a new VPC will be created automatically during migration.
+
+* `subnet_ids` - (Optional, List) Specifies an array of one or more VPC subnet IDs to attach to the target server.
+  If omitted or set to ["autoCreate"], a new subnet will be created automatically during migration.
+
+* `security_group_ids` - (Optional, List) Specifies an array of one or more security group IDs to associate with
+  the target server. If omitted or set to ["autoCreate"], a new security group will be created automatically during migration.
+
+* `volume_type` - (Optional, String) Specifies the disk type of the target server. Available values are: **SAS**, **SSD**,
+  **GPSSD** and **ESSD**, defaults to **SAS**.
+
+* `flavor` - (Optional, String) Specifies the flavor ID for the target server.
+
+* `target_server_name` - (Optional, String) Specifies the name of the target server. Defaults to the template name.
+
+* `bandwidth_size` - (Optional, Int) Specifies the bandwidth size in Mbit/s about the public IP address
+  that will be used for migration.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `vpc_name` - The name of the VPC which the target server belongs to.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minute.
+* `update` - Default is 5 minute.
+* `delete` - Default is 5 minute.
+
+## Import
+
+SMS server templates can be imported by `id`, e.g.
+
+```sh
+terraform import flexibleengine_sms_server_template.demo 4618ccaf-b4d7-43b9-b958-3df3b885126d
+```

--- a/docs/resources/sms_task.md
+++ b/docs/resources/sms_task.md
@@ -1,0 +1,161 @@
+---
+subcategory: "Server Migration Service (SMS)"
+---
+
+# flexibleengine_sms_task
+
+Manages an SMS migration task resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+variable "source_server" {}
+variable "template_id" {}
+
+resource "flexibleengine_sms_task" "migration" {
+  type             = "MIGRATE_FILE"
+  os_type          = "LINUX"
+  source_server_id = var.source_server
+  vm_template_id   = var.template_id
+  action           = "start"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the target server is located.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `type` - (Required, String, ForceNew) Specifies the type of the migration task. Available values are
+  **MIGRATE_FILE**(file-level migration) and **MIGRATE_BLOCK**(block-level migration).
+  Changing this parameter will create a new resource.
+
+  + For Linux servers, SMS supports block-level and file-level migrations. Block-level migration has
+    high efficiency but poor compatibility while file-level migration has low efficiency but excellent compatibility.
+  + For Windows servers, SMS only supports highly efficient block-level migration.
+
+* `os_type` - (Required, String, ForceNew) Specifies the OS type of the source server. The value can be **WINDOWS** and **LINUX**.
+  Changing this parameter will create a new resource.
+
+* `source_server_id` - (Required, String, ForceNew) Specifies the ID of the source server.
+  Changing this parameter will create a new resource.
+
+* `vm_template_id` - (Optional, String, ForceNew) Specifies the template used to create the target server automatically.
+   This parameter and `target_server_id` are alternative. Changing this parameter will create a new resource.
+
+* `target_server_id` - (Optional, String, ForceNew) Specifies the existing server ID as the target server.
+   This parameter and `vm_template_id` are alternative. Changing this parameter will create a new resource.
+
+* `target_server_disks` - (Optional, List, ForceNew) Specifies the disk configurations of the target server.
+  If omitted, it will be obtained from the source server. The [object](#target_server_disks_object)
+  is documented below. Changing this parameter will create a new resource.
+
+* `use_public_ip` - (Optional, Bool, ForceNew) Specifies whether to use a public IP address for migration.
+  The default value is `true`. Changing this parameter will create a new resource.
+
+* `migration_ip` - (Optional, String, ForceNew) Specifies the IP address of the target server.
+  Use the EIP of the target server if the migration network type is Internet.
+  Use the private IP address of the target server if the migration network type is Direct Connect or VPN.
+  Changing this parameter will create a new resource.
+
+* `start_target_server` - (Optional, Bool, ForceNew) Specifies whether to start the target server after the migration.
+  The default value is `true`. Changing this parameter will create a new resource.
+
+* `syncing` - (Optional, Bool, ForceNew) - Specifies whether to perform a continuous synchronization after the first replication.
+  The default value is `false`. Changing this parameter will create a new resource.
+
+* `action` - (Optional, String) Specifies the operation after the task is created.
+  The value can be **start**, **stop** and **restart**.
+
+* `project_id` - (Optional, String, ForceNew) Specifies the project ID where the target server is located.
+  If omitted, the default project in the region will be used. Changing this parameter will create a new resource.
+
+<a name="target_server_disks_object"></a>
+The `target_server_disks` block supports:
+
+* `name` - (Required, String, ForceNew) Specifies the disk name, e.g. "/dev/sda".
+  Changing this parameter will create a new resource.
+
+* `size` - (Required, int, ForceNew) Specifies the volume size in MB. Changing this parameter will create a new resource.
+
+* `device_type` - (Required, String, ForceNew) Specifies the disk type. The value can be **NORMAL** and **BOOT**.
+  Changing this parameter will create a new resource.
+
+* `disk_id` - (Optional, String, ForceNew) Specifies the disk index, e.g. "0".
+  Changing this parameter will create a new resource.
+
+* `used_size` - (Optional, int, ForceNew) Specifies the used space in MB. Changing this parameter will create a new resource.
+
+* `physical_volumes` - (Optional, List, ForceNew) Specifies an array of physical volume informations.
+  The [object](#physical_volumes_object) is documented below. Changing this parameter will create a new resource.
+
+<a name="physical_volumes_object"></a>
+The `physical_volumes` block supports:
+
+* `name` - (Required, String, ForceNew) Specifies the volume name. In Windows, it indicates the drive letter,
+  and in Linux, it indicates the device ID, e.g. "/dev/sda1".
+  Changing this parameter will create a new resource.
+
+* `size` - (Required, int, ForceNew) Specifies the volume size in MB. Changing this parameter will create a new resource.
+
+* `device_type` - (Required, String, ForceNew) Specifies the partition type. The value can be **NORMAL** and **OS**.
+  Changing this parameter will create a new resource.
+
+* `file_system` - (Required, String, ForceNew) Specifies the file system type, e.g. "ext4".
+  Changing this parameter will create a new resource.
+
+* `mount_point` - (Required, String, ForceNew) Specifies the mount point, e.g. "/".
+  Changing this parameter will create a new resource.
+
+* `index` - (Required, Int, ForceNew) Specifies the serial number of the volume.
+  Changing this parameter will create a new resource.
+
+* `used_size` - (Optional, int, ForceNew) Specifies the used space in MB.
+  Changing this parameter will create a new resource.
+
+* `uuid` - (Optional, String, ForceNew) Specifies the GUID of the volume.
+  Changing this parameter will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+* `state` - The status of the migration task.
+* `enterprise_project_id` - The enterprise project id of the target server.
+* `target_server_name` - The name of the target server.
+* `migrate_speed` - The migration rate, in MB/s.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minute.
+
+## Import
+
+SMS migration tasks can be imported by `id`, e.g.
+
+```sh
+terraform import flexibleengine_sms_task.demo 6402c49b-7d9a-413e-8b5f-a7307f7d5679
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response. The missing attributes include: `use_public_ip`, `syncing` and `action`.
+It is generally recommended running `terraform plan` after importing a migration task.
+You can then decide if changes should be applied to the task, or the resource definition should be
+updated to align with the task. Also you can ignore changes as below.
+
+```hcl
+resource "flexibleengine_sms_task" "demo" {
+    ...
+
+  lifecycle {
+    ignore_changes = [
+      use_public_ip, syncing, action,
+    ]
+  }
+}
+```

--- a/flexibleengine/acceptance/acceptance.go
+++ b/flexibleengine/acceptance/acceptance.go
@@ -36,6 +36,7 @@ var (
 	OS_SWR_SHARING_ACCOUNT    = os.Getenv("OS_SWR_SHARING_ACCOUNT")
 	OS_DLI_FLINK_JAR_OBS_PATH = os.Getenv("OS_DLI_FLINK_JAR_OBS_PATH")
 	OS_WAF_ENABLE_FLAG        = os.Getenv("OS_WAF_ENABLE_FLAG")
+	OS_SMS_SOURCE_SERVER      = os.Getenv("OS_SMS_SOURCE_SERVER")
 )
 
 // TestAccProviderFactories is a static map containing only the main provider instance
@@ -120,5 +121,10 @@ func testAccPreCheckDliJarPath(t *testing.T) {
 func testAccPrecheckWafInstance(t *testing.T) {
 	if OS_WAF_ENABLE_FLAG == "" {
 		t.Skip("Jump the WAF acceptance tests.")
+	}
+}
+func testAccPreCheckSms(t *testing.T) {
+	if OS_SMS_SOURCE_SERVER == "" {
+		t.Skip("OS_SMS_SOURCE_SERVER must be set for SMS acceptance tests")
 	}
 }

--- a/flexibleengine/acceptance/data_source_flexibleengine_sms_source_servers_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_sms_source_servers_test.go
@@ -1,0 +1,58 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccSourceServers_basic(t *testing.T) {
+	basicDataSource := "data.flexibleengine_sms_source_servers.all"
+	byNameDataSource := "data.flexibleengine_sms_source_servers.byName"
+	nonExistentDataSource := "data.flexibleengine_sms_source_servers.non-existent"
+	basicDC := acceptance.InitDataSourceCheck(basicDataSource)
+	name := OS_SMS_SOURCE_SERVER
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckSms(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSourceServers_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					basicDC.CheckResourceExists(),
+					resource.TestCheckResourceAttr(basicDataSource, "servers.#", "1"),
+					resource.TestCheckResourceAttr(basicDataSource, "servers.0.name", name),
+
+					resource.TestCheckResourceAttr(byNameDataSource, "servers.#", "1"),
+					resource.TestCheckResourceAttr(byNameDataSource, "servers.0.name", name),
+					resource.TestCheckResourceAttrSet(byNameDataSource, "servers.0.ip"),
+					resource.TestCheckResourceAttrSet(byNameDataSource, "servers.0.state"),
+
+					resource.TestCheckResourceAttr(nonExistentDataSource, "id", "0"),
+					resource.TestCheckResourceAttr(nonExistentDataSource, "servers.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccSourceServers_basic(name string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_sms_source_servers" "all" {
+}
+
+data "flexibleengine_sms_source_servers" "byName" {
+  name = "%s"
+}
+
+data "flexibleengine_sms_source_servers" "non-existent" {
+  name = "non-existent"
+}
+`, name)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_sms_server_template_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_sms_server_template_test.go
@@ -1,0 +1,194 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/sms/v3/templates"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getServerTemplateResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.SmsV3Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SMS client: %s", err)
+	}
+
+	return templates.Get(client, state.Primary.ID)
+}
+
+func TestAccServerTemplate_basic(t *testing.T) {
+	var temp templates.TemplateResponse
+	name := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_sms_server_template.test"
+	azDataName := "data.flexibleengine_availability_zones.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&temp,
+		getServerTemplateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServerTemplate_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "target_server_name", name),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "SAS"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_name", "autoCreate"),
+					resource.TestCheckResourceAttr(resourceName, "subnet_ids.0", "autoCreate"),
+					resource.TestCheckResourceAttr(resourceName, "security_group_ids.0", "autoCreate"),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone", azDataName, "names.0"),
+				),
+			},
+			{
+				Config: testAccServerTemplate_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s-update", name)),
+					resource.TestCheckResourceAttr(resourceName, "target_server_name", name),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "GPSSD"),
+					resource.TestCheckResourceAttrPair(resourceName, "availability_zone", azDataName, "names.1"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccServerTemplate_existing(t *testing.T) {
+	var temp templates.TemplateResponse
+	name := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_sms_server_template.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&temp,
+		getServerTemplateResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServerTemplate_existing(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "target_server_name", name),
+					resource.TestCheckResourceAttr(resourceName, "volume_type", "SAS"),
+					resource.TestCheckResourceAttr(resourceName, "vpc_name", name),
+					resource.TestCheckResourceAttr(resourceName, "security_group_ids.0", "autoCreate"),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "flexibleengine_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_ids.0", "flexibleengine_vpc_subnet.test", "id"),
+				),
+			},
+			{
+				Config: testAccServerTemplate_existing_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttrPair(resourceName, "vpc_id", "flexibleengine_vpc.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "subnet_ids.0", "flexibleengine_vpc_subnet.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "security_group_ids.0", "flexibleengine_networking_secgroup.test", "id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccServerTemplate_basic(name string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_availability_zones" "test" {}
+
+resource "flexibleengine_sms_server_template" "test" {
+  name              = "%s"
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+}
+`, name)
+}
+
+func testAccServerTemplate_update(name string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_availability_zones" "test" {}
+
+resource "flexibleengine_sms_server_template" "test" {
+  name               = "%s-update"
+  target_server_name = "%s"
+  availability_zone  = data.flexibleengine_availability_zones.test.names[1]
+  volume_type        = "GPSSD"
+}
+`, name, name)
+}
+
+func testAccServerTemplate_network(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet" "test" {
+  name        = "%[1]s"
+  cidr        = "192.168.0.0/24"
+  gateway_ip  = "192.168.0.1"
+  vpc_id      = flexibleengine_vpc.test.id
+  description = "created by acc test"
+}
+
+resource "flexibleengine_networking_secgroup" "test" {
+  name        = "%[1]s"
+  description = "created by acc test"
+}
+`, name)
+}
+
+func testAccServerTemplate_existing(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_availability_zones" "test" {}
+
+resource "flexibleengine_sms_server_template" "test" {
+  name              = "%s"
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+  vpc_id            = flexibleengine_vpc.test.id
+  subnet_ids        = [ flexibleengine_vpc_subnet.test.id ]
+}
+`, testAccServerTemplate_network(name), name)
+}
+
+func testAccServerTemplate_existing_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_availability_zones" "test" {}
+
+resource "flexibleengine_sms_server_template" "test" {
+  name               = "%s"
+  availability_zone  = data.flexibleengine_availability_zones.test.names[0]
+  vpc_id             = flexibleengine_vpc.test.id
+  subnet_ids         = [ flexibleengine_vpc_subnet.test.id ]
+  security_group_ids = [ flexibleengine_networking_secgroup.test.id ]
+}
+`, testAccServerTemplate_network(name), name)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_sms_task_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_sms_task_test.go
@@ -1,0 +1,86 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/sms/v3/tasks"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getMigrationTaskResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.SmsV3Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating SMS client: %s", err)
+	}
+
+	return tasks.Get(client, state.Primary.ID)
+}
+
+func TestAccMigrationTask_basic(t *testing.T) {
+	var migration tasks.MigrateTask
+	name := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_sms_task.migration"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&migration,
+		getMigrationTaskResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckSms(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMigrationTask_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "state", "READY"),
+					resource.TestCheckResourceAttr(resourceName, "use_public_ip", "true"),
+					resource.TestCheckResourceAttrSet(resourceName, "target_server_disks.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "target_server_disks.0.name"),
+					resource.TestCheckResourceAttrSet(resourceName, "target_server_disks.0.size"),
+					resource.TestCheckResourceAttrPair(resourceName, "vm_template_id",
+						"flexibleengine_sms_server_template.test", "id"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"use_public_ip", "syncing", "action"},
+			},
+		},
+	})
+}
+
+func testAccMigrationTask_basic(name string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_sms_source_servers" "source" {
+  name = "%s"
+}
+
+resource "flexibleengine_sms_server_template" "test" {
+  name              = "%s"
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+}
+
+resource "flexibleengine_sms_task" "migration" {
+  type             = "MIGRATE_FILE"
+  os_type          = "LINUX"
+  source_server_id = data.flexibleengine_sms_source_servers.source.servers[0].id
+  vm_template_id   = flexibleengine_sms_server_template.test.id
+}
+`, OS_SMS_SOURCE_SERVER, name)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -31,6 +31,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/sfs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/smn"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/sms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/swr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/tms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpc"
@@ -273,11 +274,13 @@ func Provider() *schema.Provider {
 			"flexibleengine_cce_clusters":       cce.DataSourceCCEClusters(),
 			"flexibleengine_elb_certificate":    elb.DataSourceELBCertificateV3(),
 			"flexibleengine_fgs_dependencies":   fgs.DataSourceFunctionGraphDependencies(),
+
 			"flexibleengine_networking_port":    vpc.DataSourceNetworkingPortV2(),
 			"flexibleengine_identity_group":     iam.DataSourceIdentityGroup(),
 			"flexibleengine_identity_users":     iam.DataSourceIdentityUsers(),
 			"flexibleengine_sfs_turbos":         sfs.DataSourceTurbos(),
 			"flexibleengine_smn_topics":         smn.DataSourceTopics(),
+			"flexibleengine_sms_source_servers": sms.DataSourceServers(),
 			"flexibleengine_vpc_route_table":    vpc.DataSourceVPCRouteTable(),
 
 			"flexibleengine_waf_dedicated_instances": waf.DataSourceWafDedicatedInstancesV1(),
@@ -456,6 +459,8 @@ func Provider() *schema.Provider {
 			"flexibleengine_rds_account":               rds.ResourceRdsAccount(),
 			"flexibleengine_rds_database":              rds.ResourceRdsDatabase(),
 			"flexibleengine_rds_database_privilege":    rds.ResourceRdsDatabasePrivilege(),
+			"flexibleengine_sms_server_template":       sms.ResourceServerTemplate(),
+			"flexibleengine_sms_task":                  sms.ResourceMigrateTask(),
 			"flexibleengine_swr_organization":          swr.ResourceSWROrganization(),
 			"flexibleengine_swr_organization_users":    swr.ResourceSWROrganizationPermissions(),
 			"flexibleengine_swr_repository":            swr.ResourceSWRRepository(),
@@ -625,6 +630,9 @@ func configureProvider(_ context.Context, d *schema.ResourceData) (interface{}, 
 	}
 	if _, ok := endpoints["waf-dedicated"]; !ok {
 		endpoints["waf-dedicated"] = fmt.Sprintf("https://premium-waf.%s.%s/", region, config.Cloud)
+	}
+	if _, ok := endpoints["sms"]; !ok {
+		endpoints["sms"] = fmt.Sprintf("https://sms.%s.%s/", region, config.Cloud)
 	}
 
 	config.Endpoints = endpoints


### PR DESCRIPTION
test result:
```
make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccSourceServers_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccSourceServers_basic -timeout 720m
=== RUN   TestAccSourceServers_basic
=== PAUSE TestAccSourceServers_basic
=== CONT  TestAccSourceServers_basic
--- PASS: TestAccSourceServers_basic (25.09s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      25.199s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccServerTemplate_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccServerTemplate_basic -timeout 720m
=== RUN   TestAccServerTemplate_basic
=== PAUSE TestAccServerTemplate_basic
=== CONT  TestAccServerTemplate_basic
--- PASS: TestAccServerTemplate_basic (53.23s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      53.340s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccMigrationTask_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccMigrationTask_basic -timeout 720m
=== RUN   TestAccMigrationTask_basic
=== PAUSE TestAccMigrationTask_basic
=== CONT  TestAccMigrationTask_basic
--- PASS: TestAccMigrationTask_basic (35.80s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      35.935s
```