### PR TITLE
feat(iam): add new resource identity_acl

### DIFF
--- a/docs/resources/identity_acl.md
+++ b/docs/resources/identity_acl.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Identity and Access Management (IAM)"
+---
+
+# flexibleengine_identity_acl
+
+Manages an ACL resource within FlexibleEngine IAM service. The ACL allowing user access only from specified IP address
+ranges and IPv4 CIDR blocks. The ACL take effect for IAM users under the Domain account rather than the account itself.
+
+Note: You *must* have admin privileges in your FlexibleEngine cloud to use this resource.
+
+## Example Usage
+
+```hcl
+resource "flexibleengine_identity_acl" "acl" {
+  type = "console"
+
+  ip_cidrs {
+    cidr        = "159.138.39.192/32"
+    description = "This is a test ip address"
+  }
+  ip_ranges {
+    range       = "0.0.0.0-255.255.255.0"
+    description = "This is a test ip range"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `type` - (Required, String, ForceNew) Specifies the ACL is created through the Console or API. valid value is
+  'console'. Changing this parameter will create a new ACL.
+
+* `ip_cidrs` - (Optional, List) Specifies the IPv4 CIDR blocks from which console access or api access is allowed.
+  The `ip_cidrs` cannot repeat. The structure is documented below.
+
+* `ip_ranges` - (Optional, List) Specifies the IP address ranges from which console access or api access is allowed.
+  The `ip_ranges` cannot repeat. The structure is documented below.
+
+The `ip_cidrs` block supports:
+
+* `cidr` - (Required, String) Specifies the IPv4 CIDR block, for example, **192.168.0.0/24**.
+
+* `description` - (Optional, String) Specifies a description about an IPv4 CIDR block. This parameter can contain a
+  maximum of 255 characters and the following characters are not allowed:**@#%^&*<>\\**.
+
+The `ip_ranges` block supports:
+
+* `range` - (Required, String) Specifies the Ip address range, for example, **0.0.0.0-255.255.255.0**.
+
+* `description` - (Optional, String) Specifies a description about an IP address range. This parameter can contain a
+  maximum of 255 characters and the following characters are not allowed:**@#%^&*<>\\**.
+
+->**NOTE:** Up to 200 `ip_cidrs` and `ip_ranges` can be created in total for each access method.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of identity acl.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minute.
+* `update` - Default is 5 minute.
+* `delete` - Default is 3 minute.

--- a/flexibleengine/acceptance/resource_flexibleengine_identity_acl_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_identity_acl_test.go
@@ -1,0 +1,213 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+
+	"github.com/chnsz/golangsdk/openstack/identity/v3.0/acl"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+)
+
+func getIdentitACLResourceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := c.IAMV3Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmtp.Errorf("Error creating HuaweiCloud IAM client: %s", err)
+	}
+
+	switch state.Primary.Attributes["type"] {
+	case "console":
+		v, err := acl.ConsoleACLPolicyGet(client, state.Primary.ID).ConsoleExtract()
+		if err != nil {
+			return nil, err
+		}
+		if len(v.AllowAddressNetmasks) == 0 && len(v.AllowIPRanges) == 1 &&
+			v.AllowIPRanges[0].IPRange == "0.0.0.0-255.255.255.255" {
+			return nil, fmtp.Errorf("Identity ACL for console access <%s> not exists", state.Primary.ID)
+		}
+		return v, nil
+	case "api":
+		v, err := acl.APIACLPolicyGet(client, state.Primary.ID).APIExtract()
+		if err != nil {
+			return nil, err
+		}
+		if len(v.AllowAddressNetmasks) == 0 && len(v.AllowIPRanges) == 1 &&
+			v.AllowIPRanges[0].IPRange == "0.0.0.0-255.255.255.255" {
+			return nil, fmtp.Errorf("Identity ACL for console access <%s> not exists", state.Primary.ID)
+		}
+		return v, nil
+	}
+	return nil, nil
+}
+
+func TestAccIdentitACL_basic(t *testing.T) {
+	var acl acl.ACLPolicy
+	resourceName := "flexibleengine_identity_acl.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&acl,
+		getIdentitACLResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityACL_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "type", "console"),
+					resource.TestCheckResourceAttr(resourceName, "ip_ranges.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ip_cidrs.#", "1"),
+				),
+			},
+			{
+				Config: testAccIdentityACL_update(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "type", "console"),
+					resource.TestCheckResourceAttr(resourceName, "ip_ranges.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ip_cidrs.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIdentitACL_apiAccess(t *testing.T) {
+	var acl acl.ACLPolicy
+	resourceName := "flexibleengine_identity_acl.test"
+
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&acl,
+		getIdentitACLResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIdentityACL_apiAccess(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "type", "api"),
+					resource.TestCheckResourceAttr(resourceName, "ip_ranges.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "ip_cidrs.#", "1"),
+				),
+			},
+			{
+				Config: testAccIdentityACL_apiUpdate(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "type", "api"),
+					resource.TestCheckResourceAttr(resourceName, "ip_ranges.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "ip_cidrs.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIdentityACL_basic() string {
+	return fmt.Sprintf(`
+resource "flexibleengine_identity_acl" "test" {
+  type = "console"
+
+  ip_ranges {
+    range       = "172.16.0.0-172.16.255.255"
+    description = "This is a basic ip range 1 for console access"
+  }
+
+  ip_cidrs {
+    cidr        = "159.138.32.195/32"
+    description = "This is a basic ip address 1 for console access"
+  }
+}
+`)
+}
+
+func testAccIdentityACL_update() string {
+	return fmt.Sprintf(`
+resource "flexibleengine_identity_acl" "test" {
+  type = "console"
+
+  ip_ranges {
+    range       = "172.16.0.0-172.16.255.255"
+    description = "This is a update ip range 1 for console access"
+  }
+  ip_ranges {
+    range       = "192.168.0.0-192.168.255.255"
+    description = "This is a update ip range 2 for console access"
+  }
+
+  ip_cidrs {
+    cidr        = "159.138.32.195/32"
+    description = "This is a update ip address 1 for console access"
+  }
+  ip_cidrs {
+    cidr        = "159.138.32.196/32"
+    description = "This is a update ip address 2 for console access"
+  }
+}
+`)
+}
+
+func testAccIdentityACL_apiAccess() string {
+	return fmt.Sprintf(`
+resource "flexibleengine_identity_acl" "test" {
+  type = "api"
+
+  ip_ranges {
+    range       = "172.16.0.0-172.16.255.255"
+    description = "This is a basic ip range 1 for api access"
+  }
+
+  ip_cidrs {
+    cidr        = "159.138.32.195/32"
+    description = "This is a basic ip address 1 for api access"
+  }
+}
+`)
+}
+
+func testAccIdentityACL_apiUpdate() string {
+	return fmt.Sprintf(`
+resource "flexibleengine_identity_acl" "test" {
+  type = "api"
+
+  ip_ranges {
+    range       = "172.16.0.0-172.16.255.255"
+    description = "This is a update ip range 1 for api access"
+  }
+  ip_ranges {
+    range       = "192.168.0.0-192.168.255.255"
+    description = "This is a update ip range 2 for api access"
+  }
+
+  ip_cidrs {
+    cidr        = "159.138.32.195/32"
+    description = "This is a update ip address 1 for api access"
+  }
+  ip_cidrs {
+    cidr        = "159.138.32.196/32"
+    description = "This is a update ip address 2 for api access"
+  }
+}
+`)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -453,6 +453,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_fgs_dependency":            fgs.ResourceFgsDependency(),
 			"flexibleengine_fgs_function":              fgs.ResourceFgsFunctionV2(),
 			"flexibleengine_fgs_trigger":               fgs.ResourceFunctionGraphTrigger(),
+			"flexibleengine_identity_acl":              iam.ResourceIdentityACL(),
 			"flexibleengine_rds_account":               rds.ResourceRdsAccount(),
 			"flexibleengine_rds_database":              rds.ResourceRdsDatabase(),
 			"flexibleengine_rds_database_privilege":    rds.ResourceRdsDatabasePrivilege(),


### PR DESCRIPTION
fixes #469 

test results:
```
make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccIdentitACL_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccIdentitACL_basic -timeout 720m
=== RUN   TestAccIdentitACL_basic
=== PAUSE TestAccIdentitACL_basic
=== CONT  TestAccIdentitACL_basic
--- PASS: TestAccIdentitACL_basic (32.87s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      32.969s

make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccIdentitACL_apiAccess'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccIdentitACL_apiAccess -timeout 720m
=== RUN   TestAccIdentitACL_apiAccess
=== PAUSE TestAccIdentitACL_apiAccess
=== CONT  TestAccIdentitACL_apiAccess
--- PASS: TestAccIdentitACL_apiAccess (35.03s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      35.187s
```