### PR TITLE
fix(antiddos): status returned in Create/Update/Delete func in flexibleengine_antiddos_v1 resource

### DIFF
--- a/docs/resources/antiddos_v1.md
+++ b/docs/resources/antiddos_v1.md
@@ -44,6 +44,14 @@ The following arguments are supported:
 
 All above argument parameters can be exported as attribute parameters.
 
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minute.
+* `update` - Default is 10 minute.
+* `delete` - Default is 10 minute.
+
 ## Import
 
 Antiddos can be imported using the `floating_ip_id`, e.g.

--- a/flexibleengine/resource_flexibleengine_antiddos_v1.go
+++ b/flexibleengine/resource_flexibleengine_antiddos_v1.go
@@ -94,9 +94,9 @@ func resourceAntiDdosV1Create(d *schema.ResourceData, meta interface{}) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"configging"},
 		Target:     []string{"normal"},
-		Refresh:    waitForAntiDdosActive(antiddosClient, d.Id()),
+		Refresh:    waitForAntiDdosStatus(antiddosClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutCreate),
-		Delay:      2 * time.Minute,
+		Delay:      1 * time.Minute,
 		MinTimeout: 10 * time.Second,
 	}
 
@@ -120,7 +120,7 @@ func resourceAntiDdosV1Read(d *schema.ResourceData, meta interface{}) error {
 
 	n, err := antiddos.Get(antiddosClient, d.Id()).Extract()
 	if err != nil {
-		return CheckDeleted(d, err, "Error retrieving AntiDdos")
+		return checkNotConfig(d, err, "Error retrieving AntiDdos")
 	}
 
 	d.Set("floating_ip_id", d.Id())
@@ -157,9 +157,9 @@ func resourceAntiDdosV1Update(d *schema.ResourceData, meta interface{}) error {
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"configging"},
 		Target:     []string{"normal"},
-		Refresh:    waitForAntiDdosActive(antiddosClient, d.Id()),
+		Refresh:    waitForAntiDdosStatus(antiddosClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutUpdate),
-		Delay:      2 * time.Minute,
+		Delay:      1 * time.Minute,
 		MinTimeout: 10 * time.Second,
 	}
 
@@ -179,12 +179,17 @@ func resourceAntiDdosV1Delete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error creating AntiDdos client: %s", err)
 	}
 
+	_, err = antiddos.Delete(antiddosClient, d.Id()).Extract()
+	if err != nil {
+		return fmt.Errorf("Error deleting AntiDdos: %s", err)
+	}
+
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"normal", "configging"},
 		Target:     []string{"notConfig"},
-		Refresh:    waitForAntiDdosDelete(antiddosClient, d.Id()),
+		Refresh:    waitForAntiDdosStatus(antiddosClient, d.Id()),
 		Timeout:    d.Timeout(schema.TimeoutDelete),
-		Delay:      5 * time.Second,
+		Delay:      1 * time.Minute,
 		MinTimeout: 10 * time.Second,
 	}
 
@@ -193,44 +198,40 @@ func resourceAntiDdosV1Delete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error deleting AntiDdos: %s", err)
 	}
 
-	time.Sleep(3 * time.Minute)
 	d.SetId("")
 	return nil
 }
 
-func waitForAntiDdosActive(antiddosClient *golangsdk.ServiceClient, antiddosId string) resource.StateRefreshFunc {
+func waitForAntiDdosStatus(antiddosClient *golangsdk.ServiceClient, antiddosId string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		s, err := antiddos.Get(antiddosClient, antiddosId).Extract()
+		s, err := antiddos.GetStatus(antiddosClient, antiddosId).Extract()
 		if err != nil {
 			return nil, "", err
 		}
 
-		return s, "normal", nil
+		return s, s.Status, nil
 	}
 }
 
-func waitForAntiDdosDelete(antiddosClient *golangsdk.ServiceClient, antiddosId string) resource.StateRefreshFunc {
-	return func() (interface{}, string, error) {
+// checkNotConfig checks the error returned from the API
+func checkNotConfig(d *schema.ResourceData, err error, msg string) error {
 
-		r, err := antiddos.Get(antiddosClient, antiddosId).Extract()
-		if err != nil {
-			if _, ok := err.(golangsdk.ErrDefault403); ok {
-				log.Printf("[INFO] Successfully deleted antiddos %s", antiddosId)
-				return r, "notConfig", nil
-			}
-			return r, "normal", err
-		}
-
-		_, err = antiddos.Delete(antiddosClient, antiddosId).Extract()
-
-		if err != nil {
-			if _, ok := err.(golangsdk.ErrDefault403); ok {
-				log.Printf("[INFO] Successfully deleted antiddos %s", antiddosId)
-				return r, "notConfig", nil
-			}
-			return r, "configging", err
-		}
-
-		return r, "normal", nil
+	errResp, nErr := ParseErrorMsg(err)
+	if nErr != nil {
+		return fmt.Errorf("%s: %s", msg, err)
 	}
+
+	// https://docs.prod-cloud-ocb.orange-business.com/api/antiddos/antiddos_02_0032.html
+	// 10000016 - VPC cannot be accessed or the EIP does not exist.
+	// 10001020 - ID of the IP address is invalid.
+	listOfCodes := []string{"10000016", "10001020"}
+
+	for _, code := range listOfCodes {
+		if errResp.ErrorCode == code {
+			d.SetId("")
+			return nil
+		}
+	}
+
+	return fmt.Errorf("%s: %s", msg, err)
 }

--- a/flexibleengine/utils.go
+++ b/flexibleengine/utils.go
@@ -21,12 +21,28 @@ type ErrorResp struct {
 	ErrorMsg  string `json:"error_msg"`
 }
 
-// ParseErrorMsg is used to unmarshal the error body to ErrorResp
-// usage: resp, pErr := ParseErrorMsg(err.Body)
-func ParseErrorMsg(body []byte) (ErrorResp, error) {
-	resp := ErrorResp{}
-	err := json.Unmarshal(body, &resp)
-	return resp, err
+// ParseErrorMap parses the error message from the API and returns a map
+func ParseErrorMsg(data interface{}) (ErrorResp, error) {
+
+	var (
+		err             error
+		errCode, errMsg interface{}
+	)
+
+	errCode, err = navigateValue(data, []string{"error_code"}, nil)
+	if err != nil {
+		return ErrorResp{}, err
+	}
+
+	errMsg, err = navigateValue(data, []string{"error_msg"}, nil)
+	if err != nil {
+		return ErrorResp{}, err
+	}
+
+	return ErrorResp{
+		ErrorCode: errCode.(string),
+		ErrorMsg:  errMsg.(string),
+	}, nil
 }
 
 // CheckDeleted checks the error to see if it's a 404 (Not Found) and, if so,

--- a/flexibleengine/utils.go
+++ b/flexibleengine/utils.go
@@ -21,28 +21,12 @@ type ErrorResp struct {
 	ErrorMsg  string `json:"error_msg"`
 }
 
-// ParseErrorMap parses the error message from the API and returns a map
-func ParseErrorMsg(data interface{}) (ErrorResp, error) {
-
-	var (
-		err             error
-		errCode, errMsg interface{}
-	)
-
-	errCode, err = navigateValue(data, []string{"error_code"}, nil)
-	if err != nil {
-		return ErrorResp{}, err
-	}
-
-	errMsg, err = navigateValue(data, []string{"error_msg"}, nil)
-	if err != nil {
-		return ErrorResp{}, err
-	}
-
-	return ErrorResp{
-		ErrorCode: errCode.(string),
-		ErrorMsg:  errMsg.(string),
-	}, nil
+// ParseErrorMsg is used to unmarshal the error body to ErrorResp
+// usage: resp, pErr := ParseErrorMsg(err.Body)
+func ParseErrorMsg(body []byte) (ErrorResp, error) {
+	resp := ErrorResp{}
+	err := json.Unmarshal(body, &resp)
+	return resp, err
 }
 
 // CheckDeleted checks the error to see if it's a 404 (Not Found) and, if so,


### PR DESCRIPTION
In crossplane the provider use `Read` Func before try create resource.
The terraform read function not catch err correctly therefore the
crossplane provider return err and do not try to create resource.

Error returned by crossplane :

```
Error retrieving AntiDdos: Action forbidden: [GET https://antiddos.eu-west-0.prod-cloud-ocb.orange-business.com/v1/xxx/antiddos/xxx], error message: {"error_code":"10001020", "error_msg":"IPID is invalid"}
```

In the fix use two method for catch notConfig Resource :
  * In Read func call checkNotConfig func which verifies if error is not in listed codes (10001020 and 10001020)
  * In Create/Update func edit loop stateChangeConf using
    `antiddos.GetStatus` instead `antiddos.Get` to determine status of
antiddos

Details of codes : 

- **10000016** - VPC cannot be accessed or the EIP does not exist.
- **10001020** - ID of the IP address is invalid.

Result of tests :

```
make testacc TEST='./flexibleengine' TESTARGS='-run TestAccAntiDdosV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccAntiDdosV1_basic -timeout 720m
=== RUN   TestAccAntiDdosV1_basic
--- PASS: TestAccAntiDdosV1_basic (219.31s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 219.852s
```
