### PR TITLE
feat(dws): add flavors data source

### DIFF
--- a/docs/data-sources/dws_flavors.md
+++ b/docs/data-sources/dws_flavors.md
@@ -1,0 +1,43 @@
+---
+subcategory: "Data Warehouse Service (DWS)"
+---
+
+# flexibleengine_dws_flavors
+
+Use this data source to get available flavors of FlexibleEngine DWS cluster node.
+
+## Example Usage
+
+```hcl
+data "flexibleengine_dws_flavors" "flavor" {
+  availability_zone = "eu-west-0a"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region in which to obtain the DWS cluster client.
+  If omitted, the provider-level region will be used.
+
+* `availability_zone` - (Optional, String) Specifies the availability zone name.
+
+* `vcpus` - (Optional, String) Specifies the vcpus of the DWS node flavor.
+
+* `memory` - (Optional, String) Specifies the ram of the DWS node flavor in GB.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates a data source ID.
+
+* `flavors` - Indicates the flavors information. Structure is documented below.
+
+The `flavors` block contains:
+
+* `flavor_id` - The name of the DWS node flavor. It is referenced by **node_type** in `flexibleengine_dws_cluster_v1`.
+* `vcpus` - Indicates the vcpus of the DWS node flavor.
+* `memory` - Indicates the ram of the DWS node flavor in GB.
+* `volumetype` - Indicates Disk type.
+* `size` - Indicates the Disk size in GB.
+* `availability_zone` - Indicates the availability zone where the node resides.

--- a/docs/resources/dws_cluster_v1.md
+++ b/docs/resources/dws_cluster_v1.md
@@ -11,6 +11,11 @@ Manages a DWS cluster resource within FlexibleEngine.
 ## Example Usage
 
 ```hcl
+data "flexibleengine_dws_flavors" "flavor" {
+  availability_zone = "eu-west-0a"
+  vcpus             = 8
+}
+
 resource "flexibleengine_vpc_v1" "example_vpc" {
   name = "example-vpc"
   cidr = "192.168.0.0/16"
@@ -30,7 +35,7 @@ resource "flexibleengine_networking_secgroup_v2" "example_secgroup" {
 
 resource "flexibleengine_dws_cluster_v1" "cluster" {
   name              = "dws_cluster_test"
-  node_type         = "dws.d1.xlarge"
+  node_type         = data.flexibleengine_dws_flavors.test.flavors[0].flavor_id
   number_of_node    = 3
   user_name         = "cluster_admin"
   user_pwd          = "Cluster123@!"

--- a/flexibleengine/acceptance/data_source_flexibleengine_dws_flavors_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_dws_flavors_test.go
@@ -1,0 +1,144 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDwsFlavorsDataSource_basic(t *testing.T) {
+	resourceName := "data.flexibleengine_dws_flavors.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDwsFlavorsDataSource_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDwsFlavorDataSourceID(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.flavor_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.volumetype"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.size"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.availability_zone"),
+					resource.TestCheckResourceAttr(resourceName, "flavors.0.vcpus", "8"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDwsFlavorsDataSource_memory(t *testing.T) {
+	resourceName := "data.flexibleengine_dws_flavors.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDwsFlavorsDataSource_memory,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDwsFlavorDataSourceID(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.flavor_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.volumetype"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.size"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.availability_zone"),
+					resource.TestCheckResourceAttr(resourceName, "flavors.0.memory", "64"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDwsFlavorsDataSource_all(t *testing.T) {
+	resourceName := "data.flexibleengine_dws_flavors.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDwsFlavorsDataSource_all,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDwsFlavorDataSourceID(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.flavor_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.volumetype"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.size"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.availability_zone"),
+					resource.TestCheckResourceAttr(resourceName, "flavors.0.vcpus", "8"),
+					resource.TestCheckResourceAttr(resourceName, "flavors.0.memory", "64"),
+					resource.TestCheckResourceAttrPair(resourceName, "flavors.0.availability_zone",
+						"data.flexibleengine_availability_zones.test", "names.0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDwsFlavorsDataSource_az(t *testing.T) {
+	resourceName := "data.flexibleengine_dws_flavors.test"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDwsFlavorsDataSource_az,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDwsFlavorDataSourceID(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.#"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.flavor_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.volumetype"),
+					resource.TestCheckResourceAttrSet(resourceName, "flavors.0.size"),
+					resource.TestCheckResourceAttrPair(resourceName, "flavors.0.availability_zone",
+						"data.flexibleengine_availability_zones.test", "names.0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDwsFlavorDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find dws flavors data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("DWS flavors data source ID not set")
+		}
+
+		return nil
+	}
+}
+
+const testAccDwsFlavorsDataSource_basic = `
+data "flexibleengine_dws_flavors" "test" {
+  vcpus = 8
+}
+`
+
+const testAccDwsFlavorsDataSource_memory = `
+data "flexibleengine_dws_flavors" "test" {
+  memory = 64
+}
+`
+const testAccDwsFlavorsDataSource_all = `
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_dws_flavors" "test" {
+  vcpus             = 8
+  memory            = 64
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+}
+`
+
+const testAccDwsFlavorsDataSource_az = `
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_dws_flavors" "test" {
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+}
+`

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -21,6 +21,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/drs"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dws"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eip"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/elb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eps"
@@ -272,6 +273,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_enterprise_project": eps.DataSourceEnterpriseProject(),
 			"flexibleengine_cbr_vaults":         cbr.DataSourceCbrVaultsV3(),
 			"flexibleengine_cce_clusters":       cce.DataSourceCCEClusters(),
+			"flexibleengine_dws_flavors":        dws.DataSourceDwsFlavlors(),
 			"flexibleengine_elb_certificate":    elb.DataSourceELBCertificateV3(),
 			"flexibleengine_fgs_dependencies":   fgs.DataSourceFunctionGraphDependencies(),
 

--- a/flexibleengine/resource_flexibleengine_dws_cluster_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_dws_cluster_v1_test.go
@@ -84,21 +84,25 @@ func testDWSClusterExists(n string, ar *cluster.Cluster) resource.TestCheckFunc 
 
 func testDWSClusterBasic(name string) string {
 	return fmt.Sprintf(`
+data "flexibleengine_dws_flavors" "test" {
+  availability_zone = "%[2]s"
+}
+
 resource "flexibleengine_networking_secgroup_v2" "secgroup" {
   name        = "sg-%[1]s"
   description = "terraform security group acceptance test"
 }
 
 resource "flexibleengine_dws_cluster_v1" "cluster" {
-  name           = "cluster-%[1]s"
-  node_type      = "dwsx2.xlarge"
-  number_of_node = 3
-  user_name      = "test_cluster_admin"
-  user_pwd       = "cluster123@!"
-  vpc_id         = "%s"
-  subnet_id      = "%s"
+  name              = "cluster-%[1]s"
+  availability_zone = "%[2]s"
+  node_type         = data.flexibleengine_dws_flavors.test.flavors[0].flavor_id
+  number_of_node    = 3
+  user_name         = "test_cluster_admin"
+  user_pwd          = "cluster123@!"
+  vpc_id            = "%s"
+  subnet_id         = "%s"
   security_group_id = flexibleengine_networking_secgroup_v2.secgroup.id
-  availability_zone = "%s"
 }
-`, name, OS_VPC_ID, OS_NETWORK_ID, OS_AVAILABILITY_ZONE)
+`, name, OS_AVAILABILITY_ZONE, OS_VPC_ID, OS_NETWORK_ID)
 }


### PR DESCRIPTION
fixes #891 

```
$ make testacc TEST='./flexibleengine/' TESTARGS='-run TestDWSClusterBasic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/ -v -run TestDWSClusterBasic -timeout 720m
=== RUN   TestDWSClusterBasic
--- PASS: TestDWSClusterBasic (1168.19s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 1168.287s

$ make testacc TEST='./flexibleengine/acceptance/' TESTARGS='-run TestAccDwsFlavorsDataSource'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance/ -v -run TestAccDwsFlavorsDataSource -timeout 720m
=== RUN   TestAccDwsFlavorsDataSource_basic
=== PAUSE TestAccDwsFlavorsDataSource_basic
=== RUN   TestAccDwsFlavorsDataSource_memory
=== PAUSE TestAccDwsFlavorsDataSource_memory
=== RUN   TestAccDwsFlavorsDataSource_all
=== PAUSE TestAccDwsFlavorsDataSource_all
=== RUN   TestAccDwsFlavorsDataSource_az
=== PAUSE TestAccDwsFlavorsDataSource_az
=== CONT  TestAccDwsFlavorsDataSource_basic
=== CONT  TestAccDwsFlavorsDataSource_all
=== CONT  TestAccDwsFlavorsDataSource_memory
=== CONT  TestAccDwsFlavorsDataSource_az
--- PASS: TestAccDwsFlavorsDataSource_basic (20.86s)
--- PASS: TestAccDwsFlavorsDataSource_memory (21.04s)
--- PASS: TestAccDwsFlavorsDataSource_az (25.07s)
--- PASS: TestAccDwsFlavorsDataSource_all (25.86s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      25.945s
```