### PR TITLE
fix(dcs): ignore invalid security_group_id

### DIFF
--- a/flexibleengine/resource_flexibleengine_dcs_instance_v1.go
+++ b/flexibleengine/resource_flexibleengine_dcs_instance_v1.go
@@ -344,6 +344,11 @@ func resourceDcsInstancesV1Read(d *schema.ResourceData, meta interface{}) error 
 
 	log.Printf("[DEBUG] Dcs instance %s: %+v", d.Id(), v)
 
+	// fix an issue caused by API
+	if !IsUUIDFormat(v.SecurityGroupID) {
+		v.SecurityGroupID = ""
+	}
+
 	d.SetId(v.InstanceID)
 	d.Set("name", v.Name)
 	d.Set("engine", v.Engine)

--- a/flexibleengine/utils.go
+++ b/flexibleengine/utils.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/chnsz/golangsdk"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -190,4 +191,12 @@ func HashStrings(strings []string) string {
 	}
 
 	return fmt.Sprintf("%d", schema.HashString(buf.String()))
+}
+
+func IsUUIDFormat(str string) bool {
+	if _, err := uuid.ParseUUID(str); err != nil {
+		log.Printf("[WARN] '%s' is not a valid UUID: %s", str, err)
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
the testing result as follows:

```
$ make testacc TEST='./flexibleengine/' TESTARGS='-run TestAccDcsInstancesV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/ -v -run TestAccDcsInstancesV1_basic -timeout 720m
=== RUN   TestAccDcsInstancesV1_basic
=== PAUSE TestAccDcsInstancesV1_basic
=== CONT  TestAccDcsInstancesV1_basic
--- PASS: TestAccDcsInstancesV1_basic (408.93s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 409.031s

$ make testacc TEST='./flexibleengine/' TESTARGS='-run TestAccDcsInstancesV1_redisV5'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/ -v -run TestAccDcsInstancesV1_redisV5 -timeout 720m
=== RUN   TestAccDcsInstancesV1_redisV5
=== PAUSE TestAccDcsInstancesV1_redisV5
=== CONT  TestAccDcsInstancesV1_redisV5
--- PASS: TestAccDcsInstancesV1_redisV5 (208.13s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 208.230s
```