### PR TITLE
feat(cce): support server group in node pool

### DIFF
--- a/docs/resources/cce_node_pool_v3.md
+++ b/docs/resources/cce_node_pool_v3.md
@@ -71,6 +71,9 @@ The following arguments are supported:
 * `subnet_id` - (Optional, String, ForceNew) The ID of the VPC Subnet to which the NIC belongs.
     Changing this parameter will create a new resource.
 
+* `ecs_group_id` - (Optional, String, ForceNew) Specifies the ECS group ID. If specified, the node will be created under
+  the cloud server group. Changing this parameter will create a new resource.
+
 * `max_pods` - (Optional, Int, ForceNew) The maximum number of instances a node is allowed to create.
     Changing this parameter will create a new resource.
 

--- a/flexibleengine/resource_flexibleengine_cce_node_pool.go
+++ b/flexibleengine/resource_flexibleengine_cce_node_pool.go
@@ -244,6 +244,11 @@ func resourceCCENodePool() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"ecs_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
 
 			"billing_mode": {
 				Type:     schema.TypeInt,
@@ -327,6 +332,9 @@ func resourceCCENodePoolCreate(d *schema.ResourceData, meta interface{}) error {
 				Priority:              d.Get("priority").(int),
 			},
 			InitialNodeCount: &initialNodeCount,
+			NodeManagement: nodepools.NodeManagementSpec{
+				ServerGroupReference: d.Get("ecs_group_id").(string),
+			},
 		},
 	}
 
@@ -404,6 +412,7 @@ func resourceCCENodePoolRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("priority", s.Spec.Autoscaling.Priority),
 		d.Set("type", s.Spec.Type),
 		d.Set("status", s.Status.Phase),
+		d.Set("ecs_group_id", s.Spec.NodeManagement.ServerGroupReference),
 	)
 	if err := mErr.ErrorOrNil(); err != nil {
 		return err


### PR DESCRIPTION
fixes #838 

test results:
```
make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCCENodePool_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCCENodePool_basic -timeout 720m
=== RUN   TestAccCCENodePool_basic
=== PAUSE TestAccCCENodePool_basic
=== CONT  TestAccCCENodePool_basic
--- PASS: TestAccCCENodePool_basic (884.15s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 885.186s

make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCCENodePool_serverGroup'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCCENodePool_serverGroup -timeout 720m
=== RUN   TestAccCCENodePool_serverGroup
=== PAUSE TestAccCCENodePool_serverGroup
=== CONT  TestAccCCENodePool_serverGroup
--- PASS: TestAccCCENodePool_serverGroup (717.49s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 717.633s
```