### PR TITLE
feat(cce/node): add subnet_id and ecs_group_id parameters

### DIFF
--- a/docs/resources/cce_node_v3.md
+++ b/docs/resources/cce_node_v3.md
@@ -79,6 +79,12 @@ The following arguments are supported:
 * `ecs_performance_type` - (Optional) Classification of cloud server specifications.
     Changing this parameter will create a new resource.
 
+* `ecs_group_id` - (Optional) Specifies the ECS group ID. If specified, the node will be created under
+    the cloud server group. Changing this parameter will create a new resource.
+
+* `subnet_id` - (Optional) Specifies the ID of the VPC Subnet to which the NIC belongs.
+    Changing this parameter will create a new resource.
+
 * `product_id` - (Optional) The Product ID. Changing this parameter will create a new resource.
 
 * `max_pods` - (Optional) The maximum number of instances a node is allowed to create.

--- a/flexibleengine/resource_flexibleengine_cce_node_v3.go
+++ b/flexibleengine/resource_flexibleengine_cce_node_v3.go
@@ -205,6 +205,18 @@ func resourceCCENodeV3() *schema.Resource {
 				ForceNew: true,
 				Computed: true,
 			},
+			"ecs_group_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"subnet_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 			"product_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -451,6 +463,12 @@ func resourceCCENodeV3Create(d *schema.ResourceData, meta interface{}) error {
 					},
 				},
 			},
+			NodeNicSpec: nodes.NodeNicSpec{
+				PrimaryNic: nodes.PrimaryNic{
+					SubnetId: d.Get("subnet_id").(string),
+				},
+			},
+			EcsGroupID:  d.Get("ecs_group_id").(string),
 			BillingMode: d.Get("billing_mode").(int),
 			Count:       1,
 		},
@@ -541,6 +559,8 @@ func resourceCCENodeV3Read(d *schema.ResourceData, meta interface{}) error {
 		d.Set("public_ip", s.Status.PublicIP),
 		d.Set("status", s.Status.Phase),
 		d.Set("server_id", s.Status.ServerID),
+		d.Set("subnet_id", s.Spec.NodeNicSpec.PrimaryNic.SubnetId),
+		d.Set("ecs_group_id", s.Spec.EcsGroupID),
 
 		d.Set("eip_ids", s.Spec.PublicIP.Ids),
 		d.Set("eip_count", s.Spec.PublicIP.Count),

--- a/flexibleengine/resource_flexibleengine_cce_node_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_cce_node_v3_test.go
@@ -197,6 +197,7 @@ resource "flexibleengine_cce_node_v3" "node_1" {
   flavor_id         = "s1.medium"
   availability_zone = data.flexibleengine_availability_zones.test.names[0]
   key_pair          = "%s"
+  subnet_id         = "%s"
 
   root_volume {
     size       = 40
@@ -210,7 +211,7 @@ resource "flexibleengine_cce_node_v3" "node_1" {
     key = "value"
     foo = "bar"
   }
-}`, testAccCCENodeV3_base(rName), rName, OS_KEYPAIR_NAME)
+}`, testAccCCENodeV3_base(rName), rName, OS_KEYPAIR_NAME, OS_NETWORK_ID)
 }
 
 func testAccCCENodeV3_update(rName string) string {
@@ -223,6 +224,7 @@ resource "flexibleengine_cce_node_v3" "node_1" {
   flavor_id         = "s1.medium"
   availability_zone = data.flexibleengine_availability_zones.test.names[0]
   key_pair          = "%s"
+  subnet_id         = "%s"
 
   root_volume {
     size       = 40
@@ -236,7 +238,7 @@ resource "flexibleengine_cce_node_v3" "node_1" {
     key   = "value1"
     owner = "terraform"
   }
-}`, testAccCCENodeV3_base(rName), rName, OS_KEYPAIR_NAME)
+}`, testAccCCENodeV3_base(rName), rName, OS_KEYPAIR_NAME, OS_NETWORK_ID)
 }
 
 func testAccCCENodeV3_data_volume_encryption(rName string) string {


### PR DESCRIPTION
the testing result:
```
$ make testacc TEST='./flexibleengine/' TESTARGS='-run TestAccCCENodeV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/ -v -run TestAccCCENodeV3_basic -timeout 720m
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== CONT  TestAccCCENodeV3_basic
--- PASS: TestAccCCENodeV3_basic (841.42s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 841.513s
```