### PR TITLE
docs(dms): bad value in import for group

### DIFF
--- a/docs/resources/dms_rocketmq_consumer_group.md
+++ b/docs/resources/dms_rocketmq_consumer_group.md
@@ -54,7 +54,7 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-The rocketmq consumer group can be imported using the rocketMQ instance ID and topic name separated by a slash, e.g.
+The rocketmq consumer group can be imported using the rocketMQ instance ID and group name separated by a slash, e.g.
 
 ```sh
 terraform import flexibleengine_dms_rocketmq_consumer_group.test 8d3c7938-dc47-4937-a30f-c80de381c5e3/group_1

--- a/docs/resources/dms_rocketmq_instance.md
+++ b/docs/resources/dms_rocketmq_instance.md
@@ -8,7 +8,7 @@ Manage DMS RocketMQ instance resources within FlexibleEngine.
 
 ## Example Usage
 
-```HCL
+```hcl
 variable "vpc_id" {}
 variable "subnet_id" {}
 variable "security_group_id" {}


### PR DESCRIPTION
This PR to correct the import documentation for `flexibleengine_dms_rocketmq_consumer_group`