### PR TITLE
feat(config): support update the region field in customizing OSS endp…

### DIFF
--- a/flexibleengine/config_test.go
+++ b/flexibleengine/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/chnsz/golangsdk"
+	th "github.com/chnsz/golangsdk/testhelper"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
@@ -533,4 +534,28 @@ func TestAccServiceEndpoints_Others(t *testing.T) {
 	expectedURL = fmt.Sprintf("https://rts.%s.%s/v1/%s/", OS_REGION_NAME, config.Cloud, config.TenantID)
 	actualURL = serviceClient.ResourceBaseURL()
 	testCheckServiceURL(t, expectedURL, actualURL, "RTS")
+}
+
+func TestCheckOssEndpoint(t *testing.T) {
+	cfg := &Config{
+		Region: "eu-west-0",
+		Cloud:  "prod-cloud-ocb.orange-business.com",
+	}
+
+	// without customizing OSS endpoint in Config
+	expected := "https://oss.eu-west-1.prod-cloud-ocb.orange-business.com/"
+	th.AssertEquals(t, expected, getOssEndpoint(cfg, "eu-west-1"))
+
+	// with customizing OSS endpoint in Config
+	cfg.Endpoints = map[string]string{
+		"obs": "https://oss.eu-west-0.prod-cloud-ocb.orange-business.com/",
+	}
+
+	// the region is equal to the region in customizing endpoint
+	expected = "https://oss.eu-west-0.prod-cloud-ocb.orange-business.com/"
+	th.AssertEquals(t, expected, getOssEndpoint(cfg, "eu-west-0"))
+
+	// the region is not equal to the region in customizing endpoint
+	expected = "https://oss.eu-west-1.prod-cloud-ocb.orange-business.com/"
+	th.AssertEquals(t, expected, getOssEndpoint(cfg, "eu-west-1"))
 }

--- a/flexibleengine/s3session.go
+++ b/flexibleengine/s3session.go
@@ -100,6 +100,12 @@ func newS3Session(c *Config, osDebug bool) (*session.Session, error) {
 
 func getOssEndpoint(c *Config, region string) string {
 	if endpoint, ok := c.Endpoints["oss"]; ok {
+		// replace the region in customizing OSS endpoint
+		subparts := strings.Split(endpoint, ".")
+		if len(subparts) >= 3 && subparts[1] != region {
+			subparts[1] = region
+			return strings.Join(subparts, ".")
+		}
 		return endpoint
 	}
 	return fmt.Sprintf("https://oss.%s.%s/", region, c.Cloud)

--- a/flexibleengine/s3session.go
+++ b/flexibleengine/s3session.go
@@ -99,7 +99,7 @@ func newS3Session(c *Config, osDebug bool) (*session.Session, error) {
 }
 
 func getOssEndpoint(c *Config, region string) string {
-	if endpoint, ok := c.Endpoints["oss"]; ok {
+	if endpoint, ok := c.Endpoints["obs"]; ok {
 		// replace the region in customizing OSS endpoint
 		subparts := strings.Split(endpoint, ".")
 		if len(subparts) >= 3 && subparts[1] != region {


### PR DESCRIPTION
Same as huaweicloud/terraform-provider-huaweicloud#2625 but for OSS

```
❯ go test -v ./flexibleengine -run TestCheckOssEndpoint
=== RUN   TestCheckOssEndpoint
--- PASS: TestCheckOssEndpoint (0.00s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 0.030s
```