### PR TITLE
docs: update the subcategory of object storage service

### DIFF
--- a/docs/data-sources/s3_bucket_object.md
+++ b/docs/data-sources/s3_bucket_object.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Object Storage Service (OSS)"
+subcategory: "Object Storage Service (OBS)"
 ---
 
 

--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Object Storage Service (OSS)"
+subcategory: "Object Storage Service (OBS)"
 description: ""
 page_title: "flexibleengine_obs_bucket"
 ---

--- a/docs/resources/obs_bucket_object.md
+++ b/docs/resources/obs_bucket_object.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Object Storage Service (OSS)"
+subcategory: "Object Storage Service (OBS)"
 description: ""
 page_title: "flexibleengine_obs_bucket_object"
 ---

--- a/docs/resources/obs_bucket_replication.md
+++ b/docs/resources/obs_bucket_replication.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Object Storage Service (OSS)"
+subcategory: "Object Storage Service (OBS)"
 description: ""
 page_title: "flexibleengine_obs_bucket_replication"
 ---

--- a/docs/resources/s3_bucket.md
+++ b/docs/resources/s3_bucket.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Object Storage Service (OSS)"
+subcategory: "Object Storage Service (OBS)"
 description: ""
 page_title: "flexibleengine_s3_bucket"
 ---

--- a/docs/resources/s3_bucket_object.md
+++ b/docs/resources/s3_bucket_object.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Object Storage Service (OSS)"
+subcategory: "Object Storage Service (OBS)"
 description: ""
 page_title: "flexibleengine_s3_bucket_object"
 ---

--- a/docs/resources/s3_bucket_policy.md
+++ b/docs/resources/s3_bucket_policy.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Object Storage Service (OSS)"
+subcategory: "Object Storage Service (OBS)"
 description: ""
 page_title: "flexibleengine_s3_bucket_policy"
 ---


### PR DESCRIPTION
Now, the short name of [Object Storage Service](https://docs.prod-cloud-ocb.orange-business.com/api/obs/en-us_topic_0031665984.html) is **OBS**, we should update the subcategory .