### PR TITLE
feat(obs): obs support notification

### DIFF
--- a/docs/resources/obs_bucket_notification.md
+++ b/docs/resources/obs_bucket_notification.md
@@ -1,0 +1,68 @@
+---
+subcategory: "Object Storage Service (OSS)"
+description: ""
+page_title: "flexibleengine_obs_bucket_notification"
+---
+
+# flexibleengine_obs_bucket_notification
+
+Manages an OBS bucket **Notification Configuration** resource within FlexibleEngine.
+
+[Notification Configuration](https://docs.prod-cloud-ocb.orange-business.com/usermanual/obs/en-us_topic_0045853816.html)
+OBS leverages SMN to provide the event notification function. In OBS, you can use SMN to send event notifications to
+specified subscribers, so that you will be informed of any critical operations (such as upload and deletion) 
+that occur on specified buckets in real time.
+
+## Example Usage
+
+### OBS Notification Configuration
+
+```hcl
+resource "flexibleengine_obs_bucket" "bucket" {
+  bucket = "my-test-bucket"
+  acl = "public-read"
+}
+
+resource "flexibleengine_obs_bucket_notification" notification {
+  bucket = flexibleengine_obs_bucket.bucket.bucket
+  topic_configurations {
+    name      = "notification_name"
+    events    = ["ObjectRemoved:*"]
+    prefix    = "tf_update"
+    suffix    = ".png"
+    topic_urn = "urn:smn:eu-west-0:d8cb0fdcf29b4badb9ed8b2525a3286f:topic"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket` - (Required) Specifies the name of the source bucket. Changing this parameter will create a new resource.
+
+* `name` (Required) Specifies the name of OBS Notification. The name must be unique.
+
+* `events` (Required) Type of events that need to be notified. The events include `ObjectCreated:*`,
+  `ObjectCreated:Put`, `ObjectCreated:Post`, `ObjectCreated:Copy`, `ObjectCreated:CompleteMultipartUpload`,
+  `ObjectRemoved:*`, `ObjectRemoved:Delete`, `ObjectRemoved:DeleteMarkerCreated`.
+
+* `prefix` (Optional) Specifies the prefix filtering rule. The value contains a maximum of 1024 characters.
+
+* `suffix` (Optional) Specifies the suffix filtering rule. The value contains a maximum of 1024 characters.
+
+* `topic_urn` (Required) Specifies the SMN topic that authorizes OBS to publish messages.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The name of the bucket.
+
+## Import
+
+OBS bucket notification configuration can be imported using the `<bucket>` and "name" separated by a slash, e.g.:
+
+```shell
+terraform import flexibleengine_obs_bucket_notification.instance <bucket>/name
+```

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -367,6 +367,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_obs_bucket":                         resourceObsBucket(),
 			"flexibleengine_obs_bucket_object":                  resourceObsBucketObject(),
 			"flexibleengine_obs_bucket_replication":             resourceObsBucketReplication(),
+			"flexibleengine_obs_bucket_notification":            resourceObsBucketNotification(),
 			"flexibleengine_as_group_v1":                        resourceASGroup(),
 			"flexibleengine_as_configuration_v1":                resourceASConfiguration(),
 			"flexibleengine_as_policy_v1":                       resourceASPolicy(),

--- a/flexibleengine/provider_test.go
+++ b/flexibleengine/provider_test.go
@@ -34,6 +34,7 @@ var (
 	OS_DELEGATED_DOMAIN_NAME  = os.Getenv("OS_DELEGATED_DOMAIN_NAME")
 	OS_DESTINATION_BUCKET     = os.Getenv("OS_DESTINATION_BUCKET")
 	OS_FGS_BUCKET             = os.Getenv("OS_FGS_BUCKET")
+	OS_OBS_URN_SMN            = os.Getenv("OS_OBS_URN_SMN")
 	OS_TENANT_NAME            = getTenantName()
 )
 
@@ -152,6 +153,12 @@ func testAccPreCheckS3(t *testing.T) {
 
 	if OS_ACCESS_KEY == "" || OS_SECRET_KEY == "" {
 		t.Skip("OS_ACCESS_KEY and OS_SECRET_KEY must be set for OBS/S3 acceptance tests")
+	}
+}
+
+func testAccPreCheckOBSNotification(t *testing.T) {
+	if OS_OBS_URN_SMN == "" {
+		t.Skip("OS_OBS_URN_SMN must be set for OBS notification acceptance tests")
 	}
 }
 

--- a/flexibleengine/resource_flexibleengine_obs_bucket_notification.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket_notification.go
@@ -1,0 +1,182 @@
+package flexibleengine
+
+import (
+	"context"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"log"
+	"strings"
+
+	"github.com/chnsz/golangsdk/openstack/obs"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceObsBucketNotification() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceObsBucketNotificationCreate,
+		UpdateContext: resourceObsBucketNotificationCreate,
+		ReadContext:   resourceObsBucketNotificationRead,
+		DeleteContext: resourceObsBucketNotificationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceObsBucketNotificationImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"bucket": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"events": {
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"prefix": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"suffix": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"topic_urn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceObsBucketNotificationCreate(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	obsClient, err := config.ObjectStorageClient(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating OBS client: %s", err)
+	}
+
+	bucket := d.Get("bucket").(string)
+	notificationOpt := obs.SetBucketNotificationInput{}
+	notificationOpt.Bucket = bucket
+
+	// set notification
+	configurations := buildTopicConfiguration(d)
+	notificationOpt.TopicConfigurations = configurations
+	_, err = obsClient.SetBucketNotification(&notificationOpt)
+	if err != nil {
+		return diag.Errorf("Error setting Notification Configuration of OBS bucket: %s, err: %s", bucket, err)
+	}
+	return nil
+}
+
+func buildTopicConfiguration(d *schema.ResourceData) []obs.TopicConfiguration {
+	events := d.Get("events").([]interface{})
+	eventTypes := make([]obs.EventType, 0, len(events))
+	for _, value := range events {
+		eventTypes = append(eventTypes, obs.EventType(value.(string)))
+	}
+
+	filterRules := make([]obs.FilterRule, 0, 2)
+	m := map[string]string{
+		"prefix": d.Get("prefix").(string),
+		"suffix": d.Get("suffix").(string),
+	}
+	for k, v := range m {
+		if len(v) == 0 {
+			continue
+		}
+		filterRule := obs.FilterRule{
+			Name:  k,
+			Value: v,
+		}
+		filterRules = append(filterRules, filterRule)
+	}
+	return []obs.TopicConfiguration{
+		{
+			ID:          d.Get("name").(string),
+			Topic:       d.Get("topic_urn").(string),
+			Events:      eventTypes,
+			FilterRules: filterRules,
+		},
+	}
+}
+
+func resourceObsBucketNotificationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	obsClient, err := config.ObjectStorageClient(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating OBS client: %s", err)
+	}
+
+	bucket := d.Id()
+	output, err := obsClient.GetBucketNotification(bucket)
+	if err != nil {
+		return diag.Errorf("Error getting OBS Notification Configuration: %s", err)
+	}
+
+	mErr := &multierror.Error{}
+	for _, config := range output.TopicConfigurations {
+		if config.ID != d.Get("name").(string) {
+			continue
+		}
+		events := make([]string, 0, len(config.Events))
+		for _, v := range config.Events {
+			events = append(events, string(v))
+		}
+
+		for _, v := range config.FilterRules {
+			mErr = multierror.Append(mErr, d.Set(v.Name, v.Value))
+		}
+
+		mErr = multierror.Append(mErr,
+			d.Set("name", config.ID),
+			d.Set("events", events),
+			d.Set("topic_urn", config.Topic))
+		break
+	}
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("Error saving bucket notification %s: %s", d.Id(), mErr)
+	}
+	return nil
+}
+
+func resourceObsBucketNotificationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	obsClient, err := config.ObjectStorageClient(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating OBS client: %s", err)
+	}
+
+	bucket := d.Id()
+	log.Printf("[DEBUG] delete Notification Configuration of OBS bucket %s", bucket)
+
+	notificationOpt := obs.SetBucketNotificationInput{}
+	notificationOpt.Bucket = bucket
+	_, err = obsClient.SetBucketNotification(&notificationOpt)
+	if err != nil {
+		return diag.Errorf("Error deleting Notification Configuration of OBS bucket: %s, err: %s", bucket, err)
+	}
+	return nil
+}
+
+func resourceObsBucketNotificationImport(_ context.Context, d *schema.ResourceData, _ interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.SplitN(d.Id(), "/", 2)
+	if len(parts) != 2 {
+		err := fmtp.Errorf("Invalid format specified for OBS notification. Format must be <bucket>/<name>")
+		return nil, err
+	}
+	bucket := parts[0]
+	name := parts[1]
+
+	d.SetId(bucket)
+	if err := d.Set("name", name); err != nil {
+		return nil, fmtp.Errorf("Error setting OBS notification name, %s", err)
+	}
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/flexibleengine/resource_flexibleengine_obs_bucket_notification_test.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket_notification_test.go
@@ -1,0 +1,137 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccObsBucket_notification(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "flexibleengine_obs_bucket.bucket"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckS3(t)
+			testAccPreCheckOBSNotification(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketConfigWithNotification(rInt, OS_OBS_URN_SMN),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "topic_configurations.0.name", "001"),
+					resource.TestCheckResourceAttr(
+						resourceName, "topic_configurations.0.topic_urn", OS_OBS_URN_SMN),
+					resource.TestCheckResourceAttr(
+						resourceName, "topic_configurations.0.events.0", "ObjectCreated:*"),
+					resource.TestCheckResourceAttr(
+						resourceName, "topic_configurations.0.prefix", "tf"),
+					resource.TestCheckResourceAttr(
+						resourceName, "topic_configurations.0.suffix", ".jpg"),
+					resource.TestCheckResourceAttr(
+						resourceName, "topic_configurations.1.name", "002"),
+					resource.TestCheckResourceAttr(
+						resourceName, "topic_configurations.1.topic_urn", OS_OBS_URN_SMN),
+					resource.TestCheckResourceAttr(
+						resourceName, "topic_configurations.1.events.0", "ObjectCreated:Put"),
+					resource.TestCheckResourceAttr(
+						resourceName, "topic_configurations.1.prefix", "demo"),
+					resource.TestCheckResourceAttr(
+						resourceName, "topic_configurations.1.suffix", ".png"),
+				),
+			},
+			{
+				Config: testAccObsBucketConfigWithNotificationUpdate(rInt, OS_OBS_URN_SMN),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(resourceName),
+					resource.TestCheckResourceAttr(
+						resourceName, "topic_configurations.0.name", "003"),
+					resource.TestCheckResourceAttr(
+						resourceName, "topic_configurations.0.topic_urn", OS_OBS_URN_SMN),
+					resource.TestCheckResourceAttr(
+						resourceName, "topic_configurations.0.events.0", "ObjectRemoved:*"),
+					resource.TestCheckResourceAttr(
+						resourceName, "topic_configurations.0.prefix", "tf_update"),
+					resource.TestCheckResourceAttr(
+						resourceName, "topic_configurations.0.suffix", ".png"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccObsBucketNotificationImportStateIdFunc(resourceName),
+			},
+		},
+	})
+}
+
+func testAccObsBucketNotificationImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmtp.Errorf("resource not found")
+		}
+		bucket := rs.Primary.ID
+		name := rs.Primary.Attributes["name"]
+		return fmt.Sprintf("%s/%s", bucket, name), nil
+	}
+}
+
+func testAccObsBucketConfigWithNotification(randInt int, urnSmn string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_obs_bucket" "bucket" {
+    bucket = "tf-test-bucket-%d"
+    acl = "public-read"
+}
+
+resource "flexibleengine_obs_bucket_notification" notification {
+	bucket = flexibleengine_obs_bucket.bucket.bucket
+	topic_configurations {
+		name      = "001"
+		events    = ["ObjectCreated:*"]
+		prefix    = "tf"
+		suffix    = ".jpg"
+		topic_urn = "%s"
+	}
+
+	topic_configurations {
+		name      = "002"
+		events    = ["ObjectCreated:Put"]
+		prefix    = "demo"
+		suffix    = ".png"
+		topic_urn = "%s"
+	}
+}
+
+`, randInt, urnSmn, urnSmn)
+}
+
+func testAccObsBucketConfigWithNotificationUpdate(randInt int, urnSmn string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_obs_bucket" "bucket" {
+    bucket = "tf-test-bucket-%d"
+    acl = "public-read"
+}
+
+resource "flexibleengine_obs_bucket_notification" notification {
+	bucket = flexibleengine_obs_bucket.bucket.bucket
+	topic_configurations {
+		name      = "003"
+		events    = ["ObjectRemoved:*"]
+		prefix    = "tf_update"
+		suffix    = ".png"
+		topic_urn = "%s"
+	}
+}
+
+`, randInt, urnSmn)
+}


### PR DESCRIPTION
test results:

```
make testacc TEST='./flexibleengine' TESTARGS='-run TestAccObsBucket_notification'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./flexibleengine -v -run TestAccObsBucket_notification -timeout 720m 
=== RUN   TestAccObsBucket_notification 
=== PAUSE TestAccObsBucket_notification
=== CONT  TestAccObsBucket_notification
--- PASS: TestAccObsBucket_notification (57.95s) 
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 58.049s

```