### PR TITLE
feat(obs): obs support notification

### DIFF
--- a/docs/resources/obs_bucket_notifications.md
+++ b/docs/resources/obs_bucket_notifications.md
@@ -1,0 +1,77 @@
+---
+subcategory: "Object Storage Service (OBS)"
+description: ""
+page_title: "flexibleengine_obs_bucket_notifications"
+---
+
+# flexibleengine_obs_bucket_notifications
+
+Manages an OBS bucket **Notification Configuration** resource within FlexibleEngine.
+
+**The resource overwrites an existing configuration**.
+
+[Notification Configuration](https://docs.prod-cloud-ocb.orange-business.com/usermanual/obs/en-us_topic_0045853816.html)
+OBS leverages SMN to provide the event notification function. In OBS, you can use SMN to send event notifications to
+specified subscribers, so that you will be informed of any critical operations (such as upload and deletion)
+that occur on specified buckets in real time.
+
+## Example Usage
+
+### OBS Notification Configuration
+
+```hcl
+resource "flexibleengine_obs_bucket" "bucket" {
+  bucket = "my-test-bucket"
+  acl    = "public-read"
+}
+
+resource "flexibleengine_obs_bucket_notifications" notification {
+  bucket = flexibleengine_obs_bucket.bucket.bucket
+
+  notifications {
+    name      = "notification_name"
+    events    = ["ObjectCreated:*"]
+    prefix    = "tf"
+    suffix    = ".jpg"
+    topic_urn = "urn:smn:eu-west-0:d8cb0fdcf29b4badb9ed8b2525a3286f:topic"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket` - (Required, String, ForceNew) Specifies the name of the source bucket.
+  Changing this parameter will create a new resource.
+
+* `notifications` - (Optional, List) Specifies the list of OBS bucket Notification Configurations.
+
+The `notifications` block supports:
+
+* `topic_urn` (Required, String) Specifies the SMN topic that authorizes OBS to publish messages.
+
+* `events` (Required, List) Type of events that need to be notified. The events include `ObjectCreated:*`,
+  `ObjectCreated:Put`, `ObjectCreated:Post`, `ObjectCreated:Copy`, `ObjectCreated:CompleteMultipartUpload`,
+  `ObjectRemoved:*`, `ObjectRemoved:Delete`, `ObjectRemoved:DeleteMarkerCreated`.
+
+* `name` (Optional, String) Specifies the name of OBS Notification. If not specified, the system assigns an ID
+  automatically.
+
+* `prefix` (Optional, String) Specifies the prefix filtering rule. The value contains a maximum of 1024 characters.
+
+* `suffix` (Optional, String) Specifies the suffix filtering rule. The value contains a maximum of 1024 characters.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The name of the bucket.
+
+## Import
+
+OBS bucket notification configuration can be imported using the `bucket`, e.g.
+
+```shell
+terraform import flexibleengine_obs_bucket_notifications.instance <bucket-name>
+```

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -367,6 +367,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_obs_bucket":                         resourceObsBucket(),
 			"flexibleengine_obs_bucket_object":                  resourceObsBucketObject(),
 			"flexibleengine_obs_bucket_replication":             resourceObsBucketReplication(),
+			"flexibleengine_obs_bucket_notifications":           resourceObsBucketNotifications(),
 			"flexibleengine_as_group_v1":                        resourceASGroup(),
 			"flexibleengine_as_configuration_v1":                resourceASConfiguration(),
 			"flexibleengine_as_policy_v1":                       resourceASPolicy(),

--- a/flexibleengine/provider_test.go
+++ b/flexibleengine/provider_test.go
@@ -34,6 +34,7 @@ var (
 	OS_DELEGATED_DOMAIN_NAME  = os.Getenv("OS_DELEGATED_DOMAIN_NAME")
 	OS_DESTINATION_BUCKET     = os.Getenv("OS_DESTINATION_BUCKET")
 	OS_FGS_BUCKET             = os.Getenv("OS_FGS_BUCKET")
+	OS_OBS_URN_SMN            = os.Getenv("OS_OBS_URN_SMN")
 	OS_TENANT_NAME            = getTenantName()
 )
 
@@ -152,6 +153,12 @@ func testAccPreCheckS3(t *testing.T) {
 
 	if OS_ACCESS_KEY == "" || OS_SECRET_KEY == "" {
 		t.Skip("OS_ACCESS_KEY and OS_SECRET_KEY must be set for OBS/S3 acceptance tests")
+	}
+}
+
+func testAccPreCheckOBSNotification(t *testing.T) {
+	if OS_OBS_URN_SMN == "" {
+		t.Skip("OS_OBS_URN_SMN must be set for OBS notification acceptance tests")
 	}
 }
 

--- a/flexibleengine/resource_flexibleengine_obs_bucket_notifications.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket_notifications.go
@@ -1,0 +1,191 @@
+package flexibleengine
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk/openstack/obs"
+)
+
+func resourceObsBucketNotifications() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceObsBucketNotificationCreate,
+		UpdateContext: resourceObsBucketNotificationCreate,
+		ReadContext:   resourceObsBucketNotificationRead,
+		DeleteContext: resourceObsBucketNotificationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"bucket": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"notifications": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"topic_urn": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"events": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{
+									"ObjectCreated:*", "ObjectCreated:Put", "ObjectCreated:Post", "ObjectCreated:Copy",
+									"ObjectCreated:CompleteMultipartUpload", "ObjectRemoved:*", "ObjectRemoved:Delete",
+									"ObjectRemoved:DeleteMarkerCreated",
+								}, false),
+							},
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"prefix": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"suffix": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceObsBucketNotificationCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	obsClient, err := config.ObjectStorageClient(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating OBS client: %s", err)
+	}
+
+	bucket := d.Get("bucket").(string)
+	notificationOpt := obs.SetBucketNotificationInput{}
+	notificationOpt.Bucket = bucket
+
+	// set notification
+	configurations := buildTopicConfiguration(d)
+	notificationOpt.TopicConfigurations = configurations
+	_, err = obsClient.SetBucketNotification(&notificationOpt)
+	if err != nil {
+		return diag.Errorf("Error setting Notification Configuration of OBS bucket %s, err: %s", bucket, err)
+	}
+	d.SetId(bucket)
+	return resourceObsBucketNotificationRead(ctx, d, meta)
+}
+
+func buildTopicConfiguration(d *schema.ResourceData) []obs.TopicConfiguration {
+	notifications := d.Get("notifications").([]interface{})
+
+	configurations := make([]obs.TopicConfiguration, 0, len(notifications))
+	for _, notification := range notifications {
+		notificationMap := notification.(map[string]interface{})
+		configuration := obs.TopicConfiguration{
+			ID:          notificationMap["name"].(string),
+			Topic:       notificationMap["topic_urn"].(string),
+			Events:      buildEvents(notificationMap["events"].([]interface{})),
+			FilterRules: buildFilterRules(notificationMap),
+		}
+		configurations = append(configurations, configuration)
+	}
+	return configurations
+}
+
+func buildFilterRules(notificationMap map[string]interface{}) []obs.FilterRule {
+	var filterRules []obs.FilterRule
+	for k, v := range notificationMap {
+		if k == "prefix" || k == "suffix" {
+			filterRule := obs.FilterRule{
+				Name:  k,
+				Value: v.(string),
+			}
+			filterRules = append(filterRules, filterRule)
+		}
+	}
+	return filterRules
+}
+
+func buildEvents(events []interface{}) []obs.EventType {
+	eventTypes := make([]obs.EventType, 0, len(events))
+	for _, value := range events {
+		eventTypes = append(eventTypes, obs.EventType(value.(string)))
+	}
+	return eventTypes
+}
+
+func resourceObsBucketNotificationRead(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	obsClient, err := config.ObjectStorageClient(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating OBS client: %s", err)
+	}
+
+	bucket := d.Id()
+	output, err := obsClient.GetBucketNotification(bucket)
+	if err != nil {
+		return diag.Errorf("Error getting OBS Notification Configuration: %s", err)
+	}
+
+	mErr := multierror.Append(nil, d.Set("bucket", bucket))
+	notifications := make([]map[string]interface{}, 0, len(output.TopicConfigurations))
+	for _, config := range output.TopicConfigurations {
+		events := make([]string, 0, len(config.Events))
+		for _, v := range config.Events {
+			events = append(events, string(v))
+		}
+
+		notificationMap := make(map[string]interface{})
+		notificationMap["name"] = config.ID
+		notificationMap["topic_urn"] = config.Topic
+		notificationMap["events"] = events
+		for _, v := range config.FilterRules {
+			if v.Name == "prefix" || v.Name == "suffix" {
+				notificationMap[v.Name] = v.Value
+			}
+		}
+		notifications = append(notifications, notificationMap)
+	}
+	mErr = multierror.Append(mErr, d.Set("notifications", notifications))
+	if mErr.ErrorOrNil() != nil {
+		return diag.Errorf("Error saving bucket notification %s: %s", d.Id(), mErr)
+	}
+	return nil
+}
+
+func resourceObsBucketNotificationDelete(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	obsClient, err := config.ObjectStorageClient(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating OBS client: %s", err)
+	}
+
+	bucket := d.Id()
+	log.Printf("[DEBUG] delete Notification Configuration of OBS bucket %s", bucket)
+
+	notificationOpt := obs.SetBucketNotificationInput{}
+	notificationOpt.Bucket = bucket
+	_, err = obsClient.SetBucketNotification(&notificationOpt)
+	if err != nil {
+		return diag.Errorf("Error deleting Notification Configuration of OBS bucket: %s, err: %s", bucket, err)
+	}
+	return nil
+}

--- a/flexibleengine/resource_flexibleengine_obs_bucket_notifications_test.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket_notifications_test.go
@@ -1,0 +1,109 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccObsBucket_notifications(t *testing.T) {
+	rInt := acctest.RandInt()
+	obsName := "flexibleengine_obs_bucket.bucket"
+	resourceName := "flexibleengine_obs_bucket_notifications.notification"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckS3(t)
+			testAccPreCheckOBSNotification(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckObsBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccObsBucketConfigWithNotification(rInt, OS_OBS_URN_SMN),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(obsName),
+					resource.TestCheckResourceAttr(resourceName, "notifications.0.name", "001"),
+					resource.TestCheckResourceAttr(resourceName, "notifications.0.events.0", "ObjectCreated:*"),
+					resource.TestCheckResourceAttr(resourceName, "notifications.0.prefix", "tf"),
+					resource.TestCheckResourceAttr(resourceName, "notifications.0.suffix", ".jpg"),
+					resource.TestCheckResourceAttr(resourceName, "notifications.0.topic_urn", OS_OBS_URN_SMN),
+					resource.TestCheckResourceAttr(resourceName, "notifications.1.events.0", "ObjectCreated:Post"),
+					resource.TestCheckResourceAttr(resourceName, "notifications.1.prefix", "iac"),
+					resource.TestCheckResourceAttr(resourceName, "notifications.1.suffix", ".txt"),
+					resource.TestCheckResourceAttr(resourceName, "notifications.1.topic_urn", OS_OBS_URN_SMN),
+					resource.TestCheckResourceAttrSet(resourceName, "notifications.1.name"),
+				),
+			},
+			{
+				Config: testAccObsBucketConfigWithNotificationUpdate(rInt, OS_OBS_URN_SMN),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckObsBucketExists(obsName),
+					resource.TestCheckResourceAttr(resourceName, "notifications.0.name", "003"),
+					resource.TestCheckResourceAttr(resourceName, "notifications.0.events.0", "ObjectRemoved:*"),
+					resource.TestCheckResourceAttr(resourceName, "notifications.0.prefix", "tf_update"),
+					resource.TestCheckResourceAttr(resourceName, "notifications.0.suffix", ".png"),
+					resource.TestCheckResourceAttr(resourceName, "notifications.0.topic_urn", OS_OBS_URN_SMN),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccObsBucketConfigWithNotification(randInt int, urnSmn string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_obs_bucket" "bucket" {
+  bucket = "tf-test-bucket-%d"
+  acl    = "public-read"
+}
+
+resource "flexibleengine_obs_bucket_notifications" notification {
+  bucket    = flexibleengine_obs_bucket.bucket.bucket
+
+  notifications {
+    name      = "001"
+    events    = ["ObjectCreated:*"]
+    prefix    = "tf"
+    suffix    = ".jpg"
+    topic_urn = "%s"
+  }
+
+  notifications {
+    events    = ["ObjectCreated:Post"]
+    prefix    = "iac"
+    suffix    = ".txt"
+    topic_urn = "%s"
+  }
+}
+
+`, randInt, urnSmn, urnSmn)
+}
+
+func testAccObsBucketConfigWithNotificationUpdate(randInt int, urnSmn string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_obs_bucket" "bucket" {
+  bucket = "tf-test-bucket-%d"
+  acl    = "public-read"
+}
+
+resource "flexibleengine_obs_bucket_notifications" notification {
+  bucket = flexibleengine_obs_bucket.bucket.bucket
+
+  notifications {
+    name      = "003"
+    events    = ["ObjectRemoved:*"]
+    prefix    = "tf_update"
+    suffix    = ".png"
+    topic_urn = "%s"
+  }
+}
+
+`, randInt, urnSmn)
+}


### PR DESCRIPTION
```
make testacc TEST='./flexibleengine' TESTARGS='-run TestAccObsBucket_notification'
==> Checking that code complies with gofmt requirements... 
TF_ACC=1 go test ./flexibleengine -v -run TestAccObsBucket_notification -timeout 720m 
=== RUN   TestAccObsBucket_notification 
=== PAUSE TestAccObsBucket_notification 
=== CONT  TestAccObsBucket_notification
--- PASS: TestAccObsBucket_notification (60.37s) 
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 60.450s
```