### PR TITLE
feat(dms/kafka): support tags in kafka instance

### DIFF
--- a/docs/resources/dms_kafka_instance.md
+++ b/docs/resources/dms_kafka_instance.md
@@ -140,6 +140,8 @@ The following arguments are supported:
   topic creation is enabled, a topic will be automatically created with 3 partitions and 3 replicas when a message is
   produced to or consumed from a topic that does not exist. Changing this creates a new instance resource.
 
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the DMS Kafka instance.
+
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:

--- a/flexibleengine/acceptance/resource_flexibleengine_apig_application_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_apig_application_test.go
@@ -148,7 +148,7 @@ resource "flexibleengine_apig_application" "test" {
 
   app_codes = ["%s"]
 }
-`, testAccApigApplication_base(rName), rName, utils.EncodeBase64String(code))
+`, testAccApigApplication_base(rName), rName, utils.Base64EncodeString(code))
 }
 
 func testAccApigApplication_update(rName, code string) string {
@@ -162,5 +162,5 @@ resource "flexibleengine_apig_application" "test" {
 
   app_codes = ["%s"]
 }
-`, testAccApigApplication_base(rName), rName, utils.EncodeBase64String(code))
+`, testAccApigApplication_base(rName), rName, utils.Base64EncodeString(code))
 }

--- a/flexibleengine/acceptance/resource_flexibleengine_apig_throttling_policy_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_apig_throttling_policy_test.go
@@ -188,7 +188,7 @@ resource "flexibleengine_apig_application" "test" {
 
   app_codes = ["%s"]
 }
-`, testAccApigApplication_base(rName), rName, utils.EncodeBase64String(code))
+`, testAccApigApplication_base(rName), rName, utils.Base64EncodeString(code))
 }
 
 func testAccApigThrottlingPolicy_basic(rName string) string {

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -277,7 +277,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_dms_rocketmq_broker":    dms.DataSourceDmsRocketMQBroker(),
 			"flexibleengine_dms_rocketmq_instances": dms.DataSourceDmsRocketMQInstances(),
 
-			"flexibleengine_dws_flavors":      dws.DataSourceDwsFlavlors(),
+			"flexibleengine_dws_flavors":      dws.DataSourceDwsFlavors(),
 			"flexibleengine_elb_certificate":  elb.DataSourceELBCertificateV3(),
 			"flexibleengine_fgs_dependencies": fgs.DataSourceFunctionGraphDependencies(),
 

--- a/flexibleengine/provider_test.go
+++ b/flexibleengine/provider_test.go
@@ -77,22 +77,6 @@ func testAccPreCheckRequiredEnvVars(t *testing.T) {
 	if OS_REGION_NAME == "" {
 		t.Fatal("OS_REGION_NAME must be set for acceptance tests")
 	}
-
-	if OS_AVAILABILITY_ZONE == "" {
-		t.Fatal("OS_AVAILABILITY_ZONE must be set for acceptance tests")
-	}
-
-	if OS_IMAGE_ID == "" && OS_IMAGE_NAME == "" {
-		t.Fatal("OS_IMAGE_ID or OS_IMAGE_NAME must be set for acceptance tests")
-	}
-
-	if OS_FLAVOR_ID == "" && OS_FLAVOR_NAME == "" {
-		t.Fatal("OS_FLAVOR_ID or OS_FLAVOR_NAME must be set for acceptance tests")
-	}
-
-	if OS_NETWORK_ID == "" {
-		t.Fatal("OS_NETWORK_ID must be set for acceptance tests")
-	}
 }
 
 func testAccPreCheck(t *testing.T) {

--- a/flexibleengine/resource_flexibleengine_dms_kafka_instance.go
+++ b/flexibleengine/resource_flexibleengine_dms_kafka_instance.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/dms/v1/instances"
 	dmsv2 "github.com/chnsz/golangsdk/openstack/dms/v2/kafka/instances"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
 
@@ -155,6 +156,7 @@ func resourceDmsKafkaInstances() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"tags": common.TagsForceNewSchema(),
 
 			"status": {
 				Type:     schema.TypeString,
@@ -258,6 +260,11 @@ func resourceDmsKafkaInstancesCreate(d *schema.ResourceData, meta interface{}) e
 		KafkaManagerUser: d.Get("manager_user").(string),
 		SslEnable:        sslEnable,
 		EnableAutoTopic:  d.Get("enable_auto_topic").(bool),
+	}
+
+	// set tags
+	if tagRaw := d.Get("tags").(map[string]interface{}); len(tagRaw) > 0 {
+		createOpts.Tags = utils.ExpandResourceTags(tagRaw)
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)

--- a/flexibleengine/resource_flexibleengine_dms_kafka_instance_test.go
+++ b/flexibleengine/resource_flexibleengine_dms_kafka_instance_test.go
@@ -33,6 +33,8 @@ func TestAccDmsKafkaInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "product_spec_code"),
 					resource.TestCheckResourceAttrSet(resourceName, "manegement_connect_address"),
 					resource.TestCheckResourceAttrSet(resourceName, "port"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 				),
 			},
 			{
@@ -47,7 +49,7 @@ func TestAccDmsKafkaInstance_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"access_user", "password", "manager_user", "manager_password",
+					"access_user", "password", "manager_user", "manager_password", "tags",
 				},
 			},
 		},
@@ -144,6 +146,11 @@ resource "flexibleengine_dms_kafka_instance" "instance_1" {
   product_id         = data.flexibleengine_dms_product.product_1.id
   storage_space      = data.flexibleengine_dms_product.product_1.storage_space
   engine_version     = data.flexibleengine_dms_product.product_1.engine_version
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
 }`, testAccDmsKafkaInstance_base(resName), resName)
 }
 
@@ -166,5 +173,10 @@ resource "flexibleengine_dms_kafka_instance" "instance_1" {
   product_id         = data.flexibleengine_dms_product.product_1.id
   storage_space      = data.flexibleengine_dms_product.product_1.storage_space
   engine_version     = data.flexibleengine_dms_product.product_1.engine_version
-  }`, testAccDmsKafkaInstance_base(resName), resUpdate)
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}`, testAccDmsKafkaInstance_base(resName), resUpdate)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,14 @@ go 1.18
 
 require (
 	github.com/aws/aws-sdk-go v1.34.0
-	github.com/chnsz/golangsdk v0.0.0-20230105120102-6307ec6471fc
+	github.com/chnsz/golangsdk v0.0.0-20230223093116-95ca65313a4d
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0
 	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.20
-	github.com/huaweicloud/terraform-provider-huaweicloud v1.44.1-0.20230113073706-50b0cf1801ba
+	github.com/huaweicloud/terraform-provider-huaweicloud v1.44.2
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/mitchellh/go-homedir v1.1.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/aws/aws-sdk-go v1.34.0 h1:brux2dRrlwCF5JhTL7MUT3WUwo9zfDHZZp3+g3Mvlmo
 github.com/aws/aws-sdk-go v1.34.0/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chnsz/golangsdk v0.0.0-20230105120102-6307ec6471fc h1:RBCfbJADDWB2/EhWhLsS2KBIg0SB1BNpPfizuKpr3PQ=
-github.com/chnsz/golangsdk v0.0.0-20230105120102-6307ec6471fc/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230223093116-95ca65313a4d h1:peedtA9E3upJPjT1axzVvsoqPeHFtH+08cxHojFhAbc=
+github.com/chnsz/golangsdk v0.0.0-20230223093116-95ca65313a4d/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -142,8 +142,8 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.20 h1:Pyz8ZjJEAel4axFfL3bvPJ0nXg2IAMW2ksZbepyM7KE=
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.20/go.mod h1:QpZ96CRqyqd5fEODVmnzDNp3IWi5W95BFmWz1nfkq+s=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.44.1-0.20230113073706-50b0cf1801ba h1:VZ/oOhk3Lif8BG7HJ7OZn8nA7fN+xLR1ipe5eFYHq0U=
-github.com/huaweicloud/terraform-provider-huaweicloud v1.44.1-0.20230113073706-50b0cf1801ba/go.mod h1:KrOQU8hFCv44H3y63KQiNAMr4pTnCBgDBxXHRw3GE0k=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.44.2 h1:Q9yD3crErhTbH9g3cgubOI3uXt3g1Ei8QBffQtpMZtE=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.44.2/go.mod h1:K3AXjAqPXmQKRbwVBMP/oLOJZXOclJjoJpiiL+mlTI8=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=


### PR DESCRIPTION
1. support tags in kafka instance
2. update the reference

```
make testacc TEST='./flexibleengine' TESTARGS='-run TestAccDmsKafkaInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDmsKafkaInstance_basic -timeout 720m
=== RUN   TestAccDmsKafkaInstance_basic
=== PAUSE TestAccDmsKafkaInstance_basic
=== CONT  TestAccDmsKafkaInstance_basic
--- PASS: TestAccDmsKafkaInstance_basic (963.79s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 963.885s
```