### PR TITLE
feat(kafka): add new data_source kafka instances

### DIFF
--- a/docs/data-sources/dms_kafka_instances.md
+++ b/docs/data-sources/dms_kafka_instances.md
@@ -1,0 +1,135 @@
+---
+subcategory: "Distributed Message Service (DMS)"
+---
+
+# flexibleengine_dms_kafka_instances
+
+Use this data source to query the available instances within FlexibleEngine DMS service.
+
+## Example Usage
+
+### Query all instances with the keyword in the name
+
+```hcl
+variable "keyword" {}
+
+data "flexibleengine_dms_kafka_instances" "test" {
+  name        = var.keyword
+  fuzzy_match = true
+}
+```
+
+### Query the instance with the specified name
+
+```hcl
+variable "instance_name" {}
+
+data "flexibleengine_dms_kafka_instances" "test" {
+  name = var.instance_name
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to query the kafka instance list.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Optional, String) Specifies the kafka instance ID to match exactly.
+
+* `name` - (Optional, String) Specifies the kafka instance name for data-source queries.
+
+* `fuzzy_match` - (Optional, Bool) Specifies whether to match the instance name fuzzily, the default is a exact
+  match (`flase`).
+
+* `status` - (Optional, String) Specifies the kafka instance status for data-source queries.
+
+* `include_failure` - (Optional, Bool) Specifies whether the query results contain instances that failed to create.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `instances` - The result of the query's list of kafka instances. The structure is documented below.
+
+The `instances` block supports:
+
+* `id` - The instance ID.
+
+* `type` - The instance type.
+
+* `name` - The instance name.
+
+* `description` - The instance description.
+
+* `availability_zones` - The list of AZ names.
+
+* `product_id` - The product ID used by the instance.
+
+* `engine_version` - The kafka engine version.
+
+* `storage_spec_code` - The storage I/O specification.
+
+* `storage_space` - The message storage capacity, in GB unit.
+
+* `vpc_id` - The VPC ID to which the instance belongs.
+
+* `network_id` - The subnet ID to which the instance belongs.
+
+* `security_group_id` - The security group ID associated with the instance.
+
+* `manager_user` - The username for logging in to the Kafka Manager.
+
+* `access_user` - The access username.
+
+* `maintain_begin` - The time at which a maintenance time window starts, the format is `HH:mm`.
+
+* `maintain_end` - The time at which a maintenance time window ends, the format is `HH:mm`.
+
+* `enable_public_ip` - Whether public access to the instance is enabled.
+
+* `public_ip_ids` - The IDs of the elastic IP address (EIP).
+
+* `public_conn_addresses` - The instance public access address.
+  The format of each connection address is `{IP address}:{port}`.
+
+* `retention_policy` - The action to be taken when the memory usage reaches the disk capacity threshold.
+
+* `dumping` - Whether to dumping is enabled.
+
+* `enable_auto_topic` - Whether to enable automatic topic creation.
+
+* `partition_num` - The maximum number of topics in the DMS kafka instance.
+
+* `ssl_enable` - Whether the Kafka SASL_SSL is enabled.
+
+* `used_storage_space` - The used message storage space, in GB unit.
+
+* `connect_address` - The IP address for instance connection.
+
+* `port` - The port number of the instance.
+
+* `status` - The instance status.
+
+* `resource_spec_code` - The resource specifications identifier.
+
+* `user_id` - The user ID who created the instance.
+
+* `user_name` - The username who created the instance.
+
+* `management_connect_address` - The connection address of the Kafka manager of an instance.
+
+* `tags` - The key/value pairs to associate with the instance.
+
+* `cross_vpc_accesses` - Indicates the Access information of cross-VPC. The structure is documented below.
+
+The `cross_vpc_accesses` block supports:
+
+* `listener_ip` - The listener IP address.
+
+* `advertised_ip` - The advertised IP Address.
+
+* `port` - The port number.
+
+* `port_id` - The port ID associated with the address.

--- a/flexibleengine/acceptance/data_source_flexibleengine_dms_kafka_instances_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_dms_kafka_instances_test.go
@@ -1,0 +1,80 @@
+package acceptance
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccKafkaInstancesDataSource_basic(t *testing.T) {
+	dc0 := acceptance.InitDataSourceCheck("data.flexibleengine_dms_kafka_instances.query_0")
+	dc1 := acceptance.InitDataSourceCheck("data.flexibleengine_dms_kafka_instances.query_1")
+	dc2 := acceptance.InitDataSourceCheck("data.flexibleengine_dms_kafka_instances.query_2")
+	dc3 := acceptance.InitDataSourceCheck("data.flexibleengine_dms_kafka_instances.query_3")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKafkaInstancesDataSource_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc0.CheckResourceExists(),
+					resource.TestMatchResourceAttr("data.flexibleengine_dms_kafka_instances.query_0",
+						"instances.#", regexp.MustCompile(`[1-9]\d*`)),
+					dc1.CheckResourceExists(),
+					resource.TestMatchResourceAttr("data.flexibleengine_dms_kafka_instances.query_1",
+						"instances.#", regexp.MustCompile(`[1-9]\d*`)),
+					dc2.CheckResourceExists(),
+					resource.TestMatchResourceAttr("data.flexibleengine_dms_kafka_instances.query_2",
+						"instances.#", regexp.MustCompile(`[1-9]\d*`)),
+					dc3.CheckResourceExists(),
+					resource.TestMatchResourceAttr("data.flexibleengine_dms_kafka_instances.query_3",
+						"instances.#", regexp.MustCompile(`[1-9]\d*`)),
+				),
+			},
+		},
+	})
+}
+
+func testAccKafkaInstancesDataSource_basic() string {
+	rName := acceptance.RandomAccResourceNameWithDash()
+	fuzzyName := rName[0 : len(rName)-1]
+
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_dms_kafka_instances" "query_0" {
+  depends_on = [
+    flexibleengine_dms_kafka_instance.instance_1,
+  ]
+
+  name        = "%s"
+  fuzzy_match = true
+}
+
+data "flexibleengine_dms_kafka_instances" "query_1" {
+  depends_on = [
+    flexibleengine_dms_kafka_instance.instance_1,
+  ]
+  
+  name = flexibleengine_dms_kafka_instance.instance_1.name
+}
+
+data "flexibleengine_dms_kafka_instances" "query_2" {
+  instance_id = flexibleengine_dms_kafka_instance.instance_1.id
+}
+
+data "flexibleengine_dms_kafka_instances" "query_3" {
+  depends_on = [
+    flexibleengine_dms_kafka_instance.instance_1,
+  ]
+
+  status = "RUNNING"
+}
+`, testAccDmsKafkaInstance_basic(rName), fuzzyName)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -274,6 +274,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_cbr_vaults":         cbr.DataSourceCbrVaultsV3(),
 			"flexibleengine_cce_clusters":       cce.DataSourceCCEClusters(),
 
+			"flexibleengine_dms_kafka_instances":    dms.DataSourceDmsKafkaInstances(),
 			"flexibleengine_dms_rocketmq_broker":    dms.DataSourceDmsRocketMQBroker(),
 			"flexibleengine_dms_rocketmq_instances": dms.DataSourceDmsRocketMQInstances(),
 


### PR DESCRIPTION
```
make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccKafkaInstancesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccKafkaInstancesDataSource_basic -timeout 720m
=== RUN   TestAccKafkaInstancesDataSource_basic
=== PAUSE TestAccKafkaInstancesDataSource_basic
=== CONT  TestAccKafkaInstancesDataSource_basic
--- PASS: TestAccKafkaInstancesDataSource_basic (1064.41s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      1064.528s
```