### PR TITLE
refactor(waf): remove the reference of dedicated domain

### DIFF
--- a/docs/resources/waf_dedicated_domain.md
+++ b/docs/resources/waf_dedicated_domain.md
@@ -19,7 +19,7 @@ resource "flexibleengine_vpc_v1" "example_vpc" {
   cidr = "192.168.0.0/16"
 }
 
-resource "flexibleengine_waf_certificate" "certificate_1" {
+resource "flexibleengine_waf_dedicated_certificate" "certificate_1" {
   name        = "cert_1"
   certificate = <<EOT
 -----BEGIN CERTIFICATE-----
@@ -43,7 +43,7 @@ EOT
 
 resource "flexibleengine_waf_dedicated_domain" "domain_1" {
   domain         = "www.example.com"
-  certificate_id = flexibleengine_waf_certificate.certificate_1.id
+  certificate_id = flexibleengine_waf_dedicated_certificate.certificate_1.id
 
   server {
     client_protocol = "HTTPS"
@@ -72,8 +72,8 @@ The following arguments are supported:
 * `certificate_id` - (Optional, String) Specifies the certificate ID. This parameter is mandatory when `client_protocol`
   is set to HTTPS.
 
-* `policy_id` - (Optional, String) Specifies the policy ID associated with the domain. If not specified, a new policy
-  will be created automatically.
+* `policy_id` - (Optional, String, ForceNew) Specifies the policy ID associated with the domain. If not specified,
+  a new policy will be created automatically. Changing this creates a new domain.
 
 * `proxy` - (Optional, Bool) Specifies whether a proxy is configured. Default value is `false`.
 

--- a/flexibleengine/acceptance/data_source_flexibleengine_waf_dedicated_instances_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_waf_dedicated_instances_test.go
@@ -50,6 +50,54 @@ func TestAccDataSourceWafDedicatedInstances_basic(t *testing.T) {
 	})
 }
 
+func baseDependResource(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc_v1" "vpc_1" {
+  name = "%s_waf"
+  cidr = "192.168.0.0/24"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "vpc_subnet_1" {
+  name       = "%s_waf"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = flexibleengine_vpc_v1.vpc_1.id
+}
+
+resource "flexibleengine_networking_secgroup_v2" "secgroup" {
+  name        = "%s_waf"
+  description = "terraform security group acceptance test"
+}
+
+data "flexibleengine_availability_zones" "zones" {}
+
+data "flexibleengine_compute_flavors_v2" "flavors" {
+  availability_zone = data.flexibleengine_availability_zones.zones.names[1]
+  performance_type  = "normal"
+  cpu_core          = 2
+}
+`, name, name, name)
+}
+
+func testAccWafDedicatedInstanceV1_conf(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_waf_dedicated_instance" "instance_1" {
+  name               = "%s"
+  available_zone     = data.flexibleengine_availability_zones.zones.names[1]
+  specification_code = "waf.instance.professional"
+  ecs_flavor         = data.flexibleengine_compute_flavors_v2.flavors.flavors[0]
+  vpc_id             = flexibleengine_vpc_v1.vpc_1.id
+  subnet_id          = flexibleengine_vpc_subnet_v1.vpc_subnet_1.id
+  
+  security_group = [
+    flexibleengine_networking_secgroup_v2.secgroup.id
+  ]
+}
+`, baseDependResource(name), name)
+}
+
 func testAccWafDedicatedInstances_conf(name string) string {
 	return fmt.Sprintf(`
 %s

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -490,7 +490,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_waf_dedicated_instance":    ResourceWafDedicatedInstance(),
 			"flexibleengine_waf_dedicated_policy":      ResourceWafDedicatedPolicyV1(),
 			"flexibleengine_waf_dedicated_certificate": ResourceWafDedicatedCertificateV1(),
-			"flexibleengine_waf_dedicated_domain":      waf.ResourceWafDedicatedDomainV1(),
+			"flexibleengine_waf_dedicated_domain":      ResourceWafDedicatedDomainV1(),
 
 			"flexibleengine_lb_loadbalancer_v3": elb.ResourceLoadBalancerV3(),
 			"flexibleengine_lb_listener_v3":     elb.ResourceListenerV3(),

--- a/flexibleengine/provider_test.go
+++ b/flexibleengine/provider_test.go
@@ -35,6 +35,7 @@ var (
 	OS_DESTINATION_BUCKET     = os.Getenv("OS_DESTINATION_BUCKET")
 	OS_FGS_BUCKET             = os.Getenv("OS_FGS_BUCKET")
 	OS_OBS_URN_SMN            = os.Getenv("OS_OBS_URN_SMN")
+	OS_WAF_ENABLE_FLAG        = os.Getenv("OS_WAF_ENABLE_FLAG")
 	OS_TENANT_NAME            = getTenantName()
 )
 
@@ -341,5 +342,11 @@ func testAccIdentityV3AgencyPreCheck(t *testing.T) {
 	testAccPreCheckRequiredEnvVars(t)
 	if OS_TENANT_NAME == "" {
 		t.Skip("OS_TENANT_NAME must be set for acceptance tests")
+	}
+}
+
+func testAccPrecheckWafInstance(t *testing.T) {
+	if OS_WAF_ENABLE_FLAG == "" {
+		t.Skip("Jump the WAF acceptance tests.")
 	}
 }

--- a/flexibleengine/resource_flexibleengine_waf_dedicated_certificate_test.go
+++ b/flexibleengine/resource_flexibleengine_waf_dedicated_certificate_test.go
@@ -100,6 +100,7 @@ func testAccCheckWafDedicatedCertificateV1Exists(n string, certificate *certific
 
 func testAccWafDedicatedCertificateV1_conf(name string) string {
 	return fmt.Sprintf(`
+%s
 
 resource "flexibleengine_waf_dedicated_certificate" "certificate_1" {
   name = "%s"
@@ -158,6 +159,11 @@ x7N2mFK4skBzVtMVbjAHVjG78UitVu+FrzqGreaJXHaduhgUH2iFWfw09joOotAM
 X7ioLbTeWGBqFM+C80PkdBNp
 -----END PRIVATE KEY-----
 EOT
+
+  depends_on = [
+    flexibleengine_waf_dedicated_instance.instance_1
+  ]
+
 }
-`, name)
+`, testAccWafDedicatedInstanceV1_conf(name), name)
 }

--- a/flexibleengine/resource_flexibleengine_waf_dedicated_domain.go
+++ b/flexibleengine/resource_flexibleengine_waf_dedicated_domain.go
@@ -1,0 +1,473 @@
+package flexibleengine
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/waf/v1/certificates"
+	domains "github.com/chnsz/golangsdk/openstack/waf_hw/v1/premium_domains"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/common"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+const (
+	// protectStatusEnable 1: protection status enabled.
+	protectStatusEnable = 1
+)
+
+func ResourceWafDedicatedDomainV1() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceWafDedicatedDomainV1Create,
+		Read:   resourceWafDedicatedDomainV1Read,
+		Update: resourceWafDedicatedDomainV1Update,
+		Delete: resourceWafDedicatedDomainV1Delete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"domain": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"server": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MaxItems: 80,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"client_protocol": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice([]string{"HTTP", "HTTPS"}, false),
+						},
+						"server_protocol": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice([]string{"HTTP", "HTTPS"}, false),
+						},
+						"address": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"port": {
+							Type:         schema.TypeInt,
+							ValidateFunc: validation.IntBetween(0, 65535),
+							Required:     true,
+							ForceNew:     true,
+						},
+						"type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice([]string{"ipv4", "ipv6"}, false),
+						},
+						"vpc_id": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+			"certificate_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"policy_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+			"proxy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"keep_policy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"protect_status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+				Optional: true,
+			},
+			"tls": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"TLS v1.0", "TLS v1.1", "TLS v1.2",
+				}, false),
+			},
+			"cipher": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ValidateFunc: validation.StringInSlice([]string{
+					"cipher_1",
+					"cipher_2",
+					"cipher_3",
+					"cipher_4",
+					"cipher_default",
+				}, false),
+			},
+			"pci_3ds": {
+				Type:         schema.TypeBool,
+				Optional:     true,
+				Computed:     true,
+				RequiredWith: []string{"tls", "cipher"},
+			},
+			"pci_dss": {
+				Type:         schema.TypeBool,
+				Optional:     true,
+				Computed:     true,
+				RequiredWith: []string{"tls", "cipher"},
+			},
+			"access_status": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"protocol": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"certificate_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"alarm_page": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"compliance_certification": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeBool},
+			},
+			"traffic_identifier": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+// getCertificateNameById get certificate id from FlexibleEngine.
+func getCertificateNameById(d *schema.ResourceData, meta interface{}) (string, error) {
+	config := meta.(*config.Config)
+	c, err := wafDedicatedv1Client(config, config.GetRegion(d))
+	if err != nil {
+		return "", fmt.Errorf("error creating FlexibleEngine WAF Client: %s", err)
+	}
+	if _, ok := d.GetOk("certificate_id"); ok {
+		r, err := certificates.Get(c, d.Get("certificate_id").(string)).Extract()
+		if err != nil {
+			return "", fmt.Errorf("error obtain WAF certificate name according id: %s, error: %s",
+				d.Get("certificate_id").(string), err)
+		}
+		return r.Name, nil
+	}
+	return "", nil
+}
+
+// buildCreatePremiumHostOpts build the options for creating premium domains.
+func buildCreatePremiumHostOpts(d *schema.ResourceData, meta interface{}) (*domains.CreateOpts, error) {
+	certName, err := getCertificateNameById(d, meta)
+	if err != nil {
+		return nil, err
+	}
+
+	servers := d.Get("server").([]interface{})
+	serverOpts := make([]domains.Server, len(servers))
+	for i, v := range servers {
+		s := v.(map[string]interface{})
+		serverOpts[i] = domains.Server{
+			FrontProtocol: s["client_protocol"].(string),
+			BackProtocol:  s["server_protocol"].(string),
+			Address:       s["address"].(string),
+			Port:          s["port"].(int),
+			Type:          s["type"].(string),
+			VpcId:         s["vpc_id"].(string),
+		}
+	}
+
+	proxy := d.Get("proxy").(bool)
+	opts := domains.CreateOpts{
+		CertificateId:   d.Get("certificate_id").(string),
+		CertificateName: certName,
+		HostName:        d.Get("domain").(string),
+		Proxy:           &proxy,
+		PolicyId:        d.Get("policy_id").(string),
+		Servers:         serverOpts,
+	}
+
+	log.Printf("[DEBUG] build WAF dedicated domain creation options: %#v", serverOpts)
+	return &opts, nil
+}
+
+// resourceWafDedicatedDomainV1Create create a premium domain name in FlexibleEngine.
+func resourceWafDedicatedDomainV1Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafDedicatedClient, err := config.WafDedicatedV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating FlexibleEngine WAF dedicated Client: %s", err)
+	}
+
+	createOpts, err := buildCreatePremiumHostOpts(d, meta)
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] The options of creating WAF dedicated domain: %#v", createOpts)
+
+	domain, err := domains.Create(wafDedicatedClient, *createOpts)
+	if err != nil {
+		return fmt.Errorf("error creating WAF Domain: %s", err)
+	}
+	log.Printf("[DEBUG] Waf dedicated domain has been created: %#v", domain)
+	d.SetId(domain.Id)
+
+	if d.Get("protect_status").(int) != protectStatusEnable {
+		_, err = domains.UpdateProtectStatus(wafDedicatedClient, d.Id(), d.Get("protect_status").(int))
+		if err != nil {
+			// If the protection status update fails, it will be managed by terraform, and only print log.
+			log.Printf("[ERROR] error change the protection status of WAF dedicate domain %s: %s", d.Id(), err)
+		}
+	}
+
+	if d.HasChanges("tls", "cipher", "pci_3ds", "pci_dss") {
+		if err := updateWafDedicatedDomain(wafDedicatedClient, meta, d); err != nil {
+			return fmt.Errorf("error updating WAF dedicated domain: %s", err)
+		}
+	}
+
+	return resourceWafDedicatedDomainV1Read(d, meta)
+}
+
+func updateWafDedicatedDomain(client *golangsdk.ServiceClient, meta interface{}, d *schema.ResourceData) error {
+	updateOpts := domains.UpdatePremiumHostOpts{
+		Tls:    d.Get("tls").(string),
+		Cipher: d.Get("cipher").(string),
+	}
+
+	if d.HasChange("proxy") && !d.IsNewResource() {
+		updateOpts.Proxy = utils.Bool(d.Get("proxy").(bool))
+	}
+
+	if d.HasChange("certificate_id") && !d.IsNewResource() {
+		if v, ok := d.GetOk("certificate_id"); ok {
+			certName, err := getCertificateNameById(d, meta)
+			if err != nil {
+				return err
+			}
+			updateOpts.CertificateName = certName
+			updateOpts.CertificateId = v.(string)
+		}
+	}
+
+	if d.HasChanges("pci_3ds", "pci_dss") {
+		flag, err := getHostFlag(d)
+		if err != nil {
+			return err
+		}
+		updateOpts.Flag = flag
+	}
+	log.Printf("[DEBUG] Waf dedicated domain update: %#v", updateOpts)
+	_, err := domains.Update(client, d.Id(), updateOpts)
+	if err != nil {
+		return fmt.Errorf("error updating WAF dedicated domain: %s", err)
+	}
+	return nil
+}
+
+func getHostFlag(d *schema.ResourceData) (*domains.Flag, error) {
+	pci3ds := d.Get("pci_3ds").(bool)
+	pciDss := d.Get("pci_dss").(bool)
+	if !pci3ds && !pciDss {
+		return nil, nil
+	}
+
+	// required tls="TLS v1.2" && cipher="cipher_2"
+	if d.Get("tls").(string) != "TLS v1.2" || d.Get("cipher").(string) != "cipher_2" {
+		return nil, fmt.Errorf("pci_3ds and pci_dss must be used together with tls and cipher. " +
+			"Tls must be set to TLS v1.2, and cipher must be set to cipher_2")
+	}
+	return &domains.Flag{
+		Pci3ds: strconv.FormatBool(pci3ds),
+		PciDss: strconv.FormatBool(pciDss),
+	}, nil
+}
+
+// buildDomainServerAttributes build the 'server' attribute after querying a domain.
+func buildDomainServerAttribute(domain *domains.PremiumHost) []map[string]interface{} {
+	servers := make([]map[string]interface{}, 0, len(domain.Servers))
+	for _, s := range domain.Servers {
+		servers = append(servers, map[string]interface{}{
+			"client_protocol": s.FrontProtocol,
+			"server_protocol": s.BackProtocol,
+			"address":         s.Address,
+			"port":            s.Port,
+			"type":            s.Type,
+			"vpc_id":          s.VpcId,
+		})
+	}
+	return servers
+}
+
+// buildDomainServerAttributes build the 'traffic_identifier' attribute after querying a domain.
+func buildComplianceCertificationAttribute(domain *domains.PremiumHost) map[string]interface{} {
+	f := domain.Flag
+
+	pciDss, _ := strconv.ParseBool(f["pci_dss"])
+	pci3ds, _ := strconv.ParseBool(f["pci_3ds"])
+	return map[string]interface{}{
+		"pci_dss": pciDss,
+		"pci_3ds": pci3ds,
+	}
+}
+
+// buildDomainServerAttributes build the 'compliance_certification' attribute after querying a domain.
+func buildTrafficIdentifierAttribute(domain *domains.PremiumHost) map[string]interface{} {
+	t := domain.TrafficMark
+	return map[string]interface{}{
+		"ip_tag":      strings.Join(t.Sip, ","),
+		"session_tag": t.Cookie,
+		"user_tag":    t.Params,
+	}
+}
+
+// buildAlarmPageAttribute build the 'alarm_page' attribute after querying a domain.
+func buildAlarmPageAttribute(domain *domains.PremiumHost) map[string]interface{} {
+	t := domain.BlockPage
+	return map[string]interface{}{
+		"template_name": t.Template,
+		"redirect_url":  t.RedirectUrl,
+	}
+}
+
+// resourceWafDedicatedDomainV1Read query a domain detail by id.
+func resourceWafDedicatedDomainV1Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafClient, err := config.WafDedicatedV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating FlexibleEngine WAF client: %s", err)
+	}
+
+	dm, err := domains.Get(wafClient, d.Id())
+	if err != nil {
+		return common.CheckDeleted(d, err, "Error obtain WAF dedicated domain information")
+	}
+	log.Printf("[DEBUG] Get the WAF dedicated domain : %#v", dm)
+
+	servers := buildDomainServerAttribute(dm)
+	mErr := multierror.Append(nil,
+		d.Set("region", config.GetRegion(d)),
+		d.Set("domain", dm.HostName),
+		d.Set("server", servers),
+		d.Set("certificate_id", dm.CertificateId),
+		d.Set("certificate_name", dm.CertificateName),
+		d.Set("policy_id", dm.PolicyId),
+		d.Set("proxy", dm.Proxy),
+		d.Set("protect_status", dm.ProtectStatus),
+		d.Set("access_status", dm.AccessStatus),
+		d.Set("protocol", dm.Protocol),
+		d.Set("tls", dm.Tls),
+		d.Set("cipher", dm.Cipher),
+	)
+
+	if dm.Flag["pci_3ds"] != "" {
+		pci3ds, err := strconv.ParseBool(dm.Flag["pci_3ds"])
+		if err != nil {
+			log.Printf("[WARN] error parse bool pci 3ds, %s", err)
+		}
+		mErr = multierror.Append(mErr, d.Set("pci_3ds", pci3ds))
+	}
+
+	if dm.Flag["pci_dss"] != "" {
+		pciDss, err := strconv.ParseBool(dm.Flag["pci_dss"])
+		if err != nil {
+			log.Printf("[WARN] error parse bool pci dss, %s", err)
+		}
+		mErr = multierror.Append(mErr, d.Set("pci_dss", pciDss))
+	}
+
+	if mErr.ErrorOrNil() != nil {
+		return fmt.Errorf("error setting WAF fields: %s", err)
+	}
+
+	// The resources of compliance_certification, alarm_page and traffic_identifier may be empty.
+	d.Set("compliance_certification", buildComplianceCertificationAttribute(dm))
+	d.Set("traffic_identifier", buildTrafficIdentifierAttribute(dm))
+	d.Set("alarm_page", buildAlarmPageAttribute(dm))
+
+	return nil
+}
+
+// resourceWafDedicatedDomainV1Update modify some fields of domain: certificate_id, proxy, protect_status and policy_id.
+func resourceWafDedicatedDomainV1Update(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafDedicatedClient, err := config.WafDedicatedV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating FlexibleEngine WAF dedicated Client: %s", err)
+	}
+
+	if d.HasChanges("tls", "cipher", "proxy", "certificate_id", "pci_3ds", "pci_dss") {
+		if err := updateWafDedicatedDomain(wafDedicatedClient, meta, d); err != nil {
+			return fmt.Errorf("error updating WAF dedicated domain: %s", err)
+		}
+	}
+
+	if d.HasChanges("protect_status") {
+		_, err = domains.UpdateProtectStatus(wafDedicatedClient, d.Id(), d.Get("protect_status").(int))
+		if err != nil {
+			return fmt.Errorf("[ERROR] error change the protection status of WAF dedicate domain %s: %s",
+				d.Id(), err)
+		}
+	}
+
+	return resourceWafDedicatedDomainV1Read(d, meta)
+}
+
+// resourceWafDedicatedDomainV1Delete delete a domain by id.
+func resourceWafDedicatedDomainV1Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*config.Config)
+	wafDedicatedClient, err := config.WafDedicatedV1Client(config.GetRegion(d))
+	if err != nil {
+		return fmt.Errorf("error creating FlexibleEngine WAF client: %s", err)
+	}
+
+	log.Printf("[DEBUG] Delete WAF dedicated domain(keep_policy: %v).", d.Get("keep_policy"))
+	_, err = domains.Delete(wafDedicatedClient, d.Id(), d.Get("keep_policy").(bool))
+	if err != nil {
+		return fmt.Errorf("error deleting WAF dedicated domain: %s", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/flexibleengine/resource_flexibleengine_waf_dedicated_domain_test.go
+++ b/flexibleengine/resource_flexibleengine_waf_dedicated_domain_test.go
@@ -1,4 +1,4 @@
-package acceptance
+package flexibleengine
 
 import (
 	"fmt"
@@ -32,7 +32,7 @@ func TestAccWafDedicateDomainV1_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "domain", fmt.Sprintf("www.%s.com", randName)),
 					resource.TestCheckResourceAttr(resourceName, "proxy", "false"),
 					resource.TestCheckResourceAttr(resourceName, "server.#", "1"),
-					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8080"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.address", "119.8.0.14"),
@@ -51,7 +51,7 @@ func TestAccWafDedicateDomainV1_basic(t *testing.T) {
 					testAccCheckWafDedicatedDomainV1Exists(resourceName, &domain),
 					resource.TestCheckResourceAttr(resourceName, "proxy", "true"),
 					resource.TestCheckResourceAttr(resourceName, "server.#", "2"),
-					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8443"),
 					resource.TestCheckResourceAttr(resourceName, "server.0.address", "119.8.0.14"),
@@ -68,8 +68,41 @@ func TestAccWafDedicateDomainV1_basic(t *testing.T) {
 	})
 }
 
+func TestAccWafDedicateDomainV1_policy(t *testing.T) {
+	var domain domains.PremiumHost
+	resourceName := "flexibleengine_waf_dedicated_domain.domain_1"
+	randName := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPrecheckWafInstance(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckWafDedicatedDomainV1Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccWafDedicatedDomainV1_policy(randName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWafDedicatedDomainV1Exists(resourceName, &domain),
+					resource.TestCheckResourceAttr(resourceName, "domain", fmt.Sprintf("www.%s.com", randName)),
+					resource.TestCheckResourceAttr(resourceName, "proxy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "server.#", "1"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.client_protocol", "HTTPS"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.server_protocol", "HTTP"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.port", "8080"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.address", "119.8.0.14"),
+					resource.TestCheckResourceAttr(resourceName, "server.0.type", "ipv4"),
+					resource.TestCheckResourceAttrPair(resourceName, "policy_id",
+						"flexibleengine_waf_dedicated_policy.policy_1", "id"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckWafDedicatedDomainV1Destroy(s *terraform.State) error {
-	config := acceptance.TestAccProvider.Meta().(*config.Config)
+	config := testAccProvider.Meta().(*config.Config)
 	c, err := config.WafDedicatedV1Client(OS_REGION_NAME)
 	if err != nil {
 		return fmt.Errorf("error creating Flexibleengine WAF dedicated client: %s", err)
@@ -98,7 +131,7 @@ func testAccCheckWafDedicatedDomainV1Exists(n string, domain *domains.PremiumHos
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No ID is set")
 		}
-		config := acceptance.TestAccProvider.Meta().(*config.Config)
+		config := testAccProvider.Meta().(*config.Config)
 		c, err := config.WafDedicatedV1Client(OS_REGION_NAME)
 		if err != nil {
 			return fmt.Errorf("error creating Flexibleengine WAF dedicated client: %s", err)
@@ -120,12 +153,15 @@ func testAccWafDedicatedDomainV1_basic(name string) string {
 %s
 
 resource "flexibleengine_waf_dedicated_domain" "domain_1" {
-  domain      = "www.%s.com"
-  keep_policy = false
-  proxy       = false
+  domain         = "www.%s.com"
+  certificate_id = flexibleengine_waf_dedicated_certificate.certificate_1.id
+  keep_policy    = false
+  proxy          = false
+  tls            = "TLS v1.1"
+  cipher         = "cipher_1"
 
   server {
-    client_protocol = "HTTP"
+    client_protocol = "HTTPS"
     server_protocol = "HTTP"
     address         = "119.8.0.14"
     port            = 8080
@@ -133,7 +169,7 @@ resource "flexibleengine_waf_dedicated_domain" "domain_1" {
     vpc_id          = flexibleengine_vpc_v1.vpc_1.id
   }
 }
-`, testAccWafDedicatedInstanceV1_conf(name), name)
+`, testAccWafDedicatedCertificateV1_conf(name), name)
 }
 
 func testAccWafDedicatedDomainV1_update(name string) string {
@@ -142,11 +178,16 @@ func testAccWafDedicatedDomainV1_update(name string) string {
 
 resource "flexibleengine_waf_dedicated_domain" "domain_1" {
   domain         = "www.%s.com"
+  certificate_id = flexibleengine_waf_dedicated_certificate.certificate_1.id
   keep_policy    = false
   proxy          = true
+  tls            = "TLS v1.2"
+  cipher         = "cipher_2"
+  pci_3ds        = true
+  pci_dss        = true
 
   server {
-    client_protocol = "HTTP"
+    client_protocol = "HTTPS"
     server_protocol = "HTTP"
     address         = "119.8.0.14"
     port            = 8443
@@ -155,7 +196,7 @@ resource "flexibleengine_waf_dedicated_domain" "domain_1" {
   }
 
   server {
-    client_protocol = "HTTP"
+    client_protocol = "HTTPS"
     server_protocol = "HTTP"
     address         = "119.8.0.15"
     port            = 8443
@@ -163,5 +204,38 @@ resource "flexibleengine_waf_dedicated_domain" "domain_1" {
     vpc_id          = flexibleengine_vpc_v1.vpc_1.id
   }
 }
-`, testAccWafDedicatedInstanceV1_conf(name), name)
+`, testAccWafDedicatedCertificateV1_conf(name), name)
+}
+
+func testAccWafDedicatedDomainV1_policy(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_waf_dedicated_policy" "policy_1" {
+  name  = "%s"
+
+  depends_on = [
+    flexibleengine_waf_dedicated_instance.instance_1
+  ]
+}
+
+resource "flexibleengine_waf_dedicated_domain" "domain_1" {
+  domain         = "www.%s.com"
+  certificate_id = flexibleengine_waf_dedicated_certificate.certificate_1.id
+  keep_policy    = false
+  proxy          = false
+  tls            = "TLS v1.1"
+  cipher         = "cipher_1"
+  policy_id      = flexibleengine_waf_dedicated_policy.policy_1.id
+
+  server {
+    client_protocol = "HTTPS"
+    server_protocol = "HTTP"
+    address         = "119.8.0.14"
+    port            = 8080
+    type            = "ipv4"
+    vpc_id          = flexibleengine_vpc_v1.vpc_1.id
+  }
+}
+`, testAccWafDedicatedCertificateV1_conf(name), name, name)
 }

--- a/flexibleengine/resource_flexibleengine_waf_dedicated_instance_test.go
+++ b/flexibleengine/resource_flexibleengine_waf_dedicated_instance_test.go
@@ -1,4 +1,4 @@
-package acceptance
+package flexibleengine
 
 import (
 	"fmt"
@@ -11,13 +11,12 @@ import (
 
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
-	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils/fmtp"
 )
 
 func getWafDedicatedInstanceFunc(c *config.Config, state *terraform.ResourceState) (interface{}, error) {
 	client, err := c.WafDedicatedV1Client(OS_REGION_NAME)
 	if err != nil {
-		return nil, fmtp.Errorf("error creating Flexibleengine WAF dedicated client : %s", err)
+		return nil, fmt.Errorf("error creating Flexibleengine WAF dedicated client : %s", err)
 	}
 	return instances.GetInstance(client, state.Primary.ID)
 }

--- a/flexibleengine/resource_flexibleengine_waf_dedicated_policy.go
+++ b/flexibleengine/resource_flexibleengine_waf_dedicated_policy.go
@@ -273,7 +273,7 @@ func resourceWafDedicatedPolicyV1Delete(d *schema.ResourceData, meta interface{}
 
 	err = policies.Delete(wafClient, d.Id()).ExtractErr()
 	if err != nil {
-		return fmt.Errorf("error deleting WAF Policy: %s", err)
+		return common.CheckDeleted(d, err, "error deleting WAF Policy")
 	}
 
 	d.SetId("")


### PR DESCRIPTION
```
make testacc TEST='./flexibleengine' TESTARGS='-run TestAccWafDedicateDomainV1_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccWafDedicateDomainV1_basic -timeout 720m
=== RUN   TestAccWafDedicateDomainV1_basic
=== PAUSE TestAccWafDedicateDomainV1_basic
=== CONT  TestAccWafDedicateDomainV1_basic
--- PASS: TestAccWafDedicateDomainV1_basic (503.84s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 503.959s

make testacc TEST='./flexibleengine' TESTARGS='-run TestAccWafDedicateDomainV1_policy'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccWafDedicateDomainV1_policy -timeout 720m
=== RUN   TestAccWafDedicateDomainV1_policy
=== PAUSE TestAccWafDedicateDomainV1_policy
=== CONT  TestAccWafDedicateDomainV1_policy
--- PASS: TestAccWafDedicateDomainV1_policy (473.07s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 473.196s
```