### PR TITLE
feat(gaussdb): add nosql resources

### DIFF
--- a/docs/data-sources/gaussdb_cassandra_instances.md
+++ b/docs/data-sources/gaussdb_cassandra_instances.md
@@ -1,0 +1,94 @@
+---
+subcategory: "GaussDB NoSQL"
+---
+
+# flexibleengine_gaussdb_cassandra_instances
+
+Use this data source to get available FlexibleEngine gaussdb cassandra instances.
+
+## Example Usage
+
+```hcl
+data "flexibleengine_gaussdb_cassandra_instances" "this" {
+  name = "gaussdb-instance"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the instance. If omitted, the provider-level region will
+  be used.
+
+* `name` - (Optional, String) Specifies the name of the instance.
+
+* `vpc_id` - (Optional, String) Specifies the VPC ID.
+
+* `subnet_id` - (Optional, String) Specifies the network ID of a subnet.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates the ID of the data source.
+
+* `instances` - An array of available instances.
+
+The `instances` block supports:
+
+* `region` - The region of the instance.
+
+* `name` - Indicates the name of the instance.
+
+* `vpc_id` - Indicates the VPC ID.
+
+* `subnet_id` - Indicates the network ID of a subnet.
+
+* `status` - Indicates the DB instance status.
+
+* `mode` - Indicates the instance mode.
+
+* `flavor` - Indicates the instance specifications.
+
+* `security_group_id` - Indicates the security group ID.
+
+* `enterprise_project_id` - Indicates the enterprise project id.
+
+* `db_user_name` - Indicates the default username.
+
+* `availability_zone` - Indicates the instance availability zone.
+
+* `port` - Indicates the database port.
+
+* `node_num` - Indicates the count of the nodes.
+
+* `volume_size` - Indicates the size of the volume.
+
+* `private_ips` - Indicates the list of private IP address of the nodes.
+
+* `datastore` - Indicates the database information. Structure is documented below.
+
+* `backup_strategy` - Indicates the advanced backup policy. Structure is documented below.
+
+* `nodes` - Indicates the instance nodes information. Structure is documented below.
+
+* `tags` - Indicates the key/value tags of the instance.
+
+The `datastore` block supports:
+
+* `engine` - Indicates the database engine.
+* `storage_engine` - Indicates the database storage engine.
+* `version` - Indicates the database version.
+
+The `backup_strategy` block supports:
+
+* `start_time` - Indicates the backup time window.
+* `keep_days` - Indicates the number of days to retain the generated
+
+The `nodes` block contains:
+
+* `id` - Indicates the node ID.
+* `name` - Indicates the node name.
+* `private_ip` - Indicates the private IP address of a node.
+* `status` - Indicates the node status.
+* `support_reduce` - Indicates whether the node support reduce.
+* `availability_zone` - Indicates the availability zone where the node resides.

--- a/docs/data-sources/gaussdb_nosql_flavors.md
+++ b/docs/data-sources/gaussdb_nosql_flavors.md
@@ -1,0 +1,55 @@
+---
+subcategory: "GaussDB NoSQL"
+---
+
+# flexibleengine_gaussdb_nosql_flavors
+
+Use this data source to get available FlexibleEngine GaussDB (for NoSQL) flavors.
+
+## Example Usage
+
+```hcl
+data "flexibleengine_gaussdb_nosql_flavors" "flavors" {
+  vcpus  = 4
+  memory = 16
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) Specifies the region in which to obtain the GaussDB specifications.
+  If omitted, the provider-level region will be used.
+
+* `engine` - (Optional, String) Specifies the type of the database engine. The valid values are as follows:
+  + **cassandra**: The default value and means to query GaussDB (for Cassandra) instance specifications.
+  + **influxdb**: Means to query GaussDB (for Influx) instance specifications.
+
+* `engine_version` - (Optional, String) Specifies the version of the database engine.
+
+* `vcpus` - (Optional, Int) Specifies the number of vCPUs.
+
+* `memory` - (Optional, Int) Specifies the memory size in gigabytes (GB).
+
+* `availability_zone` - (Optional, String) Specifies the availability zone (AZ) of the GaussDB specifications.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Data source ID.
+
+* `flavors` - The information of the GaussDB specifications. Structure is documented below.
+
+The `flavors` block contains:
+
+* `name` - The spec code of the flavor.
+
+* `vcpus` - The number of vCPUs.
+
+* `memory` - The memory size, in GB.
+
+* `engine` - The type of the database engine.
+
+* `engine_version` - The version of the database engine.
+
+* `availability_zones` - All available zones (on sale) for current flavor.

--- a/docs/resources/gaussdb_cassandra_instance.md
+++ b/docs/resources/gaussdb_cassandra_instance.md
@@ -1,0 +1,161 @@
+---
+subcategory: "GaussDB NoSQL"
+---
+
+# flexibleengine_gaussdb_cassandra_instance
+
+GaussDB for Cassandra instance management within FlexibleEngine.
+
+## Example Usage
+
+### create a gaussdb for cassandra instance with tags
+
+```hcl
+resource "flexibleengine_gaussdb_cassandra_instance" "instance_1" {
+  name              = "gaussdb_cassandra_instance_1"
+  password          = var.password
+  flavor            = "geminidb.cassandra.xlarge.4"
+  volume_size       = 100
+  vpc_id            = var.vpc_id
+  subnet_id         = var.subnet_id
+  security_group_id = var.secgroup_id
+  availability_zone = var.availability_zone
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+```
+
+### create a gaussdb cassandra instance with backup strategy
+
+```hcl
+resource "flexibleengine_gaussdb_cassandra_instance" "instance_1" {
+  name              = "gaussdb_cassandra_instance_1"
+  password          = var.password
+  flavor            = "geminidb.cassandra.xlarge.4"
+  volume_size       = 100
+  vpc_id            = var.vpc_id
+  subnet_id         = var.subnet_id
+  security_group_id = var.secgroup_id
+  availability_zone = var.availability_zone
+
+  backup_strategy {
+    start_time = "03:00-04:00"
+    keep_days  = 14
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the Cassandra instance resource. If omitted, the
+  provider-level region will be used. Changing this creates a new Cassandra instance resource.
+
+* `availability_zone` - (Required, String, ForceNew) Specifies the AZ name. For a three-AZ deployment instance,
+  use commas (,) to separate the AZs, for example, `cn-north-4a,cn-north-4b,cn-north-4c`.
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the instance name, which can be the same as an existing instance name. The value
+  must be 4 to 64 characters in length and start with a letter. It is case-sensitive and can contain only letters,
+  digits, hyphens (-), and underscores (_).
+
+* `flavor` - (Required, String) Specifies the instance specifications. For details,
+  see [DB Instance Specifications](https://docs.prod-cloud-ocb.orange-business.com/usermanual/nosql/nosql_05_0017.html)
+
+* `node_num` - (Optional, Int) Specifies the number of nodes, ranges from 3 to 12. Defaults to 3.
+
+* `volume_size` - (Required, Int) Specifies the storage space in GB. The value must be a multiple of 10. For a GaussDB
+  Cassandra DB instance, the minimum storage space is 100 GB, and the maximum storage space is related to the instance
+  performance specifications. For details,
+  see [DB Instance Specifications](https://docs.prod-cloud-ocb.orange-business.com/usermanual/nosql/nosql_05_0017.html)
+
+* `password` - (Required, String) Specifies the database password. The value must be 8 to 32 characters in length,
+  including uppercase and lowercase letters, digits, and special characters, such as ~!@#%^*-_=+? You are advised to
+  enter a strong password to improve security, preventing security risks such as brute force cracking.
+
+* `vpc_id` - (Required, String, ForceNew) Specifies the VPC ID. Changing this parameter will create a new resource.
+
+* `subnet_id` - (Required, String, ForceNew) Specifies the network ID of a subnet. Changing this parameter will create a
+  new resource.
+
+* `security_group_id` - (Optional, String) Specifies the security group ID. Required if the selected subnet doesn't
+  enable network ACL.
+
+* `configuration_id` - (Optional, String) Specifies the Parameter Template ID.
+
+* `ssl` - (Optional, Bool, ForceNew) Specifies whether to enable or disable SSL. Defaults to false. Changing this
+  parameter will create a new resource.
+
+* `force_import` - (Optional, Bool) If specified, try to import the instance instead of creating if the name already
+  existed.
+
+* `datastore` - (Optional, List, ForceNew) Specifies the database information. Structure is documented below. Changing
+  this parameter will create a new resource.
+
+* `backup_strategy` - (Optional, List) Specifies the advanced backup policy. Structure is documented below.
+
+* `tags` - (Optional, Map) The key/value pairs to associate with the instance.
+
+The `datastore` block supports:
+
+* `engine` - (Required, String, ForceNew) Specifies the database engine. Only "GeminiDB-Cassandra" is supported now.
+  Changing this parameter will create a new resource.
+
+* `version` - (Required, String, ForceNew) Specifies the database version.
+  Changing this parameter will create a new resource.
+
+* `storage_engine` - (Required, String, ForceNew) Specifies the storage engine. Only "rocksDB" is supported now.
+  Changing this parameter will create a new resource.
+
+The `backup_strategy` block supports:
+
+* `start_time` - (Required, String) Specifies the backup time window. Automated backups will be triggered during the
+  backup time window. It must be a valid value in the "hh:mm-HH:MM" format. The current time is in the UTC format. The
+  HH value must be 1 greater than the hh value. The values of mm and MM must be the same and must be set to 00. Example
+  value: 08:00-09:00, 03:00-04:00.
+
+* `keep_days` - (Optional, Int) Specifies the number of days to retain the generated backup files. The value ranges from
+  0 to 35. If this parameter is set to 0, the automated backup policy is not set. If this parameter is not transferred,
+  the automated backup policy is enabled by default. Backup files are stored for seven days by default.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+* `status` - Indicates the DB instance status.
+* `port` - Indicates the database port.
+* `mode` - Indicates the instance type.
+* `db_user_name` - Indicates the default username.
+* `nodes` - Indicates the instance nodes information. Structure is documented below.
+* `private_ips` - Indicates the IP address list of the db.
+* `lb_ip_address` - Indicates the LB IP address of the db.
+* `lb_port` - Indicates the LB port of the db.
+
+The `nodes` block contains:
+
+* `id` - Indicates the node ID.
+* `name` - Indicates the node name.
+* `status` - Indicates the node status.
+* `support_reduce` - Indicates whether the node support reduce or not.
+* `private_ip` - Indicates the private IP address of a node.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minute.
+* `update` - Default is 120 minute.
+* `delete` - Default is 30 minute.
+
+## Import
+
+GaussDB Cassandra instance can be imported using the `id`, e.g.
+
+```bash
+terraform import flexibleengine_gaussdb_cassandra_instance.instance_1 2e045d8b-b226-4aa2-91b9-7e76357655c06
+```

--- a/docs/resources/gaussdb_influx_instance.md
+++ b/docs/resources/gaussdb_influx_instance.md
@@ -1,0 +1,162 @@
+---
+subcategory: "GaussDB NoSQL"
+---
+
+# flexibleengine_gaussdb_influx_instance
+
+GaussDB for influx instance management within FlexibleEngine.
+
+## Example Usage
+
+### create a gaussdb for influx instance with tags
+
+```hcl
+resource "flexibleengine_gaussdb_influx_instance" "instance_1" {
+  name              = "gaussdb_influx_instance_1"
+  password          = var.password
+  flavor            = "geminidb.influxdb.large.4"
+  volume_size       = 100
+  vpc_id            = var.vpc_id
+  subnet_id         = var.subnet_id
+  security_group_id = var.secgroup_id
+  availability_zone = var.availability_zone
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+```
+
+### create a gaussdb influx instance with backup strategy
+
+```hcl
+resource "flexibleengine_gaussdb_influx_instance" "instance_1" {
+  name              = "gaussdb_influx_instance_1"
+  password          = var.password
+  flavor            = "geminidb.influxdb.large.4"
+  volume_size       = 100
+  vpc_id            = var.vpc_id
+  subnet_id         = var.subnet_id
+  security_group_id = var.secgroup_id
+  availability_zone = var.availability_zone
+
+  backup_strategy {
+    start_time = "03:00-04:00"
+    keep_days  = 14
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) The region in which to create the influx instance resource. If omitted, the
+  provider-level region will be used. Changing this creates a new influx instance resource.
+
+* `availability_zone` - (Required, String, ForceNew) Specifies the AZ name. For a three-AZ deployment instance,
+  use commas (,) to separate the AZs, for example, `cn-north-4a,cn-north-4b,cn-north-4c`.
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the instance name, which can be the same as an existing instance name. The
+  value must be **4** to **64** characters in length and start with a letter. It is case-sensitive and can contain only
+  letters, digits, hyphens (-), and underscores (_).
+
+* `flavor` - (Required, String, ForceNew) Specifies the instance specifications. For details,
+  see [DB Instance Specifications](https://docs.prod-cloud-ocb.orange-business.com/usermanual/nosql/nosql_05_0045.html)
+  Changing this parameter will create a new resource.
+
+* `node_num` - (Optional, Int) Specifies the number of nodes, ranges from **3** to **16**. Defaults to **3**.
+
+* `volume_size` - (Required, Int) Specifies the storage space in GB. The value must be a multiple of **10**. For a
+  GaussDB influx instance, the minimum storage space is **100** GB, and the maximum storage space is related to the
+  instance performance specifications. For details,
+  see [DB Instance Specifications](https://docs.prod-cloud-ocb.orange-business.com/usermanual/nosql/nosql_05_0045.html)
+
+* `password` - (Required, String) Specifies the database password. The value must be **8** to **32** characters in
+  length, including uppercase and lowercase letters, digits, and special characters, such as ~!@#%^*-_=+? You are
+  advised to enter a strong password to improve security, preventing security risks such as brute force cracking.
+
+* `vpc_id` - (Required, String, ForceNew) Specifies the VPC ID. Changing this parameter will create a new resource.
+
+* `subnet_id` - (Required, String, ForceNew) Specifies the network ID of a subnet. Changing this parameter will create
+  a new resource.
+
+* `security_group_id` - (Optional, String) Specifies the security group ID. Required if the selected subnet doesn't
+  enable network ACL.
+
+* `configuration_id` - (Optional, String) Specifies the Parameter Template ID.
+
+* `ssl` - (Optional, Bool, ForceNew) Specifies whether to enable or disable SSL. Defaults to **false**. Changing this
+  parameter will create a new resource.
+
+* `force_import` - (Optional, Bool) If specified, try to import the instance instead of creating if the name already
+  existed.
+
+* `datastore` - (Optional, List, ForceNew) Specifies the database information. Structure is documented below. Changing
+  this parameter will create a new resource.
+
+* `backup_strategy` - (Optional, List) Specifies the advanced backup policy. Structure is documented below.
+
+* `tags` - (Optional, Map) The key/value pairs to associate with the instance.
+
+The `datastore` block supports:
+
+* `engine` - (Required, String, ForceNew) Specifies the database engine. Only **influxdb** is supported now.
+  Changing this parameter will create a new resource.
+
+* `version` - (Required, String, ForceNew) Specifies the database version.
+  Changing this parameter will create a new resource.
+
+* `storage_engine` - (Required, String, ForceNew) Specifies the storage engine. Only **rocksDB** is supported now.
+  Changing this parameter will create a new resource.
+
+The `backup_strategy` block supports:
+
+* `start_time` - (Required, String) Specifies the backup time window. Automated backups will be triggered during the
+  backup time window. It must be a valid value in the "hh:mm-HH:MM" format. The current time is in the UTC format. The
+  HH value must be 1 greater than the hh value. The values of mm and MM must be the same and must be set to 00. Example
+  value: 08:00-09:00, 03:00-04:00.
+
+* `keep_days` - (Optional, Int) Specifies the number of days to retain the generated backup files. The value ranges from
+  **0** to **35**. If this parameter is set to **0**, the automated backup policy is not set. If this parameter is not
+  transferred, the automated backup policy is enabled by default. Backup files are stored for seven days by default.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Indicates a resource ID in UUID format.
+* `status` - Indicates the DB instance status.
+* `port` - Indicates the database port.
+* `mode` - Indicates the instance type.
+* `db_user_name` - Indicates the default username.
+* `nodes` - Indicates the instance nodes information. Structure is documented below.
+* `private_ips` - Indicates the IP address list of the db.
+* `lb_ip_address` - Indicates the LB IP address of the db.
+* `lb_port` - Indicates the LB port of the db.
+
+The `nodes` block contains:
+
+* `id` - Indicates the node ID.
+* `name` - Indicates the node name.
+* `status` - Indicates the node status.
+* `support_reduce` - Indicates whether the node support reduce or not.
+* `private_ip` - Indicates the private IP address of a node.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minute.
+* `update` - Default is 120 minute.
+* `delete` - Default is 30 minute.
+
+## Import
+
+GaussDB influx instance can be imported using the `id`, e.g.
+
+```bash
+terraform import flexibleengine_gaussdb_influx_instance.instance_1 2e045d8b-b226-4aa2-91b9-7e76357655c06
+```

--- a/flexibleengine/acceptance/data_source_flexibleengine_gaussdb_cassandra_instances_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_gaussdb_cassandra_instances_test.go
@@ -1,0 +1,59 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGeminiDBInstancesDataSource_basic(t *testing.T) {
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	password := acceptance.RandomPassword()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiDBInstancesDataSource_basic(rName, password),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGeminiDBInstancesDataSourceID("data.flexibleengine_gaussdb_cassandra_instances.test"),
+					resource.TestCheckResourceAttr("data.flexibleengine_gaussdb_cassandra_instances.test", "instances.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGeminiDBInstancesDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find GaussDB cassandra instance data source: %s ", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("GaussDB cassandra instances data source ID not set ")
+		}
+
+		return nil
+	}
+}
+
+func testAccGeminiDBInstancesDataSource_basic(rName, password string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_gaussdb_cassandra_instances" "test" {
+  name = "%s"
+  depends_on = [
+    flexibleengine_gaussdb_cassandra_instance.test,
+  ]
+}
+`, testAccGeminiDBInstanceConfig_basic(rName, password), rName)
+}

--- a/flexibleengine/acceptance/data_source_flexibleengine_gaussdb_nosql_flavors_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_gaussdb_nosql_flavors_test.go
@@ -1,0 +1,169 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGaussDBNoSQLFlavors_basic(t *testing.T) {
+	dataSourceName := "data.flexibleengine_gaussdb_nosql_flavors.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBNoSQLFlavors_default(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.engine", "cassandra"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.#"),
+				),
+			},
+			{
+				Config: testAccGaussDBNoSQLFlavors_cassandra(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "engine", "cassandra"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGaussDBNoSQLFlavors_influxdb(t *testing.T) {
+	dataSourceName := "data.flexibleengine_gaussdb_nosql_flavors.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBNoSQLFlavors_influxdb(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "engine", "influxdb"),
+					resource.TestCheckResourceAttrSet(dataSourceName, "flavors.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGaussDBNoSQLFlavors_vcpus(t *testing.T) {
+	dataSourceName := "data.flexibleengine_gaussdb_nosql_flavors.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBNoSQLFlavors_vcpus(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.vcpus", "4"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGaussDBNoSQLFlavors_memory(t *testing.T) {
+	dataSourceName := "data.flexibleengine_gaussdb_nosql_flavors.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBNoSQLFlavors_memory(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "flavors.0.memory", "16"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGaussDBNoSQLFlavors_az(t *testing.T) {
+	dataSourceName := "data.flexibleengine_gaussdb_nosql_flavors.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussDBNoSQLFlavors_az(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(dataSourceName, "flavors.0.availability_zones.0",
+						"data.flexibleengine_availability_zones.test", "names.0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGaussDBNoSQLFlavors_default() string {
+	return fmt.Sprintf(`
+data "flexibleengine_gaussdb_nosql_flavors" "test" {}
+`)
+}
+
+func testAccGaussDBNoSQLFlavors_cassandra() string {
+	return fmt.Sprintf(`
+data "flexibleengine_gaussdb_nosql_flavors" "test" {
+  engine = "cassandra"
+}
+`)
+}
+
+func testAccGaussDBNoSQLFlavors_influxdb() string {
+	return fmt.Sprintf(`
+data "flexibleengine_gaussdb_nosql_flavors" "test" {
+  engine = "influxdb"
+}
+`)
+}
+
+func testAccGaussDBNoSQLFlavors_vcpus() string {
+	return fmt.Sprintf(`
+data "flexibleengine_gaussdb_nosql_flavors" "test" {
+  vcpus = 4
+}
+`)
+}
+
+func testAccGaussDBNoSQLFlavors_memory() string {
+	return fmt.Sprintf(`
+data "flexibleengine_gaussdb_nosql_flavors" "test" {
+  memory = 16
+}
+`)
+}
+
+func testAccGaussDBNoSQLFlavors_az() string {
+	return fmt.Sprintf(`
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_gaussdb_nosql_flavors" "test" {
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+}
+`)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_gaussdb_cassandra_instance_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_gaussdb_cassandra_instance_test.go
@@ -1,0 +1,209 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/geminidb/v3/instances"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccGeminiDBInstance_basic(t *testing.T) {
+	var instance instances.GeminiDBInstance
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	resourceName := "flexibleengine_gaussdb_cassandra_instance.test"
+	password := acceptance.RandomPassword()
+	newPassword := acceptance.RandomPassword()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckGeminiDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGeminiDBInstanceConfig_basic(rName, password),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGeminiDBInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "password", password),
+					resource.TestCheckResourceAttr(resourceName, "node_num", "3"),
+					resource.TestCheckResourceAttr(resourceName, "volume_size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "status", "normal"),
+				),
+			},
+			{
+				Config: testAccGeminiDBInstanceConfig_update(rName, newPassword),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGeminiDBInstanceExists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", rName+"-update"),
+					resource.TestCheckResourceAttr(resourceName, "password", newPassword),
+					resource.TestCheckResourceAttr(resourceName, "node_num", "4"),
+					resource.TestCheckResourceAttr(resourceName, "volume_size", "200"),
+					resource.TestCheckResourceAttr(resourceName, "status", "normal"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGeminiDBInstanceDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*config.Config)
+	client, err := config.GeminiDBV3Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating GeminiDB client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_gaussdb_cassandra_instance" {
+			continue
+		}
+
+		found, err := instances.GetInstanceByID(client, rs.Primary.ID)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return nil
+			}
+			return err
+		}
+		if found.Id != "" {
+			return fmt.Errorf("Instance <%s> still exists.", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckGeminiDBInstanceExists(n string, instance *instances.GeminiDBInstance) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s.", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set.")
+		}
+
+		config := testAccProvider.Meta().(*config.Config)
+		client, err := config.GeminiDBV3Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating GeminiDB client: %s", err)
+		}
+
+		found, err := instances.GetInstanceByID(client, rs.Primary.ID)
+		if err != nil {
+			if _, ok := err.(golangsdk.ErrDefault404); ok {
+				return fmt.Errorf("Instance <%s> not found.", rs.Primary.ID)
+			}
+			return err
+		}
+		if found.Id == "" {
+			return fmt.Errorf("Instance <%s> not found.", rs.Primary.ID)
+		}
+		instance = &found
+
+		return nil
+	}
+}
+
+func testAccGaussDBNosql_base(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc_v1" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test" {
+  name       = "%[1]s"
+  vpc_id     = flexibleengine_vpc_v1.test.id
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+}
+
+resource "flexibleengine_networking_secgroup_v2" "test" {
+  name = "%[1]s"
+}
+`, rName)
+}
+
+func testAccGeminiDBInstanceConfig_basic(rName, password string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_gaussdb_nosql_flavors" "test" {
+  vcpus             = 4
+  engine            = "cassandra"
+}
+
+resource "flexibleengine_gaussdb_cassandra_instance" "test" {
+  name        = "%s"
+  password    = "%s"
+  flavor      = data.flexibleengine_gaussdb_nosql_flavors.test.flavors[0].name
+  volume_size = 100
+  vpc_id      = flexibleengine_vpc_v1.test.id
+  subnet_id   = flexibleengine_vpc_subnet_v1.test.id
+  ssl         = true
+  node_num    = 3
+
+  security_group_id = flexibleengine_networking_secgroup_v2.test.id
+  availability_zone = join(",", data.flexibleengine_availability_zones.test.names)
+
+  backup_strategy {
+    start_time = "03:00-04:00"
+    keep_days  = 14
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testAccGaussDBNosql_base(rName), rName, password)
+}
+
+func testAccGeminiDBInstanceConfig_update(rName, password string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_gaussdb_nosql_flavors" "test" {
+  vcpus             = 4
+  engine            = "cassandra"
+}
+
+resource "flexibleengine_gaussdb_cassandra_instance" "test" {
+  name        = "%s-update"
+  password    = "%s"
+  flavor      = data.flexibleengine_gaussdb_nosql_flavors.test.flavors[0].name
+  volume_size = 200
+  vpc_id      = flexibleengine_vpc_v1.test.id
+  subnet_id   = flexibleengine_vpc_subnet_v1.test.id
+  ssl         = true
+  node_num    = 4
+
+  security_group_id = flexibleengine_networking_secgroup_v2.test.id
+  availability_zone = join(",", data.flexibleengine_availability_zones.test.names)
+
+  backup_strategy {
+    start_time = "03:00-04:00"
+    keep_days  = 14
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testAccGaussDBNosql_base(rName), rName, password)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_gaussdb_influx_instance_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_gaussdb_influx_instance_test.go
@@ -1,0 +1,146 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/geminidb/v3/instances"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getNosqlInstance(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := conf.GeminiDBV3Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating GaussDB client: %s", err)
+	}
+
+	found, err := instances.GetInstanceByID(client, state.Primary.ID)
+	if err != nil {
+		return nil, err
+	}
+	if found.Id == "" {
+		return nil, fmt.Errorf("Instance <%s> not found.", state.Primary.ID)
+	}
+
+	return &found, nil
+}
+
+func TestAccGaussInfluxInstance_basic(t *testing.T) {
+	var instance instances.GeminiDBInstance
+	rName := acceptance.RandomAccResourceName()
+	resourceName := "flexibleengine_gaussdb_influx_instance.test"
+	password := acceptance.RandomPassword()
+	newPassword := acceptance.RandomPassword()
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&instance,
+		getNosqlInstance,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGaussInfluxInstanceConfig_basic(rName, password),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "password", password),
+					resource.TestCheckResourceAttr(resourceName, "node_num", "3"),
+					resource.TestCheckResourceAttr(resourceName, "volume_size", "100"),
+					resource.TestCheckResourceAttr(resourceName, "status", "normal"),
+				),
+			},
+			{
+				Config: testAccGaussInfluxInstanceConfig_update(rName, newPassword),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("%s-update", rName)),
+					resource.TestCheckResourceAttr(resourceName, "password", newPassword),
+					resource.TestCheckResourceAttr(resourceName, "node_num", "4"),
+					resource.TestCheckResourceAttr(resourceName, "volume_size", "200"),
+					resource.TestCheckResourceAttr(resourceName, "status", "normal"),
+				),
+			},
+		},
+	})
+}
+
+func testAccGaussInfluxInstanceConfig_basic(rName, password string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_gaussdb_nosql_flavors" "test" {
+  vcpus             = 4
+  engine            = "influxdb"
+}
+
+resource "flexibleengine_gaussdb_influx_instance" "test" {
+  name        = "%s"
+  password    = "%s"
+  flavor      = data.flexibleengine_gaussdb_nosql_flavors.test.flavors[0].name
+  volume_size = 100
+  vpc_id      = flexibleengine_vpc_v1.test.id
+  subnet_id   = flexibleengine_vpc_subnet_v1.test.id
+  node_num    = 3
+
+  security_group_id = flexibleengine_networking_secgroup_v2.test.id
+  availability_zone = join(",", data.flexibleengine_availability_zones.test.names)
+
+  backup_strategy {
+    start_time = "03:00-04:00"
+    keep_days  = 14
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testAccGaussDBNosql_base(rName), rName, password)
+}
+
+func testAccGaussInfluxInstanceConfig_update(rName, password string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_gaussdb_nosql_flavors" "test" {
+  vcpus             = 4
+  engine            = "influxdb"
+}
+
+resource "flexibleengine_gaussdb_influx_instance" "test" {
+  name        = "%s-update"
+  password    = "%s"
+  flavor      = data.flexibleengine_gaussdb_nosql_flavors.test.flavors[0].name
+  volume_size = 200
+  vpc_id      = flexibleengine_vpc_v1.test.id
+  subnet_id   = flexibleengine_vpc_subnet_v1.test.id
+  node_num    = 4
+
+  security_group_id = flexibleengine_networking_secgroup_v2.test.id
+  availability_zone = join(",", data.flexibleengine_availability_zones.test.names)
+
+  backup_strategy {
+    start_time = "03:00-04:00"
+    keep_days  = 14
+  }
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testAccGaussDBNosql_base(rName), rName, password)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -26,6 +26,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/elb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/eps"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/gaussdb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/modelarts"
@@ -282,6 +283,9 @@ func Provider() *schema.Provider {
 			"flexibleengine_elb_certificate":  elb.DataSourceELBCertificateV3(),
 			"flexibleengine_fgs_dependencies": fgs.DataSourceFunctionGraphDependencies(),
 
+			"flexibleengine_gaussdb_cassandra_instances": gaussdb.DataSourceGeminiDBInstances(),
+			"flexibleengine_gaussdb_nosql_flavors":       gaussdb.DataSourceGaussDBNoSQLFlavors(),
+
 			"flexibleengine_networking_port":    vpc.DataSourceNetworkingPortV2(),
 			"flexibleengine_identity_group":     iam.DataSourceIdentityGroup(),
 			"flexibleengine_identity_users":     iam.DataSourceIdentityUsers(),
@@ -461,15 +465,19 @@ func Provider() *schema.Provider {
 			"flexibleengine_dms_rocketmq_topic":          dms.ResourceDmsRocketMQTopic(),
 			"flexibleengine_dms_rocketmq_user":           dms.ResourceDmsRocketMQUser(),
 
-			"flexibleengine_dli_database":           dli.ResourceDliSqlDatabaseV1(),
-			"flexibleengine_dli_package":            dli.ResourceDliPackageV2(),
-			"flexibleengine_dli_spark_job":          dli.ResourceDliSparkJobV2(),
-			"flexibleengine_dli_table":              dli.ResourceDliTable(),
-			"flexibleengine_dli_flinksql_job":       dli.ResourceFlinkSqlJob(),
-			"flexibleengine_drs_job":                drs.ResourceDrsJob(),
-			"flexibleengine_fgs_dependency":         fgs.ResourceFgsDependency(),
-			"flexibleengine_fgs_function":           fgs.ResourceFgsFunctionV2(),
-			"flexibleengine_fgs_trigger":            fgs.ResourceFunctionGraphTrigger(),
+			"flexibleengine_dli_database":     dli.ResourceDliSqlDatabaseV1(),
+			"flexibleengine_dli_package":      dli.ResourceDliPackageV2(),
+			"flexibleengine_dli_spark_job":    dli.ResourceDliSparkJobV2(),
+			"flexibleengine_dli_table":        dli.ResourceDliTable(),
+			"flexibleengine_dli_flinksql_job": dli.ResourceFlinkSqlJob(),
+			"flexibleengine_drs_job":          drs.ResourceDrsJob(),
+			"flexibleengine_fgs_dependency":   fgs.ResourceFgsDependency(),
+			"flexibleengine_fgs_function":     fgs.ResourceFgsFunctionV2(),
+			"flexibleengine_fgs_trigger":      fgs.ResourceFunctionGraphTrigger(),
+
+			"flexibleengine_gaussdb_cassandra_instance": gaussdb.ResourceGeminiDBInstanceV3(),
+			"flexibleengine_gaussdb_influx_instance":    gaussdb.ResourceGaussDBInfluxInstanceV3(),
+
 			"flexibleengine_identity_acl":           iam.ResourceIdentityACL(),
 			"flexibleengine_rds_account":            rds.ResourceRdsAccount(),
 			"flexibleengine_rds_database":           rds.ResourceRdsDatabase(),


### PR DESCRIPTION
new resources:
flexibleengine_gaussdb_cassandra_instance
flexibleengine_gaussdb_influx_instance

new data_sources:
flexibleengine_gaussdb_cassandra_instances
flexibleengine_gaussdb_nosql_flavors

test results:
```
make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccGaussDBNoSQLFlavors'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccGaussDBNoSQLFlavors -timeout 720m
=== RUN   TestAccGaussDBNoSQLFlavors_basic
=== PAUSE TestAccGaussDBNoSQLFlavors_basic
=== RUN   TestAccGaussDBNoSQLFlavors_influxdb
=== PAUSE TestAccGaussDBNoSQLFlavors_influxdb
=== RUN   TestAccGaussDBNoSQLFlavors_vcpus
=== PAUSE TestAccGaussDBNoSQLFlavors_vcpus
=== RUN   TestAccGaussDBNoSQLFlavors_memory
=== PAUSE TestAccGaussDBNoSQLFlavors_memory
=== RUN   TestAccGaussDBNoSQLFlavors_az
=== PAUSE TestAccGaussDBNoSQLFlavors_az
=== CONT  TestAccGaussDBNoSQLFlavors_basic
=== CONT  TestAccGaussDBNoSQLFlavors_memory
=== CONT  TestAccGaussDBNoSQLFlavors_az
=== CONT  TestAccGaussDBNoSQLFlavors_vcpus
--- PASS: TestAccGaussDBNoSQLFlavors_memory (18.61s)
=== CONT  TestAccGaussDBNoSQLFlavors_influxdb
--- PASS: TestAccGaussDBNoSQLFlavors_vcpus (18.93s)
--- PASS: TestAccGaussDBNoSQLFlavors_az (22.10s)
--- PASS: TestAccGaussDBNoSQLFlavors_basic (37.19s)
--- PASS: TestAccGaussDBNoSQLFlavors_influxdb (20.30s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      39.016s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccGeminiDBInstancesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccGeminiDBInstancesDataSource_basic -timeout 720m
=== RUN   TestAccGeminiDBInstancesDataSource_basic
=== PAUSE TestAccGeminiDBInstancesDataSource_basic
=== CONT  TestAccGeminiDBInstancesDataSource_basic
--- PASS: TestAccGeminiDBInstancesDataSource_basic (1047.09s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      1047.235s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccGeminiDBInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccGeminiDBInstance_basic -timeout 720m
=== RUN   TestAccGeminiDBInstance_basic
=== PAUSE TestAccGeminiDBInstance_basic
=== CONT  TestAccGeminiDBInstance_basic
--- PASS: TestAccGeminiDBInstance_basic (1347.68s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      1347.790s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccGaussInfluxInstance_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccGaussInfluxInstance_basic -timeout 720m
=== RUN   TestAccGaussInfluxInstance_basic
=== PAUSE TestAccGaussInfluxInstance_basic
=== CONT  TestAccGaussInfluxInstance_basic
--- PASS: TestAccGaussInfluxInstance_basic (1470.65s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      1470.767s
```