### PR TITLE
feat(dds): unset the validation of version to create MongoDB 4.2

### DIFF
--- a/docs/resources/dds_instance_v3.md
+++ b/docs/resources/dds_instance_v3.md
@@ -147,9 +147,10 @@ The `datastore` block supports:
 
 * `type` - (Required) Specifies the DB engine. Only DDS-Community is supported now.
 
-* `version` - (Required) Specifies the DB instance version. Only 3.4 and 4.0 are supported now.
+* `version` - (Required) Specifies the DB instance version. The valid values are 3.4, 4.0 and 4.2.
 
-* `storage_engine` - (Optional) Specifies the storage engine of the DB instance. Only wiredTiger is supported now.
+* `storage_engine` - (Optional) Specifies the storage engine of the DB instance. The valid values are
+  `wiredTiger` and `rocksDB`.
 
 The `flavor` block supports:
 

--- a/flexibleengine/resource_flexibleengine_dds_instance_v3.go
+++ b/flexibleengine/resource_flexibleengine_dds_instance_v3.go
@@ -58,17 +58,11 @@ func resourceDdsInstanceV3() *schema.Resource {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"4.0", "3.4",
-							}, true),
 						},
 						"storage_engine": {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"wiredTiger",
-							}, true),
 						},
 					},
 				},
@@ -136,9 +130,6 @@ func resourceDdsInstanceV3() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
-							ValidateFunc: validation.StringInSlice([]string{
-								"ULTRAHIGH",
-							}, true),
 						},
 						"size": {
 							Type:     schema.TypeInt,

--- a/flexibleengine/resource_flexibleengine_dds_instance_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_dds_instance_v3_test.go
@@ -116,7 +116,7 @@ resource "flexibleengine_dds_instance_v3" "instance" {
   vpc_id            = "%s"
   subnet_id         = "%s"
   security_group_id = flexibleengine_networking_secgroup_v2.secgroup_1.id
-  password          = "Test@123"
+  password          = "Terraform@123"
   mode              = "Sharding"
 
   datastore {


### PR DESCRIPTION
fixes #930 

the testing result as follows:
```
$ make testacc TEST="./flexibleengine" TESTARGS="-run TestAccDDSV3Instance_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccDDSV3Instance_basic -timeout 720m
=== RUN   TestAccDDSV3Instance_basic

--- PASS: TestAccDDSV3Instance_basic (526.83s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 526.881s
```