### PR TITLE
feat(obs): support parallel_fs in obs bucket

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -176,6 +176,9 @@ The following arguments are supported:
     data in the bucket is duplicated and stored in multiple AZs.
     Changing this creates a new bucket.
 
+* `parallel_fs` - (Optional, Bool, ForceNew) Whether enable a bucket as a parallel file system. Changing this will
+  create a new bucket.
+
 * `region` - (Optional) If specified, the region this bucket should reside in. Otherwise, the region used by the provider.
     Changing this creates a new bucket.
 


### PR DESCRIPTION
```
make testacc TEST='./flexibleengine' TESTARGS='-run TestAccObsBucket_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccObsBucket_basic -timeout 720m
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (51.09s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 51.161s

$ make testacc TEST='./flexibleengine' TESTARGS='-run TestAccObsBucket_parallelFS'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccObsBucket_parallelFS -timeout 720m
=== RUN   TestAccObsBucket_parallelFS
=== PAUSE TestAccObsBucket_parallelFS
=== CONT  TestAccObsBucket_parallelFS
--- PASS: TestAccObsBucket_parallelFS (23.93s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 24.001s
```