### PR TITLE
feat(obs): add new resource bucket acl

### DIFF
--- a/docs/resources/obs_bucket_acl.md
+++ b/docs/resources/obs_bucket_acl.md
@@ -1,0 +1,102 @@
+---
+subcategory: "Object Storage Service (OBS)"
+---
+
+# flexibleengine_obs_bucket_acl
+
+Manages an OBS bucket acl resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+variable "bucket" {}
+variable "account1" {}
+variable "account2" {}
+
+resource "flexibleengine_obs_bucket_acl" "test" {
+  bucket = var.bucket
+
+  owner_permission {
+    access_to_bucket = ["READ", "WRITE"]
+    access_to_acl    = ["READ_ACP", "WRITE_ACP"]
+  }
+
+  account_permission {
+    access_to_bucket = ["READ", "WRITE"]
+    access_to_acl    = ["READ_ACP", "WRITE_ACP"]
+    account_id       = var.account1
+  }
+
+  account_permission {
+    access_to_bucket = ["READ"]
+    access_to_acl    = ["READ_ACP", "WRITE_ACP"]
+    account_id       = var.account2
+  }
+
+  public_permission {
+    access_to_bucket = ["READ", "WRITE"]
+  }
+
+  log_delivery_user_permission {
+    access_to_bucket = ["READ", "WRITE"]
+    access_to_acl    = ["READ_ACP", "WRITE_ACP"]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used.
+
+  Changing this parameter will create a new resource.
+
+* `bucket` - (Required, String, ForceNew) Specifies the name of the bucket to which to set the acl.
+
+  Changing this parameter will create a new resource.
+
+* `owner_permission` - (Optional, List) Specifies the bucket owner permission. If omitted, the current obs bucket acl
+  owner permission will not be changed.
+  The [permission_struct](#OBSBucketAcl_permission_struct) structure is documented below.
+
+* `public_permission` - (Optional, List) Specifies the public permission.
+  The [permission_struct](#OBSBucketAcl_permission_struct) structure is documented below.
+
+* `log_delivery_user_permission` - (Optional, List) Specifies the log delivery user permission.
+  The [permission_struct](#OBSBucketAcl_permission_struct) structure is documented below.
+
+* `account_permission` - (Optional, List) Specifies the account permissions.
+  The [account_permission_struct](#OBSBucketAcl_account_permission_struct) structure is documented below.
+
+<a name="OBSBucketAcl_permission_struct"></a>
+The `permission_struct` block supports:
+
+* `access_to_bucket` - (Optional, List) Specifies the access to bucket. Valid values are **READ** and **WRITE**.
+
+* `access_to_acl` - (Optional, List) Specifies the access to acl. Valid values are **READ_ACP** and **WRITE_ACP**.
+
+<a name="OBSBucketAcl_account_permission_struct"></a>
+The `account_permission_struct` block supports:
+
+* `access_to_bucket` - (Optional, List) Specifies the access to bucket. Valid values are **READ** and **WRITE**.
+
+* `access_to_acl` - (Optional, List) Specifies the access to acl. Valid values are **READ_ACP** and **WRITE_ACP**.
+
+* `account_id` - (Required, String) Specifies the account id to authorize. The account id cannot be the bucket owner,
+  and must be unique.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The name of the bucket.
+
+## Import
+
+The obs bucket acl can be imported using the `bucket`, e.g.
+
+```bash
+terraform import flexibleengine_obs_bucket_acl.test <bucket-name>
+```

--- a/flexibleengine/acceptance/resource_flexibleengine_obs_bucket_acl_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_obs_bucket_acl_test.go
@@ -1,0 +1,142 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getOBSBucketAclResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := OS_REGION_NAME
+	obsClient, err := cfg.ObjectStorageClient(region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating OBS Client: %s", err)
+	}
+
+	output, err := obsClient.GetBucketAcl(state.Primary.ID)
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+func TestAccOBSBucketAcl_basic(t *testing.T) {
+	var obj interface{}
+
+	bucketName := acceptance.RandomAccResourceNameWithDash()
+	rName := "flexibleengine_obs_bucket_acl.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getOBSBucketAclResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheckOBS(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testOBSBucketAcl_basic(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "bucket", bucketName),
+					resource.TestCheckResourceAttr(rName, "log_delivery_user_permission.0.access_to_bucket.0", "READ"),
+					resource.TestCheckResourceAttr(rName, "log_delivery_user_permission.0.access_to_bucket.1", "WRITE"),
+					resource.TestCheckResourceAttr(rName, "log_delivery_user_permission.0.access_to_acl.0", "READ_ACP"),
+					resource.TestCheckResourceAttr(rName, "log_delivery_user_permission.0.access_to_acl.1", "WRITE_ACP"),
+					resource.TestCheckResourceAttr(rName, "account_permission.#", "2"),
+					resource.TestCheckResourceAttr(rName, "owner_permission.#", "1"),
+				),
+			},
+			{
+				Config: testOBSBucketAcl_basic_update(bucketName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "owner_permission.0.access_to_bucket.0", "WRITE"),
+					resource.TestCheckResourceAttr(rName, "owner_permission.0.access_to_acl.0", "WRITE_ACP"),
+					resource.TestCheckResourceAttr(rName, "account_permission.0.access_to_acl.0", "READ_ACP"),
+					resource.TestCheckResourceAttr(rName, "account_permission.0.account_id", "1000010023"),
+					resource.TestCheckResourceAttr(rName, "public_permission.0.access_to_bucket.0", "READ"),
+					resource.TestCheckResourceAttr(rName, "public_permission.0.access_to_bucket.1", "WRITE"),
+					resource.TestCheckResourceAttr(rName, "owner_permission.#", "1"),
+					resource.TestCheckResourceAttr(rName, "public_permission.#", "1"),
+					resource.TestCheckResourceAttr(rName, "account_permission.#", "1"),
+					resource.TestCheckResourceAttr(rName, "log_delivery_user_permission.#", "0"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testOBSBucketAcl_base(bucketName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_obs_bucket" "bucket" {
+  bucket        = "%s"
+  storage_class = "STANDARD"
+  acl           = "private"
+}
+`, bucketName)
+}
+
+func testOBSBucketAcl_basic(bucketName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_obs_bucket_acl" "test" {
+  bucket = flexibleengine_obs_bucket.bucket.bucket
+
+  account_permission {
+    access_to_bucket = ["READ", "WRITE"]
+    access_to_acl    = ["READ_ACP", "WRITE_ACP"]
+    account_id       = "1000010020"
+  }
+
+  account_permission {
+    access_to_bucket = ["READ"]
+    access_to_acl    = ["READ_ACP", "WRITE_ACP"]
+    account_id       = "1000010021"
+  }
+
+  log_delivery_user_permission {
+    access_to_bucket = ["READ", "WRITE"]
+    access_to_acl    = ["READ_ACP", "WRITE_ACP"]
+  }
+}
+`, testOBSBucketAcl_base(bucketName))
+}
+
+func testOBSBucketAcl_basic_update(bucketName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_obs_bucket_acl" "test" {
+  bucket = flexibleengine_obs_bucket.bucket.bucket
+
+  owner_permission {
+    access_to_bucket = ["WRITE"]
+    access_to_acl    = ["WRITE_ACP"]
+  }
+
+  account_permission {
+    access_to_acl    = ["READ_ACP"]
+    account_id       = "1000010023"
+  }
+
+  public_permission {
+    access_to_bucket = ["READ", "WRITE"]
+  }
+}
+`, testOBSBucketAcl_base(bucketName))
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -31,6 +31,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/modelarts"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/obs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/sfs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/smn"
@@ -481,6 +482,8 @@ func Provider() *schema.Provider {
 			"flexibleengine_gaussdb_influx_instance":    gaussdb.ResourceGaussDBInfluxInstanceV3(),
 
 			"flexibleengine_identity_acl": iam.ResourceIdentityACL(),
+
+			"flexibleengine_obs_bucket_acl": obs.ResourceOBSBucketAcl(),
 
 			"flexibleengine_rds_account":            rds.ResourceRdsAccount(),
 			"flexibleengine_rds_database":           rds.ResourceRdsDatabase(),


### PR DESCRIPTION
fixes #909 

```
make testacc TEST='./flexibleengine'/acceptance TESTARGS='-run TestAccOBSBucketAcl_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccOBSBucketAcl_basic -timeout 720m
=== RUN   TestAccOBSBucketAcl_basic
=== PAUSE TestAccOBSBucketAcl_basic
=== CONT  TestAccOBSBucketAcl_basic
--- PASS: TestAccOBSBucketAcl_basic (58.60s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      58.711s
```