### PR TITLE
feat(ims/copy): add new resource support

### DIFF
--- a/docs/resources/images_image_copy.md
+++ b/docs/resources/images_image_copy.md
@@ -1,0 +1,98 @@
+---
+subcategory: "Image Management Service (IMS)"
+---
+
+# flexibleengine_images_image_copy
+
+Use this resource to copy IMS images from one region to another within FlexibleEngine.
+
+## Example Usage
+
+### Copy image within region
+
+```hcl
+variable "source_image_id" {}
+variable "name" {}
+variable "kms_key_id" {}
+
+resource "flexibleengine_images_image_copy" "test" {
+  source_image_id = var.source_image_id
+  name            = var.name
+  kms_key_id      = var.kms_key_id
+}
+```
+
+### Copy image cross region
+
+```hcl
+variable "source_image_id" {}
+variable "name" {}
+variable "target_region" {}
+variable "agency_name" {}
+
+resource "flexibleengine_images_image_copy" "test" {
+  source_image_id = var.source_image_id
+  name            = var.name
+  target_region   = var.target_region
+  agency_name     = var.agency_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region to which the source image belongs.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `source_image_id` - (Required, String, ForceNew) Specifies the ID of the copied image.
+  Changing this parameter will create a new resource.
+
+* `name` - (Required, String) Specifies the name of the copy image. The name can contain `1` to `128` characters,
+  only Chinese and English letters, digits, underscore (_), hyphens (-), dots (.) and space are
+  allowed, but it cannot start or end with a space.
+
+* `target_region` - (Optional, String, ForceNew) Specifies the target region name.
+  If specified, it means cross-region replication.
+
+* `description` - (Optional, String, ForceNew) Specifies the description of the copy image.
+  Changing this parameter will create a new resource.
+
+* `kms_key_id` - (Optional, String, ForceNew) Specifies the master key used for encrypting an image.
+  Only copying scene within a region is supported. Changing this parameter will create a new resource.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the image.
+  Only copying scene within a region is supported. Changing this parameter will create a new resource.
+
+* `agency_name` - (Optional, String, ForceNew) Specifies the agency name. It is required in the cross-region scene.
+  Changing this parameter will create a new resource.
+
+* `vault_id` - (Optional, String, ForceNew) Specifies the ID of the vault. It is used in the cross-region scene,
+  and it is mandatory if you are replicating a full-ECS image.
+  Changing this parameter will create a new resource.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the copy image.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `instance_id` - Indicates the ID of the ECS that needs to be converted into an image.
+
+* `os_version` - Indicates the OS version.
+
+* `visibility` - Indicates whether the image is visible to other tenants.
+
+* `data_origin` - Indicates the image resource.
+  The pattern can be 'instance,**instance_id**' or 'file,**image_url**'.
+
+* `disk_format` - Indicates the image file format.
+  The value can be `vhd`, `zvhd`, `raw`, `zvhd2`, or `qcow2`.
+
+* `image_size` - Indicates the size(bytes) of the image file format.
+
+* `checksum` - Indicates the checksum of the data associated with the image.
+
+* `status` - Indicates the status of the image.

--- a/flexibleengine/acceptance/acceptance.go
+++ b/flexibleengine/acceptance/acceptance.go
@@ -105,6 +105,12 @@ func testAccPreCheckReplication(t *testing.T) {
 	}
 }
 
+func testAccPreCheckIms(t *testing.T) {
+	if OS_DEST_REGION == "" {
+		t.Skip("OS_DEST_REGION must be set for IMS acceptance tests")
+	}
+}
+
 func testAccPreCheckSWRDomian(t *testing.T) {
 	if OS_SWR_SHARING_ACCOUNT == "" {
 		t.Skip("OS_SWR_SHARING_ACCOUNT must be set for swr domian tests, " +

--- a/flexibleengine/acceptance/resource_flexibleengine_images_image_copy_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_images_image_copy_test.go
@@ -1,0 +1,204 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ims"
+)
+
+func getImsImageCopyResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := OS_REGION_NAME
+	targetRegion := state.Primary.Attributes["target_region"]
+	if targetRegion != "" {
+		region = targetRegion
+	}
+
+	imsClient, err := cfg.ImageV2Client(region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IMS client: %s", err)
+	}
+
+	img, err := ims.GetCloudImage(imsClient, state.Primary.ID)
+	if err != nil {
+		return nil, fmt.Errorf("image %s not found: %s", state.Primary.ID, err)
+	}
+	return img, nil
+}
+
+func TestAccImsImageCopy_basic(t *testing.T) {
+	var obj interface{}
+
+	sourceImageName := acceptance.RandomAccResourceName()
+	name := acceptance.RandomAccResourceName()
+	updateName := acceptance.RandomAccResourceName()
+	rName := "flexibleengine_images_image_copy.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getImsImageCopyResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testImsImageCopy_basic(sourceImageName, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "it's a test"),
+					resource.TestCheckResourceAttr(rName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(rName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testImsImageCopy_update(sourceImageName, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description", "it's a test"),
+					resource.TestCheckResourceAttr(rName, "tags.key1", "value1_update"),
+					resource.TestCheckResourceAttr(rName, "tags.key3", "value3"),
+					resource.TestCheckResourceAttr(rName, "tags.key4", "value4"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccImsImageCopy_basic_cross_region(t *testing.T) {
+	var obj interface{}
+
+	sourceImageName := acceptance.RandomAccResourceName()
+	name := acceptance.RandomAccResourceName()
+	updateName := acceptance.RandomAccResourceName()
+	rName := "flexibleengine_images_image_copy.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getImsImageCopyResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckIms(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testImsImageCopy_basic_cross_region(sourceImageName, name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "description", "it's a test"),
+					resource.TestCheckResourceAttr(rName, "tags.key1", "value1"),
+					resource.TestCheckResourceAttr(rName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testImsImageCopy_update_cross_region(sourceImageName, updateName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description", "it's a test"),
+					resource.TestCheckResourceAttr(rName, "tags.key1", "value1_update"),
+					resource.TestCheckResourceAttr(rName, "tags.key3", "value3"),
+					resource.TestCheckResourceAttr(rName, "tags.key4", "value4"),
+				),
+			},
+		},
+	})
+}
+
+const testImsImageCopy_base = `
+resource "flexibleengine_images_image_v2" "test" {
+  name             = "rancheros-test"
+  image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
+  container_format = "bare"
+  disk_format      = "qcow2"
+}`
+
+func testImsImageCopy_basic(baseImageName, copyImageName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_images_image_copy" "test" {
+ source_image_id = flexibleengine_images_image_v2.test.id
+ name            = "%s"
+ description     = "it's a test"
+
+ tags = {
+    key1 = "value1"
+    key2 = "value2"
+ }
+}
+`, testImsImageCopy_base, copyImageName)
+}
+
+func testImsImageCopy_update(baseImageName, copyImageName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_images_image_copy" "test" {
+ source_image_id = flexibleengine_images_image_v2.test.id
+ name            = "%s"
+ description     = "it's a test"
+
+ tags = {
+    key1 = "value1_update"
+    key3 = "value3"
+    key4 = "value4"
+ }
+}
+`, testImsImageCopy_base, copyImageName)
+}
+
+func testImsImageCopy_basic_cross_region(baseImageName, copyImageName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_images_image_copy" "test" {
+ source_image_id = flexibleengine_images_image_v2.test.id
+ name            = "%s"
+ description     = "it's a test"
+ target_region   = "%s"
+ agency_name     = "ims_admin_agency"
+
+ tags = {
+    key1 = "value1"
+    key2 = "value2"
+ }
+}`, testImsImageCopy_base, copyImageName, OS_DEST_REGION)
+}
+
+func testImsImageCopy_update_cross_region(baseImageName, copyImageName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_images_image_copy" "test" {
+ source_image_id = flexibleengine_images_image_v2.test.id
+ name            = "%s"
+ description     = "it's a test"
+ target_region   = "%s"
+ agency_name     = "ims_admin_agency"
+
+ tags = {
+    key1 = "value1_update"
+    key3 = "value3"
+    key4 = "value4"
+ }
+}
+`, testImsImageCopy_base, copyImageName, OS_DEST_REGION)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -29,6 +29,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/fgs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/gaussdb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/iam"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ims"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/modelarts"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/obs"
@@ -482,6 +483,8 @@ func Provider() *schema.Provider {
 			"flexibleengine_gaussdb_influx_instance":    gaussdb.ResourceGaussDBInfluxInstanceV3(),
 
 			"flexibleengine_identity_acl": iam.ResourceIdentityACL(),
+
+			"flexibleengine_images_image_copy": ims.ResourceImsImageCopy(),
 
 			"flexibleengine_obs_bucket_acl": obs.ResourceOBSBucketAcl(),
 


### PR DESCRIPTION
Add new resource support:
- IMS image copy

The test result:
```
make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run=TestAccImsI
mageCopy_basic_cross_region'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run=TestAccImsImageCopy_basic_cross_region -timeout 720m
=== RUN   TestAccImsImageCopy_basic_cross_region
=== PAUSE TestAccImsImageCopy_basic_cross_region
=== CONT  TestAccImsImageCopy_basic_cross_region
--- PASS: TestAccImsImageCopy_basic_cross_region (850.17s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance    850.397s
```