### PR TITLE
feat(ims): support share and acceptance resources

### DIFF
--- a/docs/resources/images_image_share.md
+++ b/docs/resources/images_image_share.md
@@ -1,0 +1,47 @@
+---
+subcategory: "Image Management Service (IMS)"
+---
+
+# flexibleengine_images_image_share
+
+Use this resource to share an IMS image to other users (by porject) within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+variable "source_image_id" {}
+variable "target_project_ids" {}
+
+resource "flexibleengine_images_image_share" "test" {
+  source_image_id    = var.source_image_id
+  target_project_ids = var.target_project_ids
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `source_image_id` - (Required, String, ForceNew) Specifies the ID of the source image.
+
+  Changing this parameter will create a new resource.
+
+* `target_project_ids` - (Required, List) Specifies the IDs of the target projects.
+
+  -> Cannot share an image with yourself.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minutes.
+* `delete` - Default is 5 minutes.

--- a/docs/resources/images_image_share_accepter.md
+++ b/docs/resources/images_image_share_accepter.md
@@ -1,0 +1,39 @@
+---
+subcategory: "Image Management Service (IMS)"
+---
+
+# flexibleengine_images_image_share_accepter
+
+Use this resource to accept an IMS image share from other users within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+variable "image_id" {}
+
+resource "flexibleengine_images_image_share_accepter" "test" {
+  image_id = var.image_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `image_id` - (Required, String, ForceNew) Specifies the ID of the image.
+
+  Changing this parameter will create a new resource.
+
+* `vault_id` - (Optional, String, ForceNew) Specifies the ID of a vault. This parameter is mandatory if you want
+  to accept a shared full-ECS image created from a CBR backup.
+
+  Changing this parameter will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.

--- a/flexibleengine/acceptance/acceptance.go
+++ b/flexibleengine/acceptance/acceptance.go
@@ -33,6 +33,7 @@ var (
 
 	OS_DEST_REGION            = os.Getenv("OS_DEST_REGION")
 	OS_DEST_PROJECT_ID        = os.Getenv("OS_DEST_PROJECT_ID")
+	OS_NEW_DEST_PROJECT_ID    = os.Getenv("OS_NEW_DEST_PROJECT_ID")
 	OS_SWR_SHARING_ACCOUNT    = os.Getenv("OS_SWR_SHARING_ACCOUNT")
 	OS_DLI_FLINK_JAR_OBS_PATH = os.Getenv("OS_DLI_FLINK_JAR_OBS_PATH")
 	OS_WAF_ENABLE_FLAG        = os.Getenv("OS_WAF_ENABLE_FLAG")
@@ -105,9 +106,15 @@ func testAccPreCheckReplication(t *testing.T) {
 	}
 }
 
-func testAccPreCheckIms(t *testing.T) {
+func testAccPreCheckImsCopy(t *testing.T) {
 	if OS_DEST_REGION == "" {
-		t.Skip("OS_DEST_REGION must be set for IMS acceptance tests")
+		t.Skip("OS_DEST_REGION must be set for IMS copy acceptance tests")
+	}
+}
+
+func testAccPreCheckImsShare(t *testing.T) {
+	if OS_DEST_PROJECT_ID == "" || OS_NEW_DEST_PROJECT_ID == "" {
+		t.Skip("OS_DEST_PROJECT_ID and OS_NEW_DEST_PROJECT_ID must be set for IMS share acceptance tests")
 	}
 }
 

--- a/flexibleengine/acceptance/acceptance.go
+++ b/flexibleengine/acceptance/acceptance.go
@@ -31,13 +31,14 @@ var (
 	OS_KEYPAIR_NAME = os.Getenv("OS_KEYPAIR_NAME")
 	OS_FGS_BUCKET   = os.Getenv("OS_FGS_BUCKET")
 
-	OS_DEST_REGION            = os.Getenv("OS_DEST_REGION")
-	OS_DEST_PROJECT_ID        = os.Getenv("OS_DEST_PROJECT_ID")
-	OS_NEW_DEST_PROJECT_ID    = os.Getenv("OS_NEW_DEST_PROJECT_ID")
-	OS_SWR_SHARING_ACCOUNT    = os.Getenv("OS_SWR_SHARING_ACCOUNT")
-	OS_DLI_FLINK_JAR_OBS_PATH = os.Getenv("OS_DLI_FLINK_JAR_OBS_PATH")
-	OS_WAF_ENABLE_FLAG        = os.Getenv("OS_WAF_ENABLE_FLAG")
-	OS_SMS_SOURCE_SERVER      = os.Getenv("OS_SMS_SOURCE_SERVER")
+	OS_DEST_REGION                 = os.Getenv("OS_DEST_REGION")
+	OS_DEST_PROJECT_ID             = os.Getenv("OS_DEST_PROJECT_ID")
+	OS_NEW_DEST_PROJECT_ID         = os.Getenv("OS_NEW_DEST_PROJECT_ID")
+	OS_IMAGE_SHARE_SOURCE_IMAGE_ID = os.Getenv("OS_IMAGE_SHARE_SOURCE_IMAGE_ID")
+	OS_SWR_SHARING_ACCOUNT         = os.Getenv("OS_SWR_SHARING_ACCOUNT")
+	OS_DLI_FLINK_JAR_OBS_PATH      = os.Getenv("OS_DLI_FLINK_JAR_OBS_PATH")
+	OS_WAF_ENABLE_FLAG             = os.Getenv("OS_WAF_ENABLE_FLAG")
+	OS_SMS_SOURCE_SERVER           = os.Getenv("OS_SMS_SOURCE_SERVER")
 )
 
 // TestAccProviderFactories is a static map containing only the main provider instance
@@ -115,6 +116,12 @@ func testAccPreCheckImsCopy(t *testing.T) {
 func testAccPreCheckImsShare(t *testing.T) {
 	if OS_DEST_PROJECT_ID == "" || OS_NEW_DEST_PROJECT_ID == "" {
 		t.Skip("OS_DEST_PROJECT_ID and OS_NEW_DEST_PROJECT_ID must be set for IMS share acceptance tests")
+	}
+}
+
+func testAccPreCheckImageShareAccepter(t *testing.T) {
+	if OS_IMAGE_SHARE_SOURCE_IMAGE_ID == "" {
+		t.Skip("OS_IMAGE_SHARE_SOURCE_IMAGE_ID must be set for IMS share acceptance tests")
 	}
 }
 

--- a/flexibleengine/acceptance/resource_flexibleengine_images_image_copy_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_images_image_copy_test.go
@@ -92,7 +92,7 @@ func TestAccImsImageCopy_basic_cross_region(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccPreCheckIms(t)
+			testAccPreCheckImsCopy(t)
 		},
 		ProviderFactories: TestAccProviderFactories,
 		CheckDestroy:      rc.CheckResourceDestroy(),

--- a/flexibleengine/acceptance/resource_flexibleengine_images_image_share_accepter_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_images_image_share_accepter_test.go
@@ -1,0 +1,97 @@
+package acceptance
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getImsImageShareAccepterResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := OS_REGION_NAME
+	// getImage: Query IMS image
+	var (
+		getImageHttpUrl = "v2/cloudimages"
+		getImageProduct = "ims"
+	)
+	getImageClient, err := cfg.NewServiceClient(getImageProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IMS Client: %s", err)
+	}
+
+	getImagePath := getImageClient.Endpoint + getImageHttpUrl
+	getImagePath = strings.ReplaceAll(getImagePath, "{project_id}", getImageClient.ProjectID)
+
+	imageId := state.Primary.Attributes["image_id"]
+	getImageQueryParams := buildGetImageQueryParams(imageId)
+	getImagePath += getImageQueryParams
+
+	getImageOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getImageResp, err := getImageClient.Request("GET", getImagePath, &getImageOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving IMS image: %s", err)
+	}
+
+	getImageRespBody, err := utils.FlattenResponse(getImageResp)
+	if err != nil {
+		return nil, err
+	}
+
+	images := utils.PathSearch("images", getImageRespBody, nil)
+	if images == nil || len(images.([]interface{})) == 0 {
+		return nil, fmt.Errorf("error get IMS share image")
+	}
+
+	return make(map[string]interface{}), nil
+}
+
+func TestAccImsImageShareAccepter_basic(t *testing.T) {
+	var obj interface{}
+
+	rName := "flexibleengine_images_image_share_accepter.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getImsImageShareAccepterResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckImageShareAccepter(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testImsImageShareAccepter_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "image_id", OS_IMAGE_SHARE_SOURCE_IMAGE_ID),
+				),
+			},
+		},
+	})
+}
+
+func testImsImageShareAccepter_basic() string {
+	return fmt.Sprintf(`
+resource "flexibleengine_images_image_share_accepter" "test" {
+  image_id = "%[1]s"
+}
+`, OS_IMAGE_SHARE_SOURCE_IMAGE_ID)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_images_image_share_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_images_image_share_test.go
@@ -1,0 +1,135 @@
+package acceptance
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getImsImageShareResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := OS_REGION_NAME
+	// getImage: Query IMS image
+	var (
+		getImageHttpUrl = "v2/cloudimages"
+		getImageProduct = "ims"
+	)
+	getImageClient, err := cfg.NewServiceClient(getImageProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating IMS Client: %s", err)
+	}
+
+	getImagePath := getImageClient.Endpoint + getImageHttpUrl
+	getImagePath = strings.ReplaceAll(getImagePath, "{project_id}", getImageClient.ProjectID)
+
+	getImageQueryParams := buildGetImageQueryParams(state.Primary.ID)
+	getImagePath += getImageQueryParams
+
+	getImageOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getImageResp, err := getImageClient.Request("GET", getImagePath, &getImageOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving IMS image: %s", err)
+	}
+
+	getImageRespBody, err := utils.FlattenResponse(getImageResp)
+	if err != nil {
+		return nil, err
+	}
+
+	images := utils.PathSearch("images", getImageRespBody, nil)
+	if images == nil || len(images.([]interface{})) == 0 {
+		return nil, fmt.Errorf("error get IMS share image")
+	}
+
+	return make(map[string]interface{}), nil
+}
+
+func buildGetImageQueryParams(id string) string {
+	res := ""
+	res = fmt.Sprintf("%s?id=%v", res, id)
+	res = fmt.Sprintf("%s&__imagetype=%v", res, "shared")
+	return res
+}
+
+func TestAccImsImageShare_basic(t *testing.T) {
+	var obj interface{}
+
+	imageName := acceptance.RandomAccResourceName()
+	rName := "flexibleengine_images_image_share.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getImsImageShareResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckImsShare(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testImsImageShare_basic(imageName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "source_image_id",
+						"flexibleengine_images_image_v2.test", "id"),
+				),
+			},
+			{
+				Config: testImsImageShare_update(imageName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "source_image_id",
+						"flexibleengine_images_image_v2.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+const testImsImageShare_base = `
+resource "flexibleengine_images_image_v2" "test" {
+  name             = "rancheros-test"
+  image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
+  container_format = "bare"
+  disk_format      = "qcow2"
+}`
+
+func testImsImageShare_basic(imageName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_images_image_share" "test" {
+ source_image_id    = flexibleengine_images_image_v2.test.id
+ target_project_ids = ["%[2]s"]
+}
+`, testImsImageShare_base, OS_DEST_PROJECT_ID)
+}
+
+func testImsImageShare_update(imageName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_images_image_share" "test" {
+ source_image_id    = flexibleengine_images_image_v2.test.id
+ target_project_ids = ["%[2]s"]
+}
+`, testImsImageShare_base, OS_NEW_DEST_PROJECT_ID)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -484,8 +484,9 @@ func Provider() *schema.Provider {
 
 			"flexibleengine_identity_acl": iam.ResourceIdentityACL(),
 
-			"flexibleengine_images_image_copy":  ims.ResourceImsImageCopy(),
-			"flexibleengine_images_image_share": ims.ResourceImsImageShare(),
+			"flexibleengine_images_image_copy":           ims.ResourceImsImageCopy(),
+			"flexibleengine_images_image_share":          ims.ResourceImsImageShare(),
+			"flexibleengine_images_image_share_accepter": ims.ResourceImsImageShareAccepter(),
 
 			"flexibleengine_obs_bucket_acl": obs.ResourceOBSBucketAcl(),
 

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -484,7 +484,8 @@ func Provider() *schema.Provider {
 
 			"flexibleengine_identity_acl": iam.ResourceIdentityACL(),
 
-			"flexibleengine_images_image_copy": ims.ResourceImsImageCopy(),
+			"flexibleengine_images_image_copy":  ims.ResourceImsImageCopy(),
+			"flexibleengine_images_image_share": ims.ResourceImsImageShare(),
 
 			"flexibleengine_obs_bucket_acl": obs.ResourceOBSBucketAcl(),
 

--- a/go.mod
+++ b/go.mod
@@ -4,14 +4,14 @@ go 1.18
 
 require (
 	github.com/aws/aws-sdk-go v1.34.0
-	github.com/chnsz/golangsdk v0.0.0-20230428074508-e0b58e41be86
+	github.com/chnsz/golangsdk v0.0.0-20230518034805-37109d5ae6f9
 	github.com/hashicorp/errwrap v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.0
 	github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.20
-	github.com/huaweicloud/terraform-provider-huaweicloud v1.48.0
+	github.com/huaweicloud/terraform-provider-huaweicloud v1.48.1-0.20230522115237-50dafa0e00d6
 	github.com/jen20/awspolicyequivalence v1.1.0
 	github.com/mitchellh/go-homedir v1.1.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chnsz/golangsdk v0.0.0-20230428074508-e0b58e41be86 h1:oWzyOHSL7cjZCCIEO4S9H1Zc5Pwn5HCI7fvpNxpiXUs=
 github.com/chnsz/golangsdk v0.0.0-20230428074508-e0b58e41be86/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
+github.com/chnsz/golangsdk v0.0.0-20230518034805-37109d5ae6f9 h1:iqjmoZ7ufJxAQ3FbrPbqUXLpMEIiYCUnuqxMj5Aa2tA=
+github.com/chnsz/golangsdk v0.0.0-20230518034805-37109d5ae6f9/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -144,6 +146,8 @@ github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.20 h1:Pyz8ZjJEAel4axFfL3bvPJ0n
 github.com/huaweicloud/huaweicloud-sdk-go-v3 v0.1.20/go.mod h1:QpZ96CRqyqd5fEODVmnzDNp3IWi5W95BFmWz1nfkq+s=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.48.0 h1:g275EySoDsWlczy/Z7A6+W0w2EJzD3QX6a+NTlHKkek=
 github.com/huaweicloud/terraform-provider-huaweicloud v1.48.0/go.mod h1:R0t0ZpxTu2By3JkX5FBNjVE6uDOoveiKIkIDorr3MlM=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.48.1-0.20230522115237-50dafa0e00d6 h1:CA28CHZ2lRvwTh22Vbpu6MIIj6Eou9FjDmcg/jwivbY=
+github.com/huaweicloud/terraform-provider-huaweicloud v1.48.1-0.20230522115237-50dafa0e00d6/go.mod h1:MdUg/4JM8wju/ZSxwro3OA4sKGZBXcwWyhHY2+znP5Q=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=


### PR DESCRIPTION
fixes #927 

```
make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run=TestAccImsImageShare_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run=TestAccImsImageShare_basic -timeout 720m
=== RUN   TestAccImsImageShare_basic
=== PAUSE TestAccImsImageShare_basic
=== CONT  TestAccImsImageShare_basic
--- PASS: TestAccImsImageShare_basic (667.55s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      667.611s
```
```
make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run=TestAccImsImageShareAccepter_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run=TestAccImsImageShareAccepter_basic -timeout 720m
=== RUN   TestAccImsImageShareAccepter_basic
=== PAUSE TestAccImsImageShareAccepter_basic
=== CONT  TestAccImsImageShareAccepter_basic
--- PASS: TestAccImsImageShareAccepter_basic (33.23s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      33.296s
```