### PR TITLE
feat(cce) Add kms_key_id on root_volume cce nodes/nodepool

### DIFF
--- a/docs/resources/cce_node_pool_v3.md
+++ b/docs/resources/cce_node_pool_v3.md
@@ -113,6 +113,11 @@ The `root_volume` block supports:
 
 * `volumetype` - (Required, String) Specifies the disk type.
 
+* `kms_key_id` - (Optional, String) Specifies the KMS key ID. This is used to encrypt the volume.
+
+  -> You need to create an agency (EVSAccessKMS) when disk encryption is used in the current project for the first time ever.
+  The account and permission of the created agency are `op_svc_evs` and **KMS Administrator**, respectively.
+
 * `extend_params` - (Optional, Map) Specifies the disk expansion parameters in key/value pair format.
 
 The `data_volumes` block supports:

--- a/docs/resources/cce_node_v3.md
+++ b/docs/resources/cce_node_v3.md
@@ -117,6 +117,10 @@ The following arguments are supported:
   + `size` - (Required) Specifies the disk size in GB.
   + `volumetype` - (Required) Specifies the disk type.
   + `extend_params` - (Optional) Specifies the disk expansion parameters in key/value pair format.
+  + `kms_key_id` - (Optional) Specifies the ID of a KMS key. This is used to encrypt the volume.
+
+  -> You need to create an agency (EVSAccessKMS) when disk encryption is used in the current project for the first time ever.
+  The account and permission of the created agency are `op_svc_evs` and **KMS Administrator**, respectively.
 
 * `data_volumes` - (Required) Represents the data disk to be created.
   Changing this parameter will create a new resource.

--- a/flexibleengine/resource_flexibleengine_cce_node_pool.go
+++ b/flexibleengine/resource_flexibleengine_cce_node_pool.go
@@ -89,6 +89,11 @@ func resourceCCENodePool() *schema.Resource {
 							Required: true,
 							ForceNew: true,
 						},
+						"kms_key_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
 						"extend_params": {
 							Type:     schema.TypeMap,
 							Optional: true,


### PR DESCRIPTION
Hello,

Please consider this PR which adds the KMS disk encryption on root_Volume for CCE nodes (and node pool) through the Volume Metadata object as described here: https://docs.prod-cloud-ocb.orange-business.com/api2/cce/cce_02_0242.html#cce_02_0242__request_VolumeMetadata

I've successfully tested the change on an existing terraform project, setting up a new Nodepool with KMS encryption on both root_volume and data_volumes.

It's my first PR so please feel free to correct me if I missed something.

As you can see below, the root_volume is encrypted with KMS
<img width="1605" alt="Capture d’écran 2023-06-26 à 17 04 46" src="https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/1282754/74426cf7-6753-4503-9f39-5bc7a0545ae9">


---------

The tests `TestAccCCENodeV3_basic` and `TestAccCCENodeV3_volumes_encryption` are FAILED, but I don't think it's related to the current changes. I also had to change the flavor "s1.medium" which no longer exists to "s3.large.2"

> {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","code":400,"errorCode":"CCE.01400021","errorMessage":"No available flavors for nodes.","error_code":"CCE_CM.0021","error_msg":"No available node flavors","message":"S1.medium|eu-west-0a: flavor status sellout in az eu-west-0a","reason":"ECSResourcesInsufficient"}

I don't know how to fix the acceptance tests properly. I believe it is failing because of the properties `tags` and `extend_params` automatically added during the state import of the resources. I've tried to ignore them with `ImportStateVerifyIgnore` but It's still failing.

```
TF_ACC=1 go test ./flexibleengine -v -run TestAccCCENodeV3_basic -timeout 720m
=== RUN   TestAccCCENodeV3_basic
=== PAUSE TestAccCCENodeV3_basic
=== CONT  TestAccCCENodeV3_basic
    resource_flexibleengine_cce_node_v3_test.go:21: Step 1/3 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # flexibleengine_cce_node_v3.node_1 will be updated in-place
          ~ resource "flexibleengine_cce_node_v3" "node_1" {
                id                = "641e9ddd-14df-11ee-a69c-0255ac101b90"
                name              = "tf-acc-test-d8476"
              ~ tags              = {
                  - "CCE-Cluster-ID" = "823f5416-14de-11ee-a69c-0255ac101b90" -> null
                    "foo"            = "bar"
                    "key"            = "value"
                }
                # (14 unchanged attributes hidden)
        
              ~ data_volumes {
                  + extend_params = {}
                    # (2 unchanged attributes hidden)
                }
        
              ~ root_volume {
                  + extend_params = {}
                    # (2 unchanged attributes hidden)
                }
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.
--- FAIL: TestAccCCENodeV3_basic (1118.77s)
FAIL
FAIL    github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 1119.268s
FAIL
```

Do you have any hints to fix the tests @ShiChangkuo ? 🙏

