### PR TITLE
fix(network/port): deprecate mac_address which cannot be set

### DIFF
--- a/docs/resources/networking_port_v2.md
+++ b/docs/resources/networking_port_v2.md
@@ -59,12 +59,19 @@ The following arguments are supported:
 * `network_id` - (Required) The ID of the VPC Subnet to attach the port to. Changing
     this creates a new port.
 
+* `fixed_ip` - (Optional) An array of desired IPs for this port. The [object](#port_fixed_IP_object)
+    structure is described below.
+
+* `allowed_address_pairs` - (Optional) An array of IP/MAC Address pairs of additional IP
+    addresses that can be active on this port. The [object](#allowed_address_pairs_object) structure is described below.
+
+* `security_group_ids` - (Optional) A list of security group IDs to apply to the
+    port. The security groups must be specified by ID and not name (as opposed
+    to how they are configured with the Compute Instance).
+
 * `admin_state_up` - (Optional) Administrative up/down status for the port
     (must be "true" or "false" if provided). Changing this updates the
     `admin_state_up` of an existing port.
-
-* `mac_address` - (Optional) Specify a specific MAC address for the port. Changing
-    this creates a new port.
 
 * `tenant_id` - (Optional) The owner of the Port. Required if admin wants
     to create a port for another tenant. Changing this creates a new port.
@@ -72,21 +79,12 @@ The following arguments are supported:
 * `device_owner` - (Optional) The device owner of the Port. Changing this creates
     a new port.
 
-* `security_group_ids` - (Optional) A list of security group IDs to apply to the
-    port. The security groups must be specified by ID and not name (as opposed
-    to how they are configured with the Compute Instance).
-
 * `device_id` - (Optional) The ID of the device attached to the port. Changing this
     creates a new port.
 
-* `fixed_ip` - (Optional) An array of desired IPs for this port. The structure is
-    described below.
-
-* `allowed_address_pairs` - (Optional) An array of IP/MAC Address pairs of additional IP
-    addresses that can be active on this port. The structure is described below.
-
 * `value_specs` - (Optional) Map of additional options.
 
+<a name="port_fixed_IP_object"></a>
 The `fixed_ip` block supports:
 
 * `subnet_id` - (Required) The `ipv4_subnet_id` or `ipv6_subnet_id` of the
@@ -96,6 +94,7 @@ The `fixed_ip` block supports:
     you don't specify `ip_address`, an available IP address from the specified
     subnet will be allocated to this port.
 
+<a name="allowed_address_pairs_object"></a>
 The `allowed_address_pairs` block supports:
 
 * `ip_address` - (Required) The additional IP address. The value can be an IP Address or a CIDR,
@@ -118,6 +117,7 @@ The following attributes are exported:
 * `security_group_ids` - See Argument Reference above.
 * `device_id` - See Argument Reference above.
 * `fixed_ip` - See Argument Reference above.
+* `mac_address` - The MAC address for the port.
 * `all_fixed_ips` - The collection of Fixed IP addresses on the port in the
   order returned by the Network v2 API.
 

--- a/flexibleengine/resource_flexibleengine_networking_port_v2.go
+++ b/flexibleengine/resource_flexibleengine_networking_port_v2.go
@@ -50,10 +50,11 @@ func resourceNetworkingPortV2() *schema.Resource {
 				Computed: true,
 			},
 			"mac_address": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "mac_address cannot be set",
 			},
 			"tenant_id": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
When creating a port with **mac_address**, we will get the following error:

```
resource "flexibleengine_networking_port_v2" "port_1" {
  name        = "port_1"
  network_id  = flexibleengine_vpc_subnet_v1.subnet_1.id
  mac_address = "fa:16:3e:65:84:d3"
}


flexibleengine_networking_port_v2.port_1: Creating...
╷
│ Error: Error creating FlexibleEngine Neutron network: Bad request with: [POST https://vpc.eu-west-0.prod-cloud-ocb.orange-business.com/v2.0/ports], error message: {"NeutronError":{"message":"Attribute 'mac_address' cannot be set.","type":"HTTPBadRequest","detail":""}}
│
│   with flexibleengine_networking_port_v2.port_1,
│   on main.tf line 22, in resource "flexibleengine_networking_port_v2" "port_1":
│   22: resource "flexibleengine_networking_port_v2" "port_1" {
```

It's not supported by cloud side, so we should deprecate this parameter.

the testing resule as follows:
```
$ make testacc TEST="./flexibleengine" TESTARGS="-run TestAccNetworkingV2Port_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccNetworkingV2Port_basic -timeout 720m
=== RUN   TestAccNetworkingV2Port_basic
--- PASS: TestAccNetworkingV2Port_basic (80.48s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 80.562s
```