### PR TITLE
feat(ims): update image resource and data_source

### DIFF
--- a/docs/data-sources/images_image.md
+++ b/docs/data-sources/images_image.md
@@ -1,0 +1,99 @@
+---
+subcategory: "Image Management Service (IMS)"
+---
+
+# flexibleengine_images_image
+
+Use this data source to get the ID of an available FlexibleEngine image.
+
+## Example Usage
+
+```hcl
+data "flexibleengine_images_image" "ubuntu" {
+  name        = "OBS Ubuntu 18.04"
+  visibility  = "public"
+}
+
+data "flexibleengine_images_image" "centos-1" {
+  architecture = "x86"
+  os_version   = "CentOS 7.4 64bit"
+  visibility   = "public"
+  most_recent  = true
+}
+
+data "flexibleengine_images_image" "centos-2" {
+  architecture = "x86"
+  name_regex   = "^OBS CentOS 7.4"
+  visibility   = "public"
+  most_recent  = true
+}
+
+data "flexibleengine_images_image" "bms_image" {
+  architecture = "x86"
+  image_type   = "Ironic"
+  os_version   = "CentOS 7.4 64bit"
+  visibility   = "public"
+  most_recent  = true
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the images. If omitted, the provider-level region will be
+  used.
+
+* `most_recent` - (Optional, Bool) If more than one result is returned, use the latest updated image.
+
+* `name` - (Optional, String) The name of the image. Cannot be used simultaneously with `name_regex`.
+
+* `name_regex` - (Optional, String) The regular expressian of the name of the image.
+  Cannot be used simultaneously with `name`.
+
+* `visibility` - (Optional, String) The visibility of the image. Must be one of
+  **public**, **private**, **market** or **shared**.
+
+* `architecture` - (Optional, String) Specifies the image architecture type. The value can be **x86** and **arm**.
+
+* `os` - (Optional, String) Specifies the image OS type. The value can be **Windows**, **Ubuntu**,
+  **RedHat**, **SUSE**, **CentOS**, **Debian**, **OpenSUSE**, **Oracle Linux**, **Fedora**, **Other**,
+  **CoreOS**, or **EulerOS**.
+
+* `os_version` - (Optional, String) Specifies the OS version. For example, *CentOS 7.4 64bit* or *Ubuntu 18.04 server 64bit*.
+
+* `image_type` - (Optional, String) Specifies the environment where the image is used. For a BMS image, the value is **Ironic**.
+
+* `owner` - (Optional, String) The owner (UUID) of the image.
+
+* `tag` - (Optional, String) Search for images with a specific tag in "Key=Value" format.
+
+* `sort_direction` - (Optional, String) Order the results in either `asc` or `desc`.
+
+* `sort_key` - (Optional, String) Sort images based on a certain key. Must be one of
+  "name", "container_format", "disk_format", "status", "id" or "size". Defaults to `name`.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the image.
+
+* `flavor_id` - (Optional, String) Specifies the ECS flavor ID used to filter out available images.
+  You can specify only one flavor ID and only ECS flavor ID is valid, BMS flavor is not supported.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Specifies a resource ID in UUID format.
+* `checksum` - The checksum of the data associated with the image.
+* `container_format` - The format of the image's container.
+* `disk_format` - The format of the image's disk.
+* `file` - the trailing path after the glance endpoint that represent the location of the image or the path to retrieve
+  it.
+* `metadata` - The metadata associated with the image. Image metadata allow for meaningfully define the image properties
+  and tags.
+* `min_disk_gb` - The minimum amount of disk space required to use the image.
+* `min_ram_mb` - The minimum amount of ram required to use the image.
+* `protected` - Whether or not the image is protected.
+* `schema` - The path to the JSON-schema that represent the image or image.
+* `size_bytes` - The size of the image (in bytes).
+* `status` - The status of the image.
+* `backup_id` - The backup ID of the whole image in the CBR vault.
+* `created_at` - The date when the image was created.
+* `updated_at` - The date when the image was last updated.

--- a/docs/data-sources/images_image_v2.md
+++ b/docs/data-sources/images_image_v2.md
@@ -1,10 +1,12 @@
 ---
-subcategory: "Image Management Service (IMS)"
+subcategory: "Deprecated"
 ---
 
 # flexibleengine_images_image_v2
 
 Use this data source to get the ID of an available FlexibleEngine image.
+
+!> **WARNING:** It has been deprecated, please use `flexibleengine_images_image` instead.
 
 ## Example Usage
 

--- a/docs/data-sources/images_images.md
+++ b/docs/data-sources/images_images.md
@@ -1,0 +1,120 @@
+---
+subcategory: "Image Management Service (IMS)"
+---
+
+# flexibleengine_images_images
+
+Use this data source to get available FlexibleEngine IMS images.
+
+## Example Usage
+
+```hcl
+data "flexibleengine_images_images" "ubuntu" {
+  name        = "OBS Ubuntu 18.04"
+  visibility  = "public"
+}
+
+data "flexibleengine_images_images" "centos-1" {
+  architecture = "x86"
+  os_version   = "CentOS 7.4 64bit"
+  visibility   = "public"
+}
+
+data "flexibleengine_images_images" "centos-2" {
+  architecture = "x86"
+  name_regex   = "^OBS CentOS 7.4"
+  visibility   = "public"
+}
+
+data "flexibleengine_images_images" "bms_image" {
+  architecture = "x86"
+  image_type   = "Ironic"
+  os_version   = "CentOS 7.4 64bit"
+  visibility   = "public"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the images. If omitted, the provider-level region will be
+  used.
+
+* `name` - (Optional, String) The name of the image. Cannot be used simultaneously with `name_regex`.
+
+* `name_regex` - (Optional, String) The regular expressian of the name of the image.
+  Cannot be used simultaneously with `name`.
+
+* `visibility` - (Optional, String) The visibility of the image. Must be one of
+  **public**, **private**, **market** or **shared**.
+
+* `architecture` - (Optional, String) Specifies the image architecture type. The value can be **x86** and **arm**.
+
+* `os` - (Optional, String) Specifies the image OS type. The value can be **Windows**, **Ubuntu**,
+  **RedHat**, **SUSE**, **CentOS**, **Debian**, **OpenSUSE**, **Oracle Linux**, **Fedora**, **Other**,
+  **CoreOS**, or **EulerOS**.
+
+* `os_version` - (Optional, String) Specifies the OS version. For example, *CentOS 7.4 64bit* or *Ubuntu 18.04 server 64bit*.
+
+* `image_type` - (Optional, String) Specifies the environment where the image is used. For a BMS image, the value is **Ironic**.
+
+* `owner` - (Optional, String) The owner (UUID) of the image.
+
+* `tag` - (Optional, String) Search for images with a specific tag in "Key=Value" format.
+
+* `sort_direction` - (Optional, String) Order the results in either `asc` or `desc`.
+
+* `sort_key` - (Optional, String) Sort images based on a certain key. Must be one of
+  "name", "container_format", "disk_format", "status", "id" or "size". Defaults to `name`.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project ID of the image.
+
+* `flavor_id` - (Optional, String) Specifies the ECS flavor ID used to filter out available images.
+  You can specify only one flavor ID and only ECS flavor ID is valid, BMS flavor is not supported.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The data source ID.
+
+* `images` - Indicates the images information. Structure is documented below.
+
+The `images` block contains:
+
+* `id` - The ID of the image
+
+* `name` - The name of the image.
+
+* `visibility` - The visibility of the image.
+
+* `checksum` - The checksum of the data associated with the image.
+
+* `container_format` - The format of the image's container.
+
+* `disk_format` - The format of the image's disk.
+
+* `min_disk_gb` - The minimum amount of disk space required to use the image.
+
+* `min_ram_mb` - The minimum amount of ram required to use the image.
+
+* `owner` - The owner (UUID) of the image.
+
+* `protected` - Whether or not the image is protected.
+
+* `image_type` - The environment where the image is used. For a BMS image, the value is **Ironic**.
+
+* `os` - Specifies the image OS type.
+
+* `os_version` - The OS version.
+
+* `enterprise_project_id` - The enterprise project ID of the image.
+
+* `status` - The status of the image.
+
+* `backup_id` - The backup ID of the whole image in the CBR vault.
+
+* `created_at` - The date when the image was created.
+
+* `updated_at` - The date when the image was last updated.
+
+* `size_bytes` - The size of the image (in bytes).

--- a/docs/resources/images_image.md
+++ b/docs/resources/images_image.md
@@ -1,0 +1,178 @@
+---
+subcategory: "Image Management Service (IMS)"
+---
+
+# flexibleengine_images_image
+
+Manages an Image resource within FlexibleEngine IMS.
+
+## Example Usage
+
+### Creating an image from an existing ECS
+
+```hcl
+variable "instance_name" {}
+variable "image_name" {}
+
+data resource "flexibleengine_compute_instance_v2" "test" {
+  name = var.instance_name
+}
+
+resource "flexibleengine_images_image" "test" {
+  name        = var.image_name
+  instance_id = data.flexibleengine_compute_instance_v2.test.id
+  description = "created by Terraform"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+```
+
+### Creating an image from OBS bucket
+
+```hcl
+resource "flexibleengine_images_image" "ims_test_file" {
+  name        = "ims_test_file"
+  image_url   = "ims-image:centos70.qcow2"
+  min_disk    = 40
+  description = "Create an image from the OBS bucket."
+
+  tags = {
+    foo = "bar1"
+    key = "value"
+  }
+}
+```
+
+### Creating a whole image from an existing ECS
+
+```hcl
+variable "vault_id" {}
+variable "instance_id" {}
+
+resource "flexibleengine_images_image" "test" {
+  name        = "test_whole_image"
+  instance_id = var.instance_id
+  vault_id    = var.vault_id
+
+  tags = {
+    foo = "bar2"
+    key = "value"
+  }
+}
+```
+
+### Creating a whole image from CBR backup
+
+```hcl
+variable "backup_id" {}
+
+resource "flexibleengine_images_image" "test" {
+  name      = "test_whole_image"
+  backup_id = var.backup_id
+
+  tags = {
+    foo = "bar1"
+    key = "value"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required, String) The name of the image.
+
+* `instance_id` - (Optional, String, ForceNew) The ID of the ECS that needs to be converted into an image. This
+  parameter is mandatory when you create a private image or a private whole image from an ECS.
+  If the value of `vault_id` is not empty, then a whole image will be created.
+
+* `backup_id` - (Optional, String, ForceNew) The ID of the CBR backup that needs to be converted into an image. This
+  parameter is mandatory when you create a private whole image from a CBR backup.
+
+* `image_url` - (Optional, String, ForceNew) The URL of the external image file in the OBS bucket. This parameter is
+  mandatory when you create a private image from an external file uploaded to an OBS bucket. The format is *OBS bucket
+  name:Image file name*.
+
+* `min_ram` - (Optional, Int) The minimum memory of the image in the unit of MB. The default value is 0,
+  indicating that the memory is not restricted.
+
+* `max_ram` - (Optional, Int) The maximum memory of the image in the unit of MB.
+
+* `description` - (Optional, String) A description of the image.
+
+* `tags` - (Optional, Map) The tags of the image.
+
+* `min_disk` - (Optional, Int, ForceNew) The minimum size of the system disk in the unit of GB. This parameter is
+  mandatory when you create a private image from an external file uploaded to an OBS bucket. The value ranges from 1 GB
+  to 1024 GB.
+
+* `os_version` - (Optional, String, ForceNew) The OS version. This parameter is valid when you create a private image
+  from an external file uploaded to an OBS bucket.
+
+* `is_config` - (Optional, Bool, ForceNew) If automatic configuration is required, set the value to true. Otherwise, set
+  the value to false.
+
+* `cmk_id` - (Optional, String, ForceNew) The master key used for encrypting an image.
+
+* `type` - (Optional, String, ForceNew) The image type. Must be one of `ECS`, `FusionCompute`, `BMS`, or `Ironic`.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) The enterprise project id of the image. Changing this creates a
+  new image.
+
+* `vault_id` - (Optional, String, ForceNew) The ID of the vault to which an ECS is to be added or has been added.
+  This parameter is mandatory when you create a private whole image from an ECS.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A unique ID assigned by IMS.
+
+* `visibility` - Whether the image is visible to other tenants.
+
+* `data_origin` - The image resource. The pattern can be 'instance,*instance_id*', 'file,*image_url*'
+  or 'server_backup,*backup_id*'.
+
+* `disk_format` - The image file format. The value can be `vhd`, `zvhd`, `raw`, `zvhd2`, or `qcow2`.
+
+* `image_size` - The size(bytes) of the image file format.
+
+* `checksum` - The checksum of the data associated with the image.
+
+* `status` - The status of the image.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 20 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+Images can be imported using the `id`, e.g.
+
+```bash
+terraform import flexibleengine_images_image.my_image <id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to some attributes missing from the
+API response. The missing attributes include: `vault_id`. It is generally recommended running `terraform plan` after
+importing the image. You can then decide if changes should be applied to the image, or the resource
+definition should be updated to align with the image. Also you can ignore changes as below.
+
+```bash
+resource "flexibleengine_images_image" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [
+      vault_id,
+    ]
+  }
+}
+```

--- a/docs/resources/images_image_v2.md
+++ b/docs/resources/images_image_v2.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Image Management Service (IMS)"
+subcategory: "Deprecated"
 description: ""
 page_title: "flexibleengine_images_image_v2"
 ---
@@ -7,6 +7,8 @@ page_title: "flexibleengine_images_image_v2"
 # flexibleengine_images_image_v2
 
 Manages a V2 Image resource within FlexibleEngine Glance.
+
+!> **WARNING:** It has been deprecated, please use `flexibleengine_images_image` instead.
 
 ## Example Usage
 

--- a/flexibleengine/acceptance/acceptance.go
+++ b/flexibleengine/acceptance/acceptance.go
@@ -39,6 +39,7 @@ var (
 	OS_DLI_FLINK_JAR_OBS_PATH      = os.Getenv("OS_DLI_FLINK_JAR_OBS_PATH")
 	OS_WAF_ENABLE_FLAG             = os.Getenv("OS_WAF_ENABLE_FLAG")
 	OS_SMS_SOURCE_SERVER           = os.Getenv("OS_SMS_SOURCE_SERVER")
+	OS_IMS_BACKUP_ID               = os.Getenv("OS_IMS_BACKUP_ID")
 )
 
 // TestAccProviderFactories is a static map containing only the main provider instance
@@ -146,5 +147,11 @@ func testAccPrecheckWafInstance(t *testing.T) {
 func testAccPreCheckSms(t *testing.T) {
 	if OS_SMS_SOURCE_SERVER == "" {
 		t.Skip("OS_SMS_SOURCE_SERVER must be set for SMS acceptance tests")
+	}
+}
+
+func testAccPreCheckImsBackupId(t *testing.T) {
+	if OS_IMS_BACKUP_ID == "" {
+		t.Skip("OS_IMS_BACKUP_ID must be set for IMS whole image with CBR backup id")
 	}
 }

--- a/flexibleengine/acceptance/data_source_flexibleengine_images_image_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_images_image_test.go
@@ -1,0 +1,198 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccImsImageDataSource_basic(t *testing.T) {
+	imageName := "OBS CentOS 7.4"
+	osVersion := "CentOS 7.4 64bit"
+	dataSourceName := "data.flexibleengine_images_image.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImsImageDataSource_publicName(imageName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", imageName),
+					resource.TestCheckResourceAttr(dataSourceName, "protected", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "visibility", "public"),
+					resource.TestCheckResourceAttr(dataSourceName, "status", "active"),
+				),
+			},
+			{
+				Config: testAccImsImageDataSource_osVersion(osVersion),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "protected", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "visibility", "public"),
+					resource.TestCheckResourceAttr(dataSourceName, "status", "active"),
+				),
+			},
+			{
+				Config: testAccImsImageDataSource_nameRegex("^OBS CentOS 7.4"),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "protected", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "visibility", "public"),
+					resource.TestCheckResourceAttr(dataSourceName, "status", "active"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccImsImageDataSource_testQueries(t *testing.T) {
+	var rName = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	dataSourceName := "data.flexibleengine_images_image.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImsImageDataSource_base(rName),
+			},
+			{
+				Config: testAccImsImageDataSource_queryName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "protected", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "visibility", "private"),
+					resource.TestCheckResourceAttr(dataSourceName, "status", "active"),
+				),
+			},
+			{
+				Config: testAccImsImageDataSource_queryTag(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+				),
+			},
+		},
+	})
+}
+
+func testAccImsImageDataSource_publicName(imageName string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_images_image" "test" {
+  name        = "%s"
+  visibility  = "public"
+}
+`, imageName)
+}
+
+func testAccImsImageDataSource_nameRegex(regexp string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_images_image" "test" {
+  architecture = "x86"
+  name_regex   = "%s"
+  visibility   = "public"
+  most_recent  = true
+}
+`, regexp)
+}
+
+func testAccImsImageDataSource_osVersion(osVersion string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_images_image" "test" {
+  architecture = "x86"
+  os_version   = "%s"
+  visibility   = "public"
+  most_recent  = "true"
+}
+`, osVersion)
+}
+
+func testBaseNetwork(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc_v1" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test" {
+  name       = "%[1]s"
+  vpc_id     = flexibleengine_vpc_v1.test.id
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+}
+
+resource "flexibleengine_networking_secgroup_v2" "test" {
+  name                 = "%[1]s"
+  delete_default_rules = true
+}
+`, rName)
+}
+
+func testAccImsImageDataSource_base(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_compute_flavors_v2" "test" {
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core          = 2
+  memory_size       = 4
+}
+
+resource "flexibleengine_compute_instance_v2" "test" {
+  name               = "%[2]s"
+  image_name         = "OBS Ubuntu 18.04"
+  flavor_id          = data.flexibleengine_compute_flavors_v2.test.flavors[0]
+  security_groups    = [flexibleengine_networking_secgroup_v2.test.name]
+  availability_zone  = data.flexibleengine_availability_zones.test.names[0]
+
+  network {
+    uuid = flexibleengine_vpc_subnet_v1.test.id
+  }
+}
+
+resource "flexibleengine_images_image" "test" {
+  name        = "%[2]s"
+  instance_id = flexibleengine_compute_instance_v2.test.id
+  description = "created by Terraform AccTest"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testBaseNetwork(rName), rName)
+}
+
+func testAccImsImageDataSource_queryName(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_images_image" "test" {
+  most_recent = true
+  name        = flexibleengine_images_image.test.name
+}
+`, testAccImsImageDataSource_base(rName))
+}
+
+func testAccImsImageDataSource_queryTag(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_images_image" "test" {
+  most_recent = true
+  visibility  = "private"
+  tag         = "foo=bar"
+}
+`, testAccImsImageDataSource_base(rName))
+}

--- a/flexibleengine/acceptance/data_source_flexibleengine_images_images_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_images_images_test.go
@@ -1,0 +1,172 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccImsImagesDataSource_basic(t *testing.T) {
+	imageName := "OBS CentOS 7.4"
+	osVersion := "CentOS 7.4 64bit"
+	dataSourceName := "data.flexibleengine_images_images.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImsImagesDataSource_publicName(imageName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "images.0.name", imageName),
+					resource.TestCheckResourceAttr(dataSourceName, "images.0.protected", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "images.0.visibility", "public"),
+					resource.TestCheckResourceAttr(dataSourceName, "images.0.status", "active"),
+				),
+			},
+			{
+				Config: testAccImsImagesDataSource_osVersion(osVersion),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "images.0.protected", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "images.0.visibility", "public"),
+					resource.TestCheckResourceAttr(dataSourceName, "images.0.status", "active"),
+				),
+			},
+			{
+				Config: testAccImsImagesDataSource_nameRegex("^OBS CentOS 7.4"),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "images.0.protected", "true"),
+					resource.TestCheckResourceAttr(dataSourceName, "images.0.visibility", "public"),
+					resource.TestCheckResourceAttr(dataSourceName, "images.0.status", "active"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccImsImagesDataSource_testQueries(t *testing.T) {
+	var rName = fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	dataSourceName := "data.flexibleengine_images_images.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImsImagesDataSource_base(rName),
+			},
+			{
+				Config: testAccImsImagesDataSource_queryName(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "images.0.name", rName),
+					resource.TestCheckResourceAttr(dataSourceName, "images.0.protected", "false"),
+					resource.TestCheckResourceAttr(dataSourceName, "images.0.visibility", "private"),
+					resource.TestCheckResourceAttr(dataSourceName, "images.0.status", "active"),
+				),
+			},
+			{
+				Config: testAccImsImagesDataSource_queryTag(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+				),
+			},
+		},
+	})
+}
+
+func testAccImsImagesDataSource_publicName(imageName string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_images_images" "test" {
+  name       = "%s"
+  visibility = "public"
+}
+`, imageName)
+}
+
+func testAccImsImagesDataSource_nameRegex(regexp string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_images_images" "test" {
+  architecture = "x86"
+  name_regex   = "%s"
+  visibility   = "public"
+}
+`, regexp)
+}
+
+func testAccImsImagesDataSource_osVersion(osVersion string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_images_images" "test" {
+  architecture = "x86"
+  os_version   = "%s"
+  visibility   = "public"
+}
+`, osVersion)
+}
+
+func testAccImsImagesDataSource_base(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_compute_flavors_v2" "test" {
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core          = 2
+  memory_size       = 4
+}
+
+resource "flexibleengine_compute_instance_v2" "test" {
+  name               = "%[2]s"
+  image_name         = "OBS Ubuntu 18.04"
+  flavor_id          = data.flexibleengine_compute_flavors_v2.test.flavors[0]
+  security_groups    = [flexibleengine_networking_secgroup_v2.test.name]
+  availability_zone  = data.flexibleengine_availability_zones.test.names[0]
+
+  network {
+    uuid = flexibleengine_vpc_subnet_v1.test.id
+  }
+}
+
+resource "flexibleengine_images_image" "test" {
+  name        = "%[2]s"
+  instance_id = flexibleengine_compute_instance_v2.test.id
+  description = "created by Terraform AccTest"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testBaseNetwork(rName), rName)
+}
+
+func testAccImsImagesDataSource_queryName(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_images_images" "test" {
+  name = flexibleengine_images_image.test.name
+}
+`, testAccImsImagesDataSource_base(rName))
+}
+
+func testAccImsImagesDataSource_queryTag(rName string) string {
+	return fmt.Sprintf(`
+%s
+data "flexibleengine_images_images" "test" {
+  visibility = "private"
+  tag        = "foo=bar"
+}
+`, testAccImsImagesDataSource_base(rName))
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_images_image_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_images_image_test.go
@@ -1,0 +1,447 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/ims/v2/cloudimages"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ims"
+)
+
+func TestAccImsImage_basic(t *testing.T) {
+	var image cloudimages.Image
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rNameUpdate := rName + "-update"
+	resourceName := "flexibleengine_images_image.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckImsImageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImsImage_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImsImageExists(resourceName, &image),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "0"),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+				),
+			},
+			{
+				Config: testAccImsImage_update(rName, rNameUpdate, 1024, 4096),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImsImageExists(resourceName, &image),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttr(resourceName, "description",
+						"created by Terraform AccTest for update"),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "1024"),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "4096"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccImsImage_update(rName, rNameUpdate, 4096, 8192),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImsImageExists(resourceName, &image),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttr(resourceName, "description",
+						"created by Terraform AccTest for update"),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "4096"),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "8192"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccImsImage_update(rName, rNameUpdate, 0, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImsImageExists(resourceName, &image),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttr(resourceName, "description",
+						"created by Terraform AccTest for update"),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "0"),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccImsImage_wholeImage_withServer(t *testing.T) {
+	var image cloudimages.Image
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rNameUpdate := rName + "-update"
+	resourceName := "flexibleengine_images_image.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckImsImageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImsImage_wholeImage_withServer(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImsImageExists(resourceName, &image),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+				),
+			},
+			{
+				Config: testAccImsImage_wholeImage_withServer_update(rName, rNameUpdate, 1024, 4096),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImsImageExists(resourceName, &image),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "1024"),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "4096"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccImsImage_wholeImage_withServer_update(rName, rNameUpdate, 4096, 8192),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImsImageExists(resourceName, &image),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "4096"),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "8192"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				Config: testAccImsImage_wholeImage_withServer_update(rName, rNameUpdate, 0, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImsImageExists(resourceName, &image),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttr(resourceName, "min_ram", "0"),
+					resource.TestCheckResourceAttr(resourceName, "max_ram", "0"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"vault_id"},
+			},
+		},
+	})
+}
+
+func TestAccImsImage_wholeImage_withBackup(t *testing.T) {
+	var image cloudimages.Image
+
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+	rNameUpdate := rName + "-update"
+	resourceName := "flexibleengine_images_image.test"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckImsBackupId(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckImsImageDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccImsImage_wholeImage_withBackup(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImsImageExists(resourceName, &image),
+					resource.TestCheckResourceAttr(resourceName, "name", rName),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+				),
+			},
+			{
+				Config: testAccImsImage_wholeImage_withBackup_update(rNameUpdate),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImsImageExists(resourceName, &image),
+					resource.TestCheckResourceAttr(resourceName, "name", rNameUpdate),
+					resource.TestCheckResourceAttr(resourceName, "status", "active"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value1"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key2", "value2"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: false,
+			},
+		},
+	})
+}
+
+func testAccCheckImsImageDestroy(s *terraform.State) error {
+	cfg := testAccProvider.Meta().(*config.Config)
+	imageClient, err := cfg.ImageV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("error creating Image: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "flexibleengine_images_image" {
+			continue
+		}
+
+		_, err := ims.GetCloudImage(imageClient, rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("image still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckImsImageExists(n string, image *cloudimages.Image) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("IMS Resource not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		cfg := testAccProvider.Meta().(*config.Config)
+		imageClient, err := cfg.ImageV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("error creating Image: %s", err)
+		}
+
+		found, err := ims.GetCloudImage(imageClient, rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		*image = *found
+		return nil
+	}
+}
+
+func testAccImsImage_basic(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_compute_flavors_v2" "test" {
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core          = 2
+  memory_size       = 4
+}
+
+resource "flexibleengine_compute_instance_v2" "test" {
+  name               = "%[2]s"
+  image_name         = "OBS Ubuntu 18.04"
+  flavor_id          = data.flexibleengine_compute_flavors_v2.test.flavors[0]
+  security_groups    = [flexibleengine_networking_secgroup_v2.test.name]
+  availability_zone  = data.flexibleengine_availability_zones.test.names[0]
+
+  network {
+    uuid = flexibleengine_vpc_subnet_v1.test.id
+  }
+}
+
+resource "flexibleengine_images_image" "test" {
+  name        = "%[2]s"
+  instance_id = flexibleengine_compute_instance_v2.test.id
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testBaseNetwork(rName), rName)
+}
+
+func testAccImsImage_update(rName, rNameUpdate string, minRAM, maxRAM int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_compute_flavors_v2" "test" {
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core          = 2
+  memory_size       = 4
+}
+
+resource "flexibleengine_compute_instance_v2" "test" {
+  name               = "%[2]s"
+  image_name         = "OBS Ubuntu 18.04"
+  flavor_id          = data.flexibleengine_compute_flavors_v2.test.flavors[0]
+  security_groups    = [flexibleengine_networking_secgroup_v2.test.name]
+  availability_zone  = data.flexibleengine_availability_zones.test.names[0]
+
+  network {
+    uuid = flexibleengine_vpc_subnet_v1.test.id
+  }
+}
+
+resource "flexibleengine_images_image" "test" {
+  name        = "%[3]s"
+  instance_id = flexibleengine_compute_instance_v2.test.id
+  description = "created by Terraform AccTest for update"
+  min_ram     = %[4]d
+  max_ram     = %[5]d
+
+  tags = {
+    foo  = "bar"
+    key  = "value1"
+    key2 = "value2"
+  }
+}
+`, testBaseNetwork(rName), rName, rNameUpdate, minRAM, maxRAM)
+}
+
+func testAccImsImage_wholeImage_base(rName string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_compute_flavors_v2" "test" {
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core          = 2
+  memory_size       = 4
+}
+
+resource "flexibleengine_compute_instance_v2" "test" {
+  name               = "%[1]s"
+  image_name         = "OBS Ubuntu 18.04"
+  flavor_id          = data.flexibleengine_compute_flavors_v2.test.flavors[0]
+  security_groups    = [flexibleengine_networking_secgroup_v2.test.name]
+  availability_zone  = data.flexibleengine_availability_zones.test.names[0]
+
+  network {
+    uuid = flexibleengine_vpc_subnet_v1.test.id
+  }
+}
+
+resource "flexibleengine_cbr_vault" "test" {
+  name             = "%[1]s"
+  type             = "server"
+  consistent_level = "app_consistent"
+  protection_type  = "backup"
+  size             = 200
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, rName)
+}
+
+func testAccImsImage_wholeImage_withServer(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "flexibleengine_images_image" "test" {
+  name        = "%[3]s"
+  instance_id = flexibleengine_compute_instance_v2.test.id
+  description = "created by Terraform AccTest"
+  vault_id    = flexibleengine_cbr_vault.test.id
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testBaseNetwork(rName), testAccImsImage_wholeImage_base(rName), rName)
+}
+
+func testAccImsImage_wholeImage_withServer_update(rName, updateName string, minRAM, maxRAM int) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "flexibleengine_images_image" "test" {
+  name        = "%[3]s"
+  instance_id = flexibleengine_compute_instance_v2.test.id
+  description = "created by Terraform AccTest"
+  vault_id    = flexibleengine_cbr_vault.test.id
+  min_ram     = %[4]d
+  max_ram     = %[5]d
+
+  tags = {
+    foo  = "bar"
+    key  = "value1"
+    key2 = "value2"
+  }
+}
+`, testBaseNetwork(rName), testAccImsImage_wholeImage_base(rName), updateName, minRAM, maxRAM)
+}
+
+func testAccImsImage_wholeImage_withBackup(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_images_image" "test" {
+  name        = "%[1]s"
+  backup_id   = "%[2]s"
+  description = "created by Terraform AccTest"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, rName, OS_IMS_BACKUP_ID)
+}
+
+func testAccImsImage_wholeImage_withBackup_update(rName string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_images_image" "test" {
+  name        = "%[1]s"
+  backup_id   = "%[2]s"
+  description = "created by Terraform AccTest"
+
+  tags = {
+    foo  = "bar"
+    key  = "value1"
+    key2 = "value2"
+  }
+}
+`, rName, OS_IMS_BACKUP_ID)
+}

--- a/flexibleengine/data_source_flexibleengine_images_image_v2.go
+++ b/flexibleengine/data_source_flexibleengine_images_image_v2.go
@@ -15,6 +15,8 @@ func dataSourceImagesImageV2() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceImagesImageV2Read,
 
+		DeprecationMessage: "It has been deprecated. Please use flexibleengine_images_image instead",
+
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/flexibleengine/data_source_flexibleengine_images_image_v2_test.go
+++ b/flexibleengine/data_source_flexibleengine_images_image_v2_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAccImagesImageV2DataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckDeprecated(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
@@ -42,7 +42,7 @@ func TestAccImagesImageV2DataSource_basic(t *testing.T) {
 
 func TestAccImagesImageV2DataSource_testQueries(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
+		PreCheck:  func() { testAccPreCheckDeprecated(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -229,7 +229,6 @@ func Provider() *schema.Provider {
 			"flexibleengine_compute_instance_v2":       dataSourceComputeInstance(),
 			"flexibleengine_compute_instances":         dataSourceComputeInstances(),
 			"flexibleengine_compute_flavors_v2":        dataSourceEcsFlavors(),
-			"flexibleengine_images_image_v2":           dataSourceImagesImageV2(),
 			"flexibleengine_networking_secgroup_v2":    dataSourceNetworkingSecGroupV2(),
 			"flexibleengine_s3_bucket_object":          dataSourceS3BucketObject(),
 			"flexibleengine_kms_key_v1":                dataSourceKmsKeyV1(),
@@ -289,6 +288,9 @@ func Provider() *schema.Provider {
 			"flexibleengine_gaussdb_cassandra_instances": gaussdb.DataSourceGeminiDBInstances(),
 			"flexibleengine_gaussdb_nosql_flavors":       gaussdb.DataSourceGaussDBNoSQLFlavors(),
 
+			"flexibleengine_images_image":  ims.DataSourceImagesImageV2(),
+			"flexibleengine_images_images": ims.DataSourceImagesImages(),
+
 			"flexibleengine_networking_port":    vpc.DataSourceNetworkingPortV2(),
 			"flexibleengine_identity_group":     iam.DataSourceIdentityGroup(),
 			"flexibleengine_identity_users":     iam.DataSourceIdentityUsers(),
@@ -308,6 +310,8 @@ func Provider() *schema.Provider {
 			// Deprecated data source
 			"flexibleengine_compute_availability_zones_v2":      dataSourceAvailabilityZones(),
 			"flexibleengine_blockstorage_availability_zones_v3": dataSourceBlockStorageAvailabilityZonesV3(),
+
+			"flexibleengine_images_image_v2": dataSourceImagesImageV2(),
 
 			"flexibleengine_networking_network_v2": dataSourceNetworkingNetworkV2(),
 			"flexibleengine_vpc_eip_v1":            dataSourceVpcEipV1(),
@@ -338,7 +342,6 @@ func Provider() *schema.Provider {
 			"flexibleengine_fw_firewall_group_v2":               resourceFWFirewallGroupV2(),
 			"flexibleengine_fw_policy_v2":                       resourceFWPolicyV2(),
 			"flexibleengine_fw_rule_v2":                         resourceFWRuleV2(),
-			"flexibleengine_images_image_v2":                    resourceImagesImageV2(),
 			"flexibleengine_kms_key_v1":                         resourceKmsKeyV1(),
 			"flexibleengine_lb_loadbalancer_v2":                 resourceLoadBalancerV2(),
 			"flexibleengine_lb_listener_v2":                     resourceListenerV2(),
@@ -482,6 +485,7 @@ func Provider() *schema.Provider {
 
 			"flexibleengine_identity_acl": iam.ResourceIdentityACL(),
 
+			"flexibleengine_images_image":                ims.ResourceImsImage(),
 			"flexibleengine_images_image_copy":           ims.ResourceImsImageCopy(),
 			"flexibleengine_images_image_share":          ims.ResourceImsImageShare(),
 			"flexibleengine_images_image_share_accepter": ims.ResourceImsImageShareAccepter(),
@@ -534,6 +538,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_elb_listener":      resourceEListener(),
 			"flexibleengine_elb_backend":       resourceBackend(),
 			"flexibleengine_elb_health":        resourceHealth(),
+			"flexibleengine_images_image_v2":   resourceImagesImageV2(),
 			"flexibleengine_lb_certificate_v2": resourceCertificateV2(),
 			"flexibleengine_rds_instance_v1":   resourceRdsInstance(),
 			"flexibleengine_vpc_eip_v1":        resourceVpcEIPV1(),

--- a/flexibleengine/resource_flexibleengine_images_image_v2.go
+++ b/flexibleengine/resource_flexibleengine_images_image_v2.go
@@ -29,6 +29,7 @@ func resourceImagesImageV2() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		DeprecationMessage: "It has been deprecated. Please use flexibleengine_images_image instead",
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
 		},

--- a/flexibleengine/resource_flexibleengine_images_image_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_images_image_v2_test.go
@@ -15,7 +15,7 @@ func TestAccImagesImageV2_basic(t *testing.T) {
 	resourceName := "flexibleengine_images_image_v2.image_1"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckDeprecated(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckImagesImageV2Destroy,
 		Steps: []resource.TestStep{
@@ -52,7 +52,7 @@ func TestAccImagesImageV2_tags(t *testing.T) {
 	var image images.Image
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
+		PreCheck:     func() { testAccPreCheckDeprecated(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckImagesImageV2Destroy,
 		Steps: []resource.TestStep{
@@ -93,7 +93,7 @@ func TestAccImagesImageV2_visibility(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheck(t)
+			testAccPreCheckDeprecated(t)
 			testAccPreCheckAdminOnly(t)
 		},
 		Providers:    testAccProviders,


### PR DESCRIPTION
1. deperacate resource `flexibleengine_images_image_v2` and `data_source flexibleengine_images_image_v2`
2. replace them with resource `flexibleengine_images_image` and `data_source flexibleengine_images_image`
3. add a new data_source `flexibleengine_images_images`

```
make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccImsImageDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccImsImageDataSource_basic -timeout 720m
=== RUN   TestAccImsImageDataSource_basic
=== PAUSE TestAccImsImageDataSource_basic
=== CONT  TestAccImsImageDataSource_basic
--- PASS: TestAccImsImageDataSource_basic (56.75s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      56.823s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccImsImageDataSource_testQueries'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccImsImageDataSource_testQueries -timeout 720m
=== RUN   TestAccImsImageDataSource_testQueries
=== PAUSE TestAccImsImageDataSource_testQueries
=== CONT  TestAccImsImageDataSource_testQueries
--- PASS: TestAccImsImageDataSource_testQueries (641.74s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      641.847s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccImsImagesDataSource_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccImsImagesDataSource_basic -timeout 720m
=== RUN   TestAccImsImagesDataSource_basic
=== PAUSE TestAccImsImagesDataSource_basic
=== CONT  TestAccImsImagesDataSource_basic
--- PASS: TestAccImsImagesDataSource_basic (55.28s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      55.348s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccImsImagesDataSource_testQueries'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccImsImagesDataSource_testQueries -timeout 720m
=== RUN   TestAccImsImagesDataSource_testQueries
=== PAUSE TestAccImsImagesDataSource_testQueries
=== CONT  TestAccImsImagesDataSource_testQueries
--- PASS: TestAccImsImagesDataSource_testQueries (468.27s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      468.353s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccImsImage_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccImsImage_basic -timeout 720m
=== RUN   TestAccImsImage_basic
=== PAUSE TestAccImsImage_basic
=== CONT  TestAccImsImage_basic
--- PASS: TestAccImsImage_basic (553.73s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      553.795s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccImsImage_wholeImage_withServer'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccImsImage_wholeImage_withServer -timeout 720m
=== RUN   TestAccImsImage_wholeImage_withServer
=== PAUSE TestAccImsImage_wholeImage_withServer
=== CONT  TestAccImsImage_wholeImage_withServer
--- PASS: TestAccImsImage_wholeImage_withServer (723.69s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      723.760s
```