### PR TITLE
feat(cbr): update vault and add a new data_source

### DIFF
--- a/docs/data-sources/cbr_backup.md
+++ b/docs/data-sources/cbr_backup.md
@@ -1,0 +1,180 @@
+---
+subcategory: "Cloud Backup and Recovery (CBR)"
+---
+
+# flexibleengine_cbr_backup
+
+Use this data source to query the backup detail using its ID within FlexibleEngine.
+
+## Example Usage
+
+### Using backup ID to query the backup detail
+
+```hcl
+variable "backup_id" {}
+
+data "flexibleengine_cbr_backup" "test" {
+  id = "backup_id"
+}
+```
+
+## Argument reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the backup detail.
+  If omitted, the provider-level region will be used.
+
+* `id` - (Required, String) Specifies the backup ID.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `parent_id` - The parent backup ID.
+
+* `type` - The backup type.
+
+* `name` - The backup name.
+
+* `description` - The backup description.
+
+* `checkpoint_id` - The restore point ID.
+
+* `resource_id` - The backup resource ID.
+
+* `resource_type` - The backup resource type.
+
+* `resource_size` - The backup resource size, in GB.
+
+* `resource_name` - The backup resource name.
+
+* `resource_az` - The availability zone where the backup resource is located.
+
+* `enterprise_project_id` - The enterprise project to which the backup resource belongs.
+
+* `vault_id` - The vault to which the backup resource belongs.
+
+* `replication_records` - The replication records.
+  The [object](#cbr_backup_replication_records) structure is documented below.
+
+* `children` - The backup list of the sub-backup resources.
+  The [object](#cbr_backup_children) structure is documented below.
+
+* `extend_info` - The extended information.
+  The [object](#cbr_backup_extend_info) structure is documented below.
+
+* `status` - The backup status.
+
+* `created_at` - The creation time of the backup.
+
+* `updated_at` - The latest update time of the backup.
+
+* `expired_at` - The expiration time of the backup.
+
+<a name="cbr_backup_replication_records"></a>
+The `replication_records` block supports:
+
+* `id` - The replication record ID.
+
+* `destination_backup_id` - The ID of the destination backup used for replication.
+
+* `destination_checkpoint_id` - The record ID of the destination backup used for replication.
+
+* `destination_project_id` - The ID of the replication destination project.
+
+* `destination_region` - The replication destination region.
+
+* `destination_vault_id` - The destination vault ID.
+
+* `source_backup_id` - The ID of the source backup used for replication.
+
+* `source_checkpoint_id` - The ID of the source backup record used for replication.
+
+* `source_project_id` - The ID of the replication source project.
+
+* `source_region` - The replication source region.
+
+* `status` - The replication status.
+
+* `vault_id` - The ID of the vault where the backup resides.
+
+* `extra_info` - The additional information of the replication.
+  The [object](#cbr_backup_replication_record_extra_info) structure is documented below.
+
+* `created_at` - The creation time of the replication.
+
+<a name="cbr_backup_replication_record_extra_info"></a>
+The `extra_info` block supports:
+
+* `progress` - The replication progress.
+
+* `fail_code` - The error code.
+
+* `fail_reason` - The error cause.
+
+* `auto_trigger` - Whether replication is automatically scheduled.
+
+* `destination_vault_id` - The destination vault ID.
+
+<a name="cbr_backup_children"></a>
+The `children` block supports:
+
+* `id` - The sub-backup ID.
+
+* `name` - The sub-backup name.
+
+* `description` - The sub-backup description.
+
+* `type` - The sub-backup type.
+
+* `checkpoint_id` - The restore point ID of the sub-backup resource.
+
+* `resource_id` - The sub-backup resource ID.
+
+* `resource_type` - The sub-backup resource type.
+
+* `resource_size` - The sub-backup resource size, in GB.
+
+* `resource_name` - The sub-backup resource name.
+
+* `resource_az` - The availability zone where the backup sub-backup resource is located.
+
+* `enterprise_project_id` - The enterprise project to which the backup sub-backup resource belongs.
+
+* `vault_id` - The vault to which the backup resource belongs.
+
+* `replication_records` - The replication records.
+
+* `extend_info` - The extended information.
+
+* `status` - The sub-backup status.
+
+* `created_at` - The creation time of the sub-backup.
+
+* `updated_at` - The latest update time of the sub-backup.
+
+* `expired_at` - The expiration time of the sub-backup.
+
+<a name="cbr_backup_extend_info"></a>
+The `extend_info` block supports:
+
+* `auto_trigger` - Whether the backup is automatically generated.
+
+* `bootable` - Whether the backup is a system disk backup.
+
+* `incremental` - Whether the backup is an incremental backup.
+
+* `snapshot_id` - Snapshot ID of the disk backup.
+
+* `support_lld` - Whether to allow lazyloading for fast restoration.
+
+* `supported_restore_mode` - The restoration mode.
+
+* `os_registry_images` - The ID list of images created using backups.
+
+* `contain_system_disk` - Whether the VM backup data contains system disk data.
+
+* `encrypted` - Whether the backup is encrypted.
+
+* `is_system_disk` - Whether the disk is a system disk.

--- a/docs/data-sources/cbr_vaults.md
+++ b/docs/data-sources/cbr_vaults.md
@@ -20,29 +20,36 @@ data "flexibleengine_cbr_vaults" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String) Specifies the region in which to query the CBR vaults.
+* `region` - (Optional, String) Specifies the region in which to query the vaults.
   If omitted, the provider-level region will be used.
 
-* `name` - (Optional, String) Specifies a unique name of the CBR vault. This parameter can contain a maximum of 64
+* `name` - (Optional, String) Specifies the vault name. This parameter can contain a maximum of 64
   characters, which may consist of letters, digits, underscores(_) and hyphens (-).
 
-* `type` - (Optional, String) Specifies the object type of the CBR vault. The vaild values are as follows:
+* `type` - (Optional, String) Specifies the object type of the vault. The vaild values are as follows:
   + **server** (Cloud Servers)
   + **disk** (EVS Disks)
   + **turbo** (SFS Turbo file systems)
 
-* `protection_type` - (Optional, String) Specifies the protection type of the CBR vault.
+* `consistent_level` - (Optional, String) Specifies the consistent level (specification) of the vault.
+  The valid values are as follows:
+  + **[crash_consistent](https://docs.prod-cloud-ocb.orange-business.com/usermanual/cbr/cbr_03_0109.html)**
+  + **[app_consistent](https://docs.prod-cloud-ocb.orange-business.com/usermanual/cbr/cbr_03_0109.html)**
+
+  Only server type vaults support application consistent.
+
+* `protection_type` - (Optional, String) Specifies the protection type of the vault.
   The valid values are **backup** and **replication**. Vaults of type **disk** don't support **replication**.
 
 * `size` - (Optional, Int) Specifies the vault sapacity, in GB. The valid value range is `1` to `10,485,760`.
 
 * `auto_expand_enabled` - (Optional, Bool) Specifies whether to enable automatic expansion of the backup protection
-  type vault. Default to **false**.
+  type vault. Defaults to **false**.
 
-* `policy_id` - (Optional, String) Specifies a policy to associate with the CBR vault.
+* `policy_id` - (Optional, String) Specifies the ID of the policy associated with the vault.
   The `policy_id` cannot be used with the vault of replicate protection type.
 
-* `status` - (Optional, String) Specifies the CBR vault status, including **available**, **lock**, **frozen** and **error**.
+* `status` - (Optional, String) Specifies the vault status, including **available**, **lock**, **frozen** and **error**.
 
 ## Attributes Reference
 
@@ -50,25 +57,25 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - The data source ID in hashcode format.
 
-* `vaults` - List of CBR vault details. The object structure of each CBR vault is documented below.
+* `vaults` - List of vault details. The object structure of each vault is documented below.
 
 The `vaults` block supports:
 
 * `id` - The vault ID in UUID format.
 
-* `name` - The CBR vault name.
+* `name` - The vault name.
 
-* `type` - The object type of the CBR vault.
+* `type` - The object type of the vault.
 
-* `consistent_level` - The backup specifications. The valid value is **crash_consistent**.
+* `consistent_level` - The consistent level (specification) of the vault.
 
-* `protection_type` - The protection type of the CBR vault.
+* `protection_type` - The protection type of the vault.
 
 * `size` - The vault capacity, in GB.
 
 * `auto_expand_enabled` - Whether to enable automatic expansion of the backup protection type vault.
 
-* `policy_id` - The policy associated with the CBR vault.
+* `policy_id` - The ID of the policy associated with the vault.
 
 * `allocated` - The allocated capacity of the vault, in GB.
 
@@ -80,13 +87,16 @@ The `vaults` block supports:
 
 * `storage` - The name of the bucket for the vault.
 
-* `tags` - The key/value pairs to associate with the CBR vault.
+* `tags` - The key/value pairs to associate with the vault.
 
-* `resources` - An array of one or more resources to attach to the CBR vault.
-  The object structure is documented below.
+* `resources` - The array of one or more resources to attach to the vault.
+  The [object](#cbr_vault_resources) structure is documented below.
 
+<a name="cbr_vault_resources"></a>
 The `resources` block supports:
 
 * `server_id` - The ID of the ECS instance to be backed up.
 
-* `includes` - An array of disk or SFS file system IDs which will be included in the backup.
+* `excludes` - The array of disk IDs which will be excluded in the backup.
+
+* `includes` - The array of disk or SFS file system IDs which will be included in the backup.

--- a/flexibleengine/acceptance/data_source_flexibleengine_cbr_backup_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_cbr_backup_test.go
@@ -1,0 +1,107 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataBackup_basic(t *testing.T) {
+	randName := acceptance.RandomAccResourceNameWithDash()
+	dataSourceName := "data.flexibleengine_cbr_backup.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataBackup_basic(randName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataBackup_base(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc_v1" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test" {
+  name       = "%[1]s"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = flexibleengine_vpc_v1.test.id
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+resource "flexibleengine_networking_secgroup_v2" "test" {
+  name        = "%[1]s"
+  description = "terraform security group acceptance test"
+}
+
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_compute_flavors_v2" "test" {
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core          = 2
+  memory_size       = 4
+}
+
+data "flexibleengine_images_image" "test" {
+  name = "OBS Ubuntu 18.04"
+}
+`, name)
+}
+
+func testAccDataBackup_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_compute_instance_v2" "test" {
+  name              = "%[2]s"
+  image_id          = data.flexibleengine_images_image.test.id
+  flavor_id         = data.flexibleengine_compute_flavors_v2.test.flavors[0]
+  security_groups   = [flexibleengine_networking_secgroup_v2.test.name]
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+
+  network {
+    uuid = flexibleengine_vpc_subnet_v1.test.id
+  }
+}
+
+resource "flexibleengine_cbr_vault" "test" {
+  name             = "%[2]s"
+  type             = "server"
+  consistent_level = "app_consistent"
+  protection_type  = "backup"
+  size             = 200
+}
+
+resource "flexibleengine_images_image" "test" {
+  name        = "%[2]s"
+  instance_id = flexibleengine_compute_instance_v2.test.id
+  vault_id    = flexibleengine_cbr_vault.test.id
+}
+
+data "flexibleengine_cbr_backup" "test" {
+  id = flexibleengine_images_image.test.backup_id
+}
+`, testAccDataBackup_base(name), name)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_cbr_vault_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_cbr_vault_test.go
@@ -51,7 +51,7 @@ func TestAccCBRV3Vault_BasicServer(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo1", "bar"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
-					resource.TestCheckResourceAttrPair(resourceName, "policy_id", "flexibleengine_cbr_policy.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "policy.0.id", "flexibleengine_cbr_policy.test", "id"),
 				),
 			},
 			{
@@ -130,7 +130,7 @@ func TestAccCBRV3Vault_BasicVolume(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
 					resource.TestCheckResourceAttr(resourceName, "size", "100"),
 					resource.TestCheckResourceAttr(resourceName, "auto_expand", "true"),
-					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy.0.id"),
 					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "resources.0.includes.#", "2"),
 				),
@@ -176,7 +176,7 @@ func TestAccCBRV3Vault_BasicTurbo(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "type", cbr.VaultTypeTurbo),
 					resource.TestCheckResourceAttr(resourceName, "protection_type", "backup"),
 					resource.TestCheckResourceAttr(resourceName, "size", "1000"),
-					resource.TestCheckResourceAttrSet(resourceName, "policy_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "policy.0.id"),
 					resource.TestCheckResourceAttr(resourceName, "resources.#", "1"),
 				),
 			},
@@ -428,7 +428,10 @@ resource "flexibleengine_cbr_vault" "test" {
   consistent_level = "crash_consistent"
   protection_type  = "backup"
   size             = 300
-  policy_id        = flexibleengine_cbr_policy.test.id
+
+  policy {
+    id = flexibleengine_cbr_policy.test.id
+  }
 
   resources {
     server_id = flexibleengine_compute_instance_v2.test.id
@@ -485,7 +488,11 @@ resource "flexibleengine_cbr_vault" "test" {
   protection_type = "backup"
   size            = 100
   auto_expand     = true
-  policy_id       = flexibleengine_cbr_policy.test.id
+
+  policy {
+    id = flexibleengine_cbr_policy.test.id
+  }
+
 
   resources {
     includes = flexibleengine_compute_volume_attach_v2.test[*].volume_id
@@ -567,7 +574,10 @@ resource "flexibleengine_cbr_vault" "test" {
   type            = "turbo"
   protection_type = "backup"
   size            = 1000
-  policy_id       = flexibleengine_cbr_policy.test.id
+
+  policy {
+    id = flexibleengine_cbr_policy.test.id
+  }
 
   resources {
     includes = [

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -275,6 +275,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_apig_environments":  apig.DataSourceEnvironments(),
 			"flexibleengine_enterprise_project": eps.DataSourceEnterpriseProject(),
 			"flexibleengine_cbr_vaults":         cbr.DataSourceCbrVaultsV3(),
+			"flexibleengine_cbr_backup":         cbr.DataSourceBackup(),
 			"flexibleengine_cce_clusters":       cce.DataSourceCCEClusters(),
 
 			"flexibleengine_dms_kafka_instances":    dms.DataSourceDmsKafkaInstances(),

--- a/go.sum
+++ b/go.sum
@@ -21,17 +21,8 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aws/aws-sdk-go v1.34.0 h1:brux2dRrlwCF5JhTL7MUT3WUwo9zfDHZZp3+g3Mvlmo=
 github.com/aws/aws-sdk-go v1.34.0/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
-github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chnsz/golangsdk v0.0.0-20230607084208-af9cb224d7a2 h1:M7ID+H4g9gcg3bAN0u70WDq86x0jQNGCl1pHuvukRAU=
 github.com/chnsz/golangsdk v0.0.0-20230607084208-af9cb224d7a2/go.mod h1:j6UR2TfACtmWBEvYrQqTpk5wy3b2QsEdiLkjMoM47j8=
-github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
-github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
fixes #940 

1. update the docs of cbr resource and data_source
2. update test cases of resource flexibleengine_cbr_vault
3. add new data_source `flexibleengine_cbr_backup`

```
make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccDataBackup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccDataBackup_basic -timeout 720m
=== RUN   TestAccDataBackup_basic
=== PAUSE TestAccDataBackup_basic
=== CONT  TestAccDataBackup_basic
--- PASS: TestAccDataBackup_basic (550.04s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      550.125s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccCBRV3Vault_BasicServer'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccCBRV3Vault_BasicServer -timeout 720m
=== RUN   TestAccCBRV3Vault_BasicServer
=== PAUSE TestAccCBRV3Vault_BasicServer
=== CONT  TestAccCBRV3Vault_BasicServer
--- PASS: TestAccCBRV3Vault_BasicServer (345.75s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      345.847s
```