### PR TITLE
feat(kms): add new resource kms_grant

### DIFF
--- a/docs/resources/kms_grant.md
+++ b/docs/resources/kms_grant.md
@@ -1,0 +1,73 @@
+---
+subcategory: "Key Management Service (KMS)"
+---
+
+# flexibleengine_kms_grant
+
+Users can create authorizations for other IAM users or accounts,
+granting them permission to use their own master key (CMK),
+and a maximum of 100 authorizations can be created under one master key.
+
+## Example Usage
+
+```hcl
+variable "key_id" {}
+variable "user_id" {}
+
+resource "flexibleengine_kms_grant" "test" {
+  key_id            = var.key_id
+  type              = "user"
+  grantee_principal = var.user_id
+  operations        = ["create-datakey", "encrypt-datakey"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `key_id` - (Required, String, ForceNew) Key ID.
+
+  Changing this parameter will create a new resource.
+
+* `grantee_principal` - (Required, String, ForceNew) The ID of the authorized user or account.  
+
+  Changing this parameter will create a new resource.
+
+* `operations` - (Required, List, ForceNew) List of granted operations.
+  The options are: **create-datakey**, **create-datakey-without-plaintext**, **encrypt-datakey**,
+  **decrypt-datakey**, **describe-key**, **create-grant**, **retire-grant**, **encrypt-data**, **decrypt-data**
+  A value containing only **create-grant** is invalid.
+
+  Changing this parameter will create a new resource.
+
+* `name` - (Optional, String, ForceNew) Grant name.  
+  It must be 1 to 255 characters long, start with a letter, and contain only letters (case-sensitive),
+  digits, hyphens (-), underscores (_), and slash(/).
+
+  Changing this parameter will create a new resource.
+
+* `type` - (Optional, String, ForceNew) Authorization type.
+  The options are: **user**, **domain**. The default value is **user**.  
+
+  Changing this parameter will create a new resource.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `creator` - The ID of the creator.  
+
+## Import
+
+The kms grant can be imported using
+`key_id`, `grant_id`, separated by slashes, e.g.
+
+```bash
+terraform import flexibleengine_kms_grant.test <key_id>/<grant_id>
+```

--- a/flexibleengine/acceptance/resource_flexibleengine_kms_grant_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_kms_grant_test.go
@@ -1,0 +1,142 @@
+package acceptance
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jmespath/go-jmespath"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getKmsGrantResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := OS_REGION_NAME
+	// getGrant: Query the KMS manual Grant
+	var (
+		getGrantHttpUrl = "v1.0/{project_id}/kms/list-grants"
+		getGrantProduct = "kms"
+	)
+	getGrantClient, err := cfg.NewServiceClient(getGrantProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating KMS Client: %s", err)
+	}
+
+	getGrantPath := getGrantClient.Endpoint + getGrantHttpUrl
+	getGrantPath = strings.ReplaceAll(getGrantPath, "{project_id}", getGrantClient.ProjectID)
+
+	getGrantOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+		JSONBody: map[string]interface{}{
+			"key_id": state.Primary.Attributes["key_id"],
+			"limit":  100,
+		},
+	}
+	getGrantResp, err := getGrantClient.Request("POST", getGrantPath, &getGrantOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving KMS grant: %s", err)
+	}
+
+	grantResponseBody, err := utils.FlattenResponse(getGrantResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving KMS grant: %s", err)
+	}
+
+	searchPath := fmt.Sprintf("grants[?grant_id=='%s']|[0]", state.Primary.ID)
+	r, err := jmespath.Search(searchPath, grantResponseBody)
+	if err != nil || r == nil {
+		return nil, fmt.Errorf("error retrieving KMS grant: %s", err)
+	}
+
+	return r, nil
+}
+func TestAccKmsGrant_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "flexibleengine_kms_grant.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getKmsGrantResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckAdminOnly(t)
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testKmsGrant_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "operations.#", "2"),
+					resource.TestCheckResourceAttrPair(rName, "key_id", "flexibleengine_kms_key_v1.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "grantee_principal", "flexibleengine_identity_user_v3.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "creator"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testKmsGrantImportState(rName),
+			},
+		},
+	})
+}
+
+func testKmsGrant_basic(name string) string {
+	return fmt.Sprintf(`
+
+resource "flexibleengine_kms_key_v1" "test" {
+  key_alias    = "%s"
+  pending_days = "7"
+}
+
+resource "flexibleengine_identity_user_v3" "test" {
+  name        = "%s"
+  password    = "password123@!"
+  enabled     = true
+  description = "tested by terraform"
+}
+
+resource "flexibleengine_kms_grant" "test" {
+  key_id            = flexibleengine_kms_key_v1.test.id
+  grantee_principal = flexibleengine_identity_user_v3.test.id
+  operations        = ["create-datakey", "encrypt-datakey"]
+}
+
+`, name, name)
+}
+
+func testKmsGrantImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("Resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.Attributes["key_id"] == "" {
+			return "", fmt.Errorf("Attribute (key_id) of Resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.ID == "" {
+			return "", fmt.Errorf("Attribute (ID) of Resource (%s) not found: %s", name, rs)
+		}
+
+		return rs.Primary.Attributes["key_id"] + "/" +
+			rs.Primary.ID, nil
+	}
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -19,6 +19,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cse"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dds"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/deprecated"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dew"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dli"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/dms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/drs"
@@ -490,6 +491,8 @@ func Provider() *schema.Provider {
 			"flexibleengine_images_image_copy":           ims.ResourceImsImageCopy(),
 			"flexibleengine_images_image_share":          ims.ResourceImsImageShare(),
 			"flexibleengine_images_image_share_accepter": ims.ResourceImsImageShareAccepter(),
+
+			"flexibleengine_kms_grant": dew.ResourceKmsGrant(),
 
 			"flexibleengine_obs_bucket_acl": obs.ResourceOBSBucketAcl(),
 


### PR DESCRIPTION
fixes #951 

```
make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccKmsGrant_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccKmsGrant_basic -timeout 720m
=== RUN   TestAccKmsGrant_basic
=== PAUSE TestAccKmsGrant_basic
=== CONT  TestAccKmsGrant_basic
--- PASS: TestAccKmsGrant_basic (35.89s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      35.944s
```