### PR TITLE
feat(as): add new resources

### DIFF
--- a/docs/data-sources/as_configurations.md
+++ b/docs/data-sources/as_configurations.md
@@ -1,0 +1,110 @@
+---
+subcategory: "Auto Scaling (AS)"
+---
+
+# flexibleengine_as_configurations
+
+Use this data source to get a list of AS configurations.
+
+```hcl
+data "flexibleengine_as_configurations" "configurations" {
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to obtain the AS configurations.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the AS configuration name. Supports fuzzy search.
+
+* `image_id` - (Optional, String) Specifies the image ID.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the list.
+
+* `configurations` - A list of AS configurations.
+
+The `configurations` block supports:
+
+* `scaling_configuration_name` - The AS configuration name.
+
+* `instance_config` - The list of information about instance configurations.
+  The [object](#instance_config_object) structure is documented below.
+
+* `status` - The AS configuration status, the value can be **Bound** or **Unbound**.
+
+<a name="instance_config_object"></a>
+The `instance_config` block supports:
+
+* `instance_id` - The ECS instance ID when using its specification as the template to create AS configurations.
+
+* `flavor` - The ECS flavor name.
+
+* `image` - The ECS image ID.
+
+* `disk` - The list of disk group information. The [object](#instance_config_disk_object) structure is documented below.
+
+* `key_name` - The name of the SSH key pair used to log in to the instance.
+
+* `security_group_ids` - An array of one or more security group IDs.
+
+* `charging_mode` - The billing mode for ECS, the value can be **postPaid** or **spot**.
+
+* `flavor_priority_policy` - The priority policy used when there are multiple flavors
+  and instances to be created using an AS configuration. The value can be `PICK_FIRST` and `COST_FIRST`.
+
+* `ecs_group_id` - The ECS group ID.
+
+* `user_data` - The user data to provide when launching the instance.
+
+* `public_ip` - The EIP list of the ECS instance.
+  The [object](#instance_config_public_ip_object) structure is documented below.
+
+* `metadata` - The key/value pairs to make available from within the instance.
+
+* `personality` - The list of information about the injected file.
+  The [object](#instance_config_personality_object) structure is documented below.
+
+<a name="instance_config_disk_object"></a>
+The `disk` block supports:
+
+* `size` - The disk size. The unit is GB.
+
+* `volume_type` - The volume type.
+
+* `disk_type` - The disk type.
+
+* `kms_id` - The encryption KMS ID of the **DATA** disk.
+
+<a name="instance_config_public_ip_object"></a>
+The `public_ip` block supports:
+
+* `eip` - The list of EIP configuration that will be automatically assigned to the instance.
+  The object structure is documented below.
+
+The `eip` block supports:
+
+* `ip_type` - The EIP type.
+
+* `bandwidth` - The list of bandwidth information. The object structure is documented below.
+
+The `bandwidth` block supports:
+
+* `share_type` - The bandwidth sharing type.
+
+* `charging_mode` - The bandwidth billing mode, the value can be **traffic** or **bandwidth**.
+
+* `size` - The bandwidth (Mbit/s).
+
+<a name="instance_config_personality_object"></a>
+The `personality` block supports:
+
+* `path` - The path of the injected file.
+
+* `content` - The content of the injected file.

--- a/docs/data-sources/as_groups.md
+++ b/docs/data-sources/as_groups.md
@@ -1,0 +1,133 @@
+---
+subcategory: "Auto Scaling (AS)"
+---
+
+# flexibleengine_as_groups
+
+Use this data source to get a list of AS groups.
+
+```hcl
+data "flexibleengine_as_groups" "groups" {
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) The region in which to obtain the AS groups.
+  If omitted, the provider-level region will be used.
+
+* `name` - (Optional, String) Specifies the AS group name. Fuzzy search is supported.
+
+* `scaling_configuration_id` - (Optional, String) Specifies the AS configuration ID, which can be obtained using
+  the API for listing AS configurations.
+
+* `status` - (Optional, String) Specifies the AS group status. The options are as follows:
+  - **INSERVICE**: indicates that the AS group is functional.
+  - **PAUSED**: indicates that the AS group is paused.
+  - **ERROR**: indicates that the AS group malfunctions.
+  - **DELETING**: indicates that the AS group is being deleted.
+  - **FREEZED**: indicates that the AS group has been frozen.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the list.
+
+* `groups` - A list of AS groups.
+
+The `groups` block supports:
+
+* `scaling_group_name` - The name of the AS group.
+
+* `scaling_group_id` - The AS group ID.
+
+* `status` - The AS group status.
+
+* `scaling_configuration_id` - The AS configuration ID.
+
+* `scaling_configuration_name` - The AS configuration name.
+
+* `current_instance_number` - The number of current instances in the AS group.
+
+* `desire_instance_number` - The expected number of instances in the AS group.
+
+* `min_instance_number` - The minimum number of instances in the AS group.
+
+* `max_instance_number` - The maximum number of instances in the AS group.
+
+* `cool_down_time` - The cooling duration, in seconds..
+
+* `lbaas_listeners` - The enhanced load balancers.
+  The [object](#lbaas_listener_object) structure is documented below.
+
+* `availability_zones` - The AZ information.
+
+* `networks` - The network information.
+  The [object](#network_object) structure is documented below.
+
+* `security_groups` - The security group information.
+  The [object](#security_group_object) structure is documented below.
+
+* `created_at` - The time when an AS group was created. The time format complies with UTC.
+
+* `vpc_id` - The ID of the VPC to which the AS group belongs.
+
+* `detail` - Details about the AS group. If a scaling action fails, this parameter is used to record errors.
+
+* `is_scaling` - The scaling flag of the AS group.
+
+* `health_periodic_audit_method` - The health check method.
+
+* `health_periodic_audit_time` - The health check interval.
+
+* `health_periodic_audit_grace_period` - The grace period for health check.
+
+* `instance_terminate_policy` - The instance removal policy.
+
+* `delete_publicip` - Whether to delete the EIP bound to the ECS when deleting the ECS.
+
+* `delete_volume` - Whether to delete the data disks attached to the ECS when deleting the ECS.
+
+* `enterprise_project_id` - The enterprise project ID.
+
+* `activity_type` - The type of the AS action.
+
+* `multi_az_scaling_policy` - The priority policy used to select target AZs when adjusting the number of
+  instances in an AS group.
+
+* `description` - The description of the AS group.
+
+* `iam_agency_name` - The agency name.
+
+* `tags` - The tag of AS group.
+
+* `instances` - The scaling group instances ids.
+
+<a name="lbaas_listener_object"></a>
+The `lbaas_listeners` block supports:
+
+* `pool_id` - The backend ECS group ID.
+
+* `protocol_port` - The backend protocol ID, which is the port on which a backend ECS listens for traffic.
+
+* `weight` - The weight, which determines the portion of requests a backend ECS processes
+  compared to other backend ECSs added to the same listener.
+
+<a name="network_object"></a>
+The `networks` block supports:
+
+* `id` - The subnet ID.
+
+* `ipv6_enable` - Specifies whether to support IPv6 addresses.
+
+* `ipv6_bandwidth_id` - The ID of the shared bandwidth of an IPv6 address.
+
+* `source_dest_check` - Whether processesing only traffic that is destined specifically for it.
+
+<a name="security_group_object"></a>
+The `security_groups` block supports:
+
+* `id` - The ID of the security group.

--- a/docs/resources/as_configuration.md
+++ b/docs/resources/as_configuration.md
@@ -1,10 +1,10 @@
 ---
 subcategory: "Auto Scaling (AS)"
 description: ""
-page_title: "flexibleengine_as_configuration_v1"
+page_title: "flexibleengine_as_configuration"
 ---
 
-# flexibleengine_as_configuration_v1
+# flexibleengine_as_configuration
 
 Manages a V1 AS Configuration resource within flexibleengine.
 
@@ -13,7 +13,7 @@ Manages a V1 AS Configuration resource within flexibleengine.
 ### Basic AS Configuration
 
 ```hcl
-resource "flexibleengine_as_configuration_v1" "my_as_config" {
+resource "flexibleengine_as_configuration" "my_as_config" {
   scaling_configuration_name = "my_as_config"
 
   instance_config {
@@ -33,7 +33,7 @@ resource "flexibleengine_as_configuration_v1" "my_as_config" {
 ### AS Configuration With User Data and Metadata
 
 ```hcl
-resource "flexibleengine_as_configuration_v1" "my_as_config" {
+resource "flexibleengine_as_configuration" "my_as_config" {
   scaling_configuration_name = "my_as_config"
 
   instance_config {
@@ -59,7 +59,7 @@ function, or the `template_cloudinit_config` resource.
 ### AS Configuration uses the existing instance specifications as the template
 
 ```hcl
-resource "flexibleengine_as_configuration_v1" "my_as_config" {
+resource "flexibleengine_as_configuration" "my_as_config" {
   scaling_configuration_name = "my_as_config"
   instance_config = {
     instance_id = "4579f2f5-cbe8-425a-8f32-53dcb9d9053a"

--- a/docs/resources/as_group.md
+++ b/docs/resources/as_group.md
@@ -1,10 +1,10 @@
 ---
 subcategory: "Auto Scaling (AS)"
 description: ""
-page_title: "flexibleengine_as_group_v1"
+page_title: "flexibleengine_as_group"
 ---
 
-# flexibleengine_as_group_v1
+# flexibleengine_as_group
 
 Manages a V1 Autoscaling Group resource within flexibleengine.
 
@@ -25,7 +25,7 @@ resource "flexibleengine_vpc_subnet_v1" "example_subnet" {
   vpc_id     = flexibleengine_vpc_v1.example_vpc.id
 }
 
-resource "flexibleengine_as_group_v1" "my_as_group" {
+resource "flexibleengine_as_group" "my_as_group" {
   scaling_group_name       = "my_as_group"
   desire_instance_number   = 2
   min_instance_number      = 0
@@ -59,7 +59,7 @@ resource "flexibleengine_vpc_subnet_v1" "example_subnet" {
   vpc_id     = flexibleengine_vpc_v1.example_vpc.id
 }
 
-resource "flexibleengine_as_group_v1" "my_as_group_only_remove_members" {
+resource "flexibleengine_as_group" "my_as_group_only_remove_members" {
   scaling_group_name       = "my_as_group_only_remove_members"
   desire_instance_number   = 2
   min_instance_number      = 0
@@ -103,7 +103,7 @@ resource "flexibleengine_lb_listener_v2" "listener_1" {
   loadbalancer_id = flexibleengine_lb_loadbalancer_v2.lb_1.id
 }
 
-resource "flexibleengine_as_group_v1" "my_as_group_with_elb" {
+resource "flexibleengine_as_group" "my_as_group_with_elb" {
   scaling_group_name       = "my_as_group_with_elb"
   desire_instance_number   = 2
   min_instance_number      = 0

--- a/docs/resources/as_instance_attach.md
+++ b/docs/resources/as_instance_attach.md
@@ -1,0 +1,106 @@
+---
+subcategory: "Auto Scaling (AS)"
+---
+
+# flexibleengine_as_instance_attach
+
+Manages an AS instance attachment resource within FlexibleEngine.
+
+## Example Usage
+
+### Add an instance
+
+```hcl
+variable "scaling_group_id" {}
+variable "ecs_id" {}
+
+resource "flexibleengine_as_instance_attach" "test" {
+  scaling_group_id = var.scaling_group_id
+  instance_id      = var.ecs_id
+}
+```
+
+### Add an instance with protection
+
+```hcl
+variable "scaling_group_id" {}
+variable "ecs_id" {}
+
+resource "flexibleengine_as_instance_attach" "test" {
+  scaling_group_id = var.scaling_group_id
+  instance_id      = var.ecs_id
+  protected        = true
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `scaling_group_id` - (Required, String, ForceNew) Specifies the AS group ID.
+  Changing this creates a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ECS instance ID.
+  Changing this creates a new resource.
+
+  <!--markdownlint-disable MD033-->
+  -> Before adding instances to an AS group, ensure that the following conditions are met:
+  <br/>1. The instance is not in other AS groups.
+  <br/>2. The instance is in the same VPC as the AS group.
+  <br/>3. The instance is in the AZs used by the AS group.
+  <br/>4. After the instance is added, the total number of instances is less than or equal to the maximum number of
+  instances allowed.
+
+* `protected` - (Optional, Bool) Specifies whether the instance can be removed **automatically** from the AS group.
+  Once configured, when AS automatically scales in the AS group, the instance that is protected will not be removed.
+
+* `standby` - (Optional, Bool) Specifies whether to stop distributing traffic to the instance but do not want to remove
+  it from the AS group. You can stop or restart the instance without worrying about it will be removed from the AS group.
+
+* `append_instance` - (Optional, Bool) Specifies whether to add a new instance when the instance enter standby mode.
+  This parameter takes effect only when `standby` is set to true.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in format of `scaling_group_id`/`instance_id`.
+* `instance_name` - The ECS instance name.
+* `health_status` - The instance health status. The value can be `INITIALIZING`, `NORMAL` or `ERROR`.
+* `status` - The instance lifecycle status in the AS group. The value can be `INSERVICE`, `STANDBY`, `PENDING` or `REMOVING`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+The AS instances can be imported by the `scaling_group_id` and `instance_id`, separated by a slash, e.g.
+
+```bash
+terraform import flexibleengine_as_instance_attach.test <scaling_group_id>/<instance_id>
+```
+
+Note that the imported state may not be identical to your resource definition, due to `append_instance` is missing from
+the API response.
+
+It is generally recommended running `terraform plan` after importing the resource.
+You can then decide if changes should be applied to the resource, or the resource definition should be updated to
+align with the resource. Also you can ignore changes as below.
+
+```hcl
+resource "flexibleengine_as_instance_attach" "test" {
+  ...
+
+  lifecycle {
+    ignore_changes = [append_instance]
+  }
+}
+```

--- a/docs/resources/as_notification.md
+++ b/docs/resources/as_notification.md
@@ -1,0 +1,55 @@
+---
+subcategory: "Auto Scaling (AS)"
+---
+
+# flexibleengine_as_notification
+
+Manages an AS notification resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+variable "scaling_group_id" {}
+variable "topic_urn" {}
+variable "events" {
+  type = list(string)
+}
+
+resource "flexibleengine_as_notification" "test" {
+  scaling_group_id = var.scaling_group_id
+  topic_urn        = var.topic_urn
+  events           = var.events
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
+
+* `scaling_group_id` - (Required, String, ForceNew) Specifies the AS group ID.
+  Changing this creates a new AS notification.
+
+* `topic_urn` - (Required, String, ForceNew) Specifies the unique topic URN of the SMN.
+  Changing this creates a new AS notification.
+
+* `events` - (Required, List) Specifies the topic scene of AS group. The events include `SCALING_UP`,
+  `SCALING_UP_FAIL`, `SCALING_DOWN`, `SCALING_DOWN_FAIL`, `SCALING_GROUP_ABNORMAL`.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The unique topic URN in SMN.
+
+* `topic_name` - The topic name in SMN.
+
+## Import
+
+The as notification can be imported using `scaling_group_id`, `topic_urn`, separated by a slash, e.g.
+
+```bash
+terraform import flexibleengine_as_notification.test <scaling_group_id>/<topic_urn>
+```

--- a/flexibleengine/acceptance/data_source_flexibleengine_as_configurations_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_as_configurations_test.go
@@ -1,0 +1,45 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceASConfiguration_basic(t *testing.T) {
+	dataSourceName := "data.flexibleengine_as_configurations.configurations"
+	name := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceASConfiguration_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "configurations.0.scaling_configuration_name", name),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceASConfiguration_conf(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_as_configurations" "configurations" {
+  name     = flexibleengine_as_configuration.acc_as_config.scaling_configuration_name
+  image_id = flexibleengine_as_configuration.acc_as_config.instance_config.0.image
+
+  depends_on = [flexibleengine_as_configuration.acc_as_config]
+}
+`, testASGroup_Base(name))
+}

--- a/flexibleengine/acceptance/data_source_flexibleengine_as_groups_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_as_groups_test.go
@@ -1,0 +1,44 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDataSourceASGroup_basic(t *testing.T) {
+	dataSourceName := "data.flexibleengine_as_groups.groups"
+	name := acceptance.RandomAccResourceName()
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceASGroup_conf(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "groups.0.scaling_group_name", name),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceASGroup_conf(name string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_as_groups" "groups" {
+  name = flexibleengine_as_group.acc_as_group.scaling_group_name
+
+  depends_on = [flexibleengine_as_group.acc_as_group]
+}
+`, testASGroup_basic(name))
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_as_instance_acctah_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_as_instance_acctah_test.go
@@ -1,0 +1,228 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/autoscaling/v1/instances"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getASInstanceAttachResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := OS_REGION_NAME
+	client, err := cfg.AutoscalingV1Client(region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating autoscaling client: %s", err)
+	}
+
+	groupID := state.Primary.Attributes["scaling_group_id"]
+	instanceID := state.Primary.Attributes["instance_id"]
+	page, err := instances.List(client, groupID, nil).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	allInstances, err := page.(instances.InstancePage).Extract()
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetching instances in AS group %s: %s", groupID, err)
+	}
+
+	for _, ins := range allInstances {
+		if ins.ID == instanceID {
+			return &ins, nil
+		}
+	}
+
+	return nil, fmt.Errorf("can not find the instance %s in AS group %s", instanceID, groupID)
+}
+
+func TestAccASInstanceAttach_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "flexibleengine_as_instance_attach.test0"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getASInstanceAttachResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testASInstanceAttach_conf(name, "false", "false"),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "scaling_group_id", "flexibleengine_as_group.acc_as_group", "id"),
+					resource.TestCheckResourceAttrPair(rName, "instance_id", "flexibleengine_compute_instance_v2.test.0", "id"),
+					resource.TestCheckResourceAttr(rName, "protected", "false"),
+					resource.TestCheckResourceAttr(rName, "standby", "false"),
+					resource.TestCheckResourceAttr(rName, "status", "INSERVICE"),
+				),
+			},
+			{
+				Config: testASInstanceAttach_conf(name, "true", "false"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "protected", "true"),
+					resource.TestCheckResourceAttr(rName, "standby", "false"),
+					resource.TestCheckResourceAttr(rName, "status", "INSERVICE"),
+				),
+			},
+			{
+				Config: testASInstanceAttach_conf(name, "true", "true"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(rName, "protected", "true"),
+					resource.TestCheckResourceAttr(rName, "standby", "true"),
+					resource.TestCheckResourceAttr(rName, "status", "STANDBY"),
+				),
+			},
+			{
+				ResourceName:            rName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"append_instance"},
+			},
+		},
+	})
+}
+
+func testASGroup_Base(rName string) string {
+	return fmt.Sprintf(`
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_compute_flavors_v2" "test" {
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core          = 2
+  memory_size       = 4
+}
+
+data "flexibleengine_images_image" "test" {
+  name = "OBS Ubuntu 18.04"
+}
+
+resource "flexibleengine_vpc_v1" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test" {
+  name       = "%[1]s"
+  vpc_id     = flexibleengine_vpc_v1.test.id
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+}
+
+resource "flexibleengine_networking_secgroup_v2" "test" {
+  name                 = "%[1]s"
+  delete_default_rules = true
+}
+
+resource "flexibleengine_compute_keypair_v2" "acc_key" {
+  name       = "%[1]s"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAjpC1hwiOCCmKEWxJ4qzTTsJbKzndLo1BCz5PcwtUnflmU+gHJtWMZKpuEGVi29h0A/+ydKek1O18k10Ff+4tyFjiHDQAT9+OfgWf7+b1yK+qDip3X1C0UPMbwHlTfSGWLGZquwhvEFx9k3h/M+VtMvwR1lJ9LUyTAImnNjWG7TAIPmui30HvM2UiFEmqkr4ijq45MyX2+fLIePLRIFuu1p4whjHAQYufqyno3BS48icQb4p6iVEZPo4AE2o9oIyQvj2mx4dk5Y8CgSETOZTYDOR3rU2fZTRDRgPJDH9FWvQjF5tA0p3d9CoWWd2s6GKKbfoUIi8R/Db1BSPJwkqB jrp-hp-pc"
+}
+
+resource "flexibleengine_lb_loadbalancer_v3" "loadbalancer_1" {
+  availability_zone = [data.flexibleengine_availability_zones.test.names[0]]
+  name              = "%[1]s"
+  ipv4_subnet_id    = flexibleengine_vpc_subnet_v1.test.ipv4_subnet_id
+}
+
+resource "flexibleengine_lb_listener_v3" "listener_1" {
+  name            = "%[1]s"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v3.loadbalancer_1.id
+}
+
+resource "flexibleengine_lb_pool_v3" "pool_1" {
+  name        = "%[1]s"
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = flexibleengine_lb_listener_v3.listener_1.id
+}
+
+resource "flexibleengine_as_configuration" "acc_as_config"{
+  scaling_configuration_name = "%[1]s"
+  instance_config {
+	image    = data.flexibleengine_images_image.test.id
+	flavor   = data.flexibleengine_compute_flavors_v2.test.flavors[0]
+    key_name = flexibleengine_compute_keypair_v2.acc_key.id
+    disk {
+      size        = 40
+      volume_type = "SSD"
+      disk_type   = "SYS"
+    }
+  }
+}`, rName)
+}
+
+func testASGroup_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_as_group" "acc_as_group"{
+  scaling_group_name       = "%s"
+  scaling_configuration_id = flexibleengine_as_configuration.acc_as_config.id
+  vpc_id                   = flexibleengine_vpc_v1.test.id
+  max_instance_number      = 5
+
+  networks {
+    id = flexibleengine_vpc_subnet_v1.test.id
+  }
+  security_groups {
+    id = flexibleengine_networking_secgroup_v2.test.id
+  }
+  lbaas_listeners {
+    pool_id       = flexibleengine_lb_pool_v3.pool_1.id
+    protocol_port = flexibleengine_lb_listener_v3.listener_1.protocol_port
+  }
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testASGroup_Base(rName), rName)
+}
+
+func testASInstanceAttach_conf(name, protection, standby string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_compute_instance_v2" "test" {
+  count           = 2
+  name            = "%s-${count.index}"
+  image_id        = data.flexibleengine_images_image.test.id
+  flavor_id       = data.flexibleengine_compute_flavors_v2.test.flavors[0]
+  security_groups = [flexibleengine_networking_secgroup_v2.test.name]
+
+  network {
+    uuid = flexibleengine_vpc_subnet_v1.test.id
+  }
+}
+
+resource "flexibleengine_as_instance_attach" "test0" {
+  scaling_group_id = flexibleengine_as_group.acc_as_group.id
+  instance_id      = flexibleengine_compute_instance_v2.test[0].id
+  protected        = %[3]s
+  standby          = %[4]s
+}
+
+resource "flexibleengine_as_instance_attach" "test1" {
+  scaling_group_id = flexibleengine_as_group.acc_as_group.id
+  instance_id      = flexibleengine_compute_instance_v2.test[1].id
+  protected        = %[3]s
+  standby          = %[4]s
+}
+`, testASGroup_basic(name), name, protection, standby)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_as_notification_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_as_notification_test.go
@@ -1,0 +1,168 @@
+package acceptance
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getAsNotificationResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := OS_REGION_NAME
+	// getASNotification: Query the AS notification.
+	var (
+		getASNotificationHttpUrl = "autoscaling-api/v1/{project_id}/scaling_notification/{scaling_group_id}"
+		getASNotificationProduct = "autoscaling"
+	)
+	getASNotificationClient, err := cfg.NewServiceClient(getASNotificationProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating AutoScaling Client: %s", err)
+	}
+
+	getASNotificationPath := getASNotificationClient.Endpoint + getASNotificationHttpUrl
+	getASNotificationPath = strings.ReplaceAll(getASNotificationPath, "{project_id}",
+		getASNotificationClient.ProjectID)
+	getASNotificationPath = strings.ReplaceAll(getASNotificationPath, "{scaling_group_id}",
+		fmt.Sprintf("%v", state.Primary.Attributes["scaling_group_id"]))
+
+	getASNotificationOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getASNotificationResp, err := getASNotificationClient.Request("GET", getASNotificationPath,
+		&getASNotificationOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving AS notification: %s", err)
+	}
+
+	getASNotificationRespBody, err := utils.FlattenResponse(getASNotificationResp)
+	if err != nil {
+		return nil, fmt.Errorf("error flatten response: %s", err)
+	}
+	return filterTargetASNotificationByTopicUrn(getASNotificationRespBody, state.Primary.ID)
+}
+
+func filterTargetASNotificationByTopicUrn(resp interface{}, topicUrn string) (interface{}, error) {
+	if resp == nil {
+		return nil, fmt.Errorf("resp cannot be nil")
+	}
+
+	curJson := utils.PathSearch("topics", resp, make([]interface{}, 0))
+	curArray := curJson.([]interface{})
+	for _, v := range curArray {
+		urn := utils.PathSearch("topic_urn", v, "")
+		if topicUrn == urn.(string) {
+			return v, nil
+		}
+	}
+	return nil, fmt.Errorf("the target AS notification: %s not found", topicUrn)
+}
+
+func TestAccAsNotification_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "flexibleengine_as_notification.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getAsNotificationResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAsNotification_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "events.0", "SCALING_UP"),
+					resource.TestCheckResourceAttrSet(rName, "scaling_group_id"),
+					resource.TestCheckResourceAttrSet(rName, "topic_urn"),
+					resource.TestCheckResourceAttrSet(rName, "topic_name"),
+				),
+			},
+			{
+				Config: testAsNotification_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "events.0", "SCALING_DOWN_FAIL"),
+					resource.TestCheckResourceAttr(rName, "events.1", "SCALING_GROUP_ABNORMAL"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAsNotificationImportState(rName),
+			},
+		},
+	})
+}
+
+func testAsNotification_base(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_smn_topic_v2" "topic_1" {
+  name         = "%s"
+  display_name = "The display name of %s"
+}
+
+`, testASGroup_basic(name), name, name)
+}
+
+func testAsNotification_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_as_notification" "test" {
+  scaling_group_id = flexibleengine_as_group.acc_as_group.id
+  topic_urn        = flexibleengine_smn_topic_v2.topic_1.id
+  events           = ["SCALING_UP"]
+}
+`, testAsNotification_base(name))
+}
+
+func testAsNotification_basic_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_as_notification" "test" {
+  scaling_group_id = flexibleengine_as_group.acc_as_group.id
+  topic_urn        = flexibleengine_smn_topic_v2.topic_1.id
+  events           = ["SCALING_DOWN_FAIL", "SCALING_GROUP_ABNORMAL"]
+}
+`, testAsNotification_base(name))
+}
+
+func testAsNotificationImportState(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+
+		var scalingGroupID, topicUrn string
+		if scalingGroupID = rs.Primary.Attributes["scaling_group_id"]; scalingGroupID == "" {
+			return "", fmt.Errorf("attribute (scaling_group_id) of Resource (%s) not found: %s", name, rs)
+		}
+		if topicUrn = rs.Primary.Attributes["topic_urn"]; topicUrn == "" {
+			return "", fmt.Errorf("attribute (topic_urn) of Resource (%s) not found: %s", name, rs)
+		}
+		return fmt.Sprintf("%s/%s", scalingGroupID, topicUrn), nil
+	}
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/apig"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/as"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cbr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cce"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/cse"
@@ -272,7 +273,11 @@ func Provider() *schema.Provider {
 			"flexibleengine_elb_flavors":               dataSourceElbFlavorsV3(),
 
 			// importing new data source
-			"flexibleengine_apig_environments":  apig.DataSourceEnvironments(),
+			"flexibleengine_apig_environments": apig.DataSourceEnvironments(),
+
+			"flexibleengine_as_configurations": as.DataSourceASConfigurations(),
+			"flexibleengine_as_groups":         as.DataSourceASGroups(),
+
 			"flexibleengine_enterprise_project": eps.DataSourceEnterpriseProject(),
 			"flexibleengine_cbr_vaults":         cbr.DataSourceCbrVaultsV3(),
 			"flexibleengine_cbr_backup":         cbr.DataSourceBackup(),
@@ -380,8 +385,8 @@ func Provider() *schema.Provider {
 			"flexibleengine_obs_bucket_object":                  resourceObsBucketObject(),
 			"flexibleengine_obs_bucket_replication":             resourceObsBucketReplication(),
 			"flexibleengine_obs_bucket_notifications":           resourceObsBucketNotifications(),
-			"flexibleengine_as_group_v1":                        resourceASGroup(),
-			"flexibleengine_as_configuration_v1":                resourceASConfiguration(),
+			"flexibleengine_as_group":                           resourceASGroup(),
+			"flexibleengine_as_configuration":                   resourceASConfiguration(),
 			"flexibleengine_as_policy_v1":                       resourceASPolicy(),
 			"flexibleengine_as_lifecycle_hook_v1":               resourceASLifecycleHook(),
 			"flexibleengine_rds_read_replica_v3":                resourceRdsReadReplicaInstance(),
@@ -451,6 +456,9 @@ func Provider() *schema.Provider {
 
 			"flexibleengine_api_gateway_api":   huaweicloud.ResourceAPIGatewayAPI(),
 			"flexibleengine_api_gateway_group": huaweicloud.ResourceAPIGatewayGroup(),
+
+			"flexibleengine_as_instance_attach": as.ResourceASInstanceAttach(),
+			"flexibleengine_as_notification":    as.ResourceAsNotification(),
 
 			"flexibleengine_enterprise_project":        eps.ResourceEnterpriseProject(),
 			"flexibleengine_cbr_policy":                cbr.ResourceCBRPolicyV3(),
@@ -535,6 +543,9 @@ func Provider() *schema.Provider {
 			"flexibleengine_smn_subscription_v2": smn.ResourceSubscription(),          // v1.39.0
 
 			// Deprecated resource
+			"flexibleengine_as_group_v1":         resourceASGroup(),
+			"flexibleengine_as_configuration_v1": resourceASConfiguration(),
+
 			"flexibleengine_elb_loadbalancer":  resourceELoadBalancer(),
 			"flexibleengine_elb_listener":      resourceEListener(),
 			"flexibleengine_elb_backend":       resourceBackend(),

--- a/flexibleengine/resource_flexibleengine_as_group_v1.go
+++ b/flexibleengine/resource_flexibleengine_as_group_v1.go
@@ -50,6 +50,7 @@ func resourceASGroup() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: false,
+				Computed: true,
 			},
 			"min_instance_number": {
 				Type:     schema.TypeInt,


### PR DESCRIPTION
1. add new resources `flexibleengine_as_instance_attach` and `flexibleengine_as_notification`
2. add new data_sources `flexibleengine_as_configurations` and `flexibleengine_as_groups`
3. rename resource `flexibleengine_as_configuration_v1` to `flexibleengine_as_configuration`
4. rename resource `flexibleengine_as_group_v1` to `flexibleengine_as_group`

```
make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccAsNotification_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccAsNotification_basic -timeout 720m
=== RUN   TestAccAsNotification_basic
=== PAUSE TestAccAsNotification_basic
=== CONT  TestAccAsNotification_basic
--- PASS: TestAccAsNotification_basic (245.25s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      245.302s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccASInstanceAttach_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccASInstanceAttach_basic -timeout 720m
=== RUN   TestAccASInstanceAttach_basic
=== PAUSE TestAccASInstanceAttach_basic
=== CONT  TestAccASInstanceAttach_basic
--- PASS: TestAccASInstanceAttach_basic (387.43s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      387.878s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccDataSourceASConfiguration_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccDataSourceASConfiguration_basic -timeout 720m
=== RUN   TestAccDataSourceASConfiguration_basic
=== PAUSE TestAccDataSourceASConfiguration_basic
=== CONT  TestAccDataSourceASConfiguration_basic
--- PASS: TestAccDataSourceASConfiguration_basic (141.75s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      141.827s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccDataSourceASGroup_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccDataSourceASGroup_basic -timeout 720m
=== RUN   TestAccDataSourceASGroup_basic
=== PAUSE TestAccDataSourceASGroup_basic
=== CONT  TestAccDataSourceASGroup_basic
--- PASS: TestAccDataSourceASGroup_basic (147.82s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      147.875s
```