### PR TITLE
chore: deprecate lb_certificates_v2 in docs and acc-tests

### DIFF
--- a/docs/resources/lb_listener_v2.md
+++ b/docs/resources/lb_listener_v2.md
@@ -38,7 +38,7 @@ resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
   vip_subnet_id = flexibleengine_vpc_subnet_v1.example_subnet.ipv4_subnet_id
 }
 
-resource "flexibleengine_lb_certificate_v2" "certificate_1" {
+resource "flexibleengine_elb_certificate" "certificate_1" {
   name        = "cert"
   domain      = "www.elb.com"
   private_key = <<EOT
@@ -102,7 +102,7 @@ resource "flexibleengine_lb_listener_v2" "listener_1" {
   protocol                  = "TERMINATED_HTTPS"
   protocol_port             = 8080
   loadbalancer_id           = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
-  default_tls_container_ref = flexibleengine_lb_certificate_v2.certificate_1.id
+  default_tls_container_ref = flexibleengine_elb_certificate.certificate_1.id
 }
 ```
 

--- a/flexibleengine/data_source_flexibleengine_lb_certificates_v2.go
+++ b/flexibleengine/data_source_flexibleengine_lb_certificates_v2.go
@@ -73,11 +73,11 @@ func dataSourceCertificateV2Read(d *schema.ResourceData, meta interface{}) error
 	}
 	allPages, err := certificates.List(lbClient, listOpts).AllPages()
 	if err != nil {
-		return fmt.Errorf("Error retrieving flexibleengine_lb_certificate_v2: %s", err)
+		return fmt.Errorf("Error retrieving ELB certificate: %s", err)
 	}
 	certs, err := certificates.ExtractCertificates(allPages)
 	if err != nil {
-		return fmt.Errorf("Error extracting flexibleengine_lb_certificate_v2 from response: %s", err)
+		return fmt.Errorf("Error extracting ELB certificate from response: %s", err)
 	}
 
 	if len(certs) < 1 {

--- a/flexibleengine/resource_flexibleengine_lb_listener_v2_test.go
+++ b/flexibleengine/resource_flexibleengine_lb_listener_v2_test.go
@@ -221,7 +221,7 @@ resource "flexibleengine_lb_loadbalancer_v2" "loadbalancer_1" {
   vip_subnet_id = "%s"
 }
 
-resource "flexibleengine_lb_certificate_v2" "certificate_1" {
+resource "flexibleengine_elb_certificate" "certificate_1" {
   name        = "cert-%s"
   domain      = "www.elb.com"
   private_key = <<EOT
@@ -286,7 +286,7 @@ resource "flexibleengine_lb_listener_v2" "listener_1" {
   protocol_port             = 8080
   http2_enable              = true
   loadbalancer_id           = flexibleengine_lb_loadbalancer_v2.loadbalancer_1.id
-  default_tls_container_ref = flexibleengine_lb_certificate_v2.certificate_1.id
+  default_tls_container_ref = flexibleengine_elb_certificate.certificate_1.id
 }
 `, name, OS_SUBNET_ID, name, name)
 }


### PR DESCRIPTION
fixes #963 

the testing as follows:

```bash
$ make testacc TEST="./flexibleengine" TESTARGS="-run TestAccLBV2Listener"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccLBV2Listener -timeout 720m
=== RUN   TestAccLBV2Listener_basic
--- PASS: TestAccLBV2Listener_basic (138.03s)
=== RUN   TestAccLBV2Listener_withCert
--- PASS: TestAccLBV2Listener_withCert (70.12s)
=== RUN   TestAccLBV2Listener_v3
--- PASS: TestAccLBV2Listener_v3 (71.04s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 279.292s
```