### PR TITLE
feat(NAT): add private nat resources

### DIFF
--- a/docs/resources/nat_private_dnat_rule.md
+++ b/docs/resources/nat_private_dnat_rule.md
@@ -1,0 +1,163 @@
+---
+subcategory: "NAT Gateway (NAT)"
+---
+
+# flexibleengine_nat_private_dnat_rule
+
+Manages a DNAT rule resource of the **private** NAT within FlexibleEngine.
+
+## Example Usage
+
+### DNAT rules forwarded with ECS instance as the backend
+
+```hcl
+variable "gateway_id" {}
+variable "transit_ip_id" {}
+
+resource "flexibleengine_compute_instance_v2" "test" {
+  ...
+}
+
+resource "flexibleengine_nat_private_dnat_rule" "test" {
+  gateway_id            = var.gateway_id
+  protocol              = "tcp"
+  transit_ip_id         = var.transit_ip_id
+  transit_service_port  = 1000
+  backend_interface_id  = flexibleengine_compute_instance_v2.test.network[0].port
+  internal_service_port = 2000
+}
+```
+
+### DNAT rules forwarded with ELB loadbalancer as the backend
+
+```hcl
+variable "network_id" {}
+variable "gateway_id" {}
+variable "transit_ip_id" {}
+
+resource "flexibleengine_lb_loadbalancer_v3" "test" {
+  ...
+}
+
+data "flexibleengine_networking_port" "test" {
+  network_id = var.network_id
+  fixed_ip   = flexibleengine_lb_loadbalancer_v3.test.ipv4_address
+}
+
+resource "flexibleengine_nat_private_dnat_rule" "test" {
+  gateway_id            = var.gateway_id
+  protocol              = "tcp"
+  transit_ip_id         = var.transit_ip_id
+  transit_service_port  = 1000
+  backend_interface_id  = data.flexibleengine_networking_port.test.id
+  internal_service_port = 2000
+}
+```
+
+### DNAT rules forwarded with VIP as the backend
+
+```hcl
+variable "network_id" {}
+variable "gateway_id" {}
+variable "transit_ip_id" {}
+
+resource "flexibleengine_networking_vip_v2" "test" {
+  network_id = var.network_id
+}
+
+resource "flexibleengine_nat_private_dnat_rule" "test" {
+  gateway_id            = var.gateway_id
+  protocol              = "tcp"
+  transit_ip_id         = var.transit_ip_id
+  transit_service_port  = 1000
+  backend_interface_id  = flexibleengine_networking_vip_v2.test.id
+  internal_service_port = 2000
+}
+```
+
+### DNAT rules forwarded with a custom private IP address as the backend
+
+```hcl
+variable "gateway_id" {}
+variable "transit_ip_id" {}
+
+resource "flexibleengine_nat_private_dnat_rule" "test" {
+  gateway_id            = var.gateway_id
+  protocol              = "tcp"
+  transit_ip_id         = var.transit_ip_id
+  transit_service_port  = 1000
+  backend_private_ip    = "172.168.0.69"
+  internal_service_port = 2000
+}
+```
+
+### DNAT rules for all ports
+
+```hcl
+variable "gateway_id" {}
+variable "transit_ip_id" {}
+
+resource "flexibleengine_nat_private_dnat_rule" "test" {
+  gateway_id         = var.gateway_id
+  protocol           = "any"
+  transit_ip_id      = var.transit_ip_id
+  backend_private_ip = "172.168.0.69"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the DNAT rule is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `gateway_id` - (Required, String, ForceNew) Specifies the private NAT gateway ID to which the DNAT rule belongs.  
+  Changing this will create a new resource.
+
+* `transit_ip_id` - (Required, String) Specifies the ID of the transit IP for private NAT.
+
+* `transit_service_port` - (Optional, Int) Specifies the port of the transit IP.  
+
+-> Defaults to `0` and the default port is only available for rules with the protocol **any**.
+
+* `protocol` - (Optional, String) Specifies the protocol type.  
+  The valid values are **tcp**, **udp** and **any**. Defaults to **any**.
+
+* `backend_interface_id` - (Optional, String) Specifies the network interface ID of the transit IP for private NAT.  
+  Exactly one of `backend_interface_id` and `backend_private_ip` must be set.
+
+* `backend_private_ip` - (Optional, String) Specifies the private IP address of the backend instance.
+
+* `internal_service_port` - (Optional, Int) Specifies the port of the backend instance.
+
+-> Defaults to `0` and the default port is only available for rules with the protocol **any**.
+
+* `description` - (Optional, String) Specifies the description of the DNAT rule, which contain maximum of `255`
+  characters, and angle brackets (< and >) are not allowed.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `backend_type` - The type of backend instance.
+  The valid values are as follows:
+  + **COMPUTE**: ECS instance.
+  + **VIP**: VIP.
+  + **ELB**: ELB loadbalancer.
+  + **ELBv3**: ver.3 ELB loadbalancer.
+  + **CUSTOMIZE**: custom backend IP address.
+
+* `created_at` - The creation time of the DNAT rule.
+
+* `updated_at` - The latest update time of the DNAT rule.
+
+## Import
+
+DNAT rules can be imported using their `id`, e.g.
+
+```bash
+terraform import flexibleengine_nat_private_dnat_rule.test 19e3f4ed-fde0-406a-828d-7e0482400da9
+```

--- a/docs/resources/nat_private_gateway.md
+++ b/docs/resources/nat_private_gateway.md
@@ -1,0 +1,79 @@
+---
+subcategory: "NAT Gateway (NAT)"
+---
+
+# flexibleengine_nat_private_gateway
+
+Manages a gateway resource of the **private** NAT within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+variable "subnet_id" {}
+variable "gateway_name" {}
+
+resource "flexibleengine_nat_private_gateway" "test" {
+  subnet_id             = var.subnet_id
+  name                  = var.gateway_name
+  spec                  = "Small"
+  description           = "Created by terraform script"
+  enterprise_project_id = "0"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the private NAT gateway is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `subnet_id` - (Required, String, ForceNew) Specifies the network ID of the subnet to which the private NAT gateway
+  belongs.  
+  Changing this will create a new resource.
+
+* `name` - (Required, String) Specifies the private NAT gateway name.  
+  The valid length is limited from `1` to `64`, only English letters, Chinese characters, digits, hyphens (-) and
+  underscores (_) are allowed.
+
+* `spec` - (Optional, String) Specifies the specification of the private NAT gateway.  
+  The valid values are as follows:
+  + **Small**: Small type, which supports up to `20` rules, `200 Mbit/s` bandwidth, `20,000` PPS and `2,000` SNAT
+    connections.
+  + **Medium**: Medium type, which supports up to `50` rules, `500 Mbit/s` bandwidth, `50,000` PPS and `5,000` SNAT
+    connections.
+  + **Large**: Large type, which supports up to `200` rules, `2 Gbit/s` bandwidth, `200,000` PPS and `20,000` SNAT
+    connections.
+  + **Extra-Large**: Extra-large type, which supports up to `500` rules, `5 Gbit/s` bandwidth, `500,000` PPS and
+    `50,000` SNAT connections.
+
+  Defaults to **Small**.
+
+* `description` - (Optional, String) Specifies the description of the private NAT gateway, which contain maximum of
+  `255` characters, and angle brackets (< and >) are not allowed.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the ID of the enterprise project to which the private
+  NAT gateway belongs.  
+  Changing this will create a new resource.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the private NAT geteway.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `created_at` - The creation time of the private NAT gateway.
+
+* `updated_at` - The latest update time of the private NAT gateway.
+
+* `status` - The current status of the private NAT gateway.
+
+## Import
+
+The private NAT gateways can be imported using their `id`, e.g.
+
+```bash
+terraform import flexibleengine_nat_private_gateway.test 13d9d015-9d6f-483d-882d-d996cdf2c1d0
+```

--- a/docs/resources/nat_private_snat_rule.md
+++ b/docs/resources/nat_private_snat_rule.md
@@ -1,0 +1,80 @@
+---
+subcategory: "NAT Gateway (NAT)"
+---
+
+# flexibleengine_nat_private_snat_rule
+
+Manages an SNAT rule resource of the **private** NAT within FlexibleEngine.
+
+## Example Usage
+
+### Create an SNAT rule via subnet ID
+
+```hcl
+variable "gateway_id" {}
+variable "transit_ip_id" {}
+variable "subnet_id" {}
+
+resource "flexibleengine_nat_private_snat_rule" "test" {
+  gateway_id    = var.gateway_id
+  transit_ip_id = var.transit_ip_id
+  subnet_id     = var.subnet_id
+}
+```
+
+### Create an SNAT rule via CIDR
+
+```hcl
+variable "gateway_id" {}
+variable "transit_ip_id" {}
+variable "cidr_block" {}
+
+resource "flexibleengine_nat_private_snat_rule" "test" {
+  gateway_id    = var.gateway_id
+  transit_ip_id = var.transit_ip_id
+  cidr          = var.cidr_block
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the SNAT rule is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `gateway_id` - (Required, String, ForceNew) Specifies the private NAT gateway ID to which the SNAT rule belongs.  
+  Changing this will create a new resource.
+
+* `transit_ip_id` - (Required, String) Specifies the ID of the transit IP associated with SNAT rule.
+
+* `cidr` - (Optional, String, ForceNew) Specifies the CIDR block of the match rule.  
+  Changing this will create a new resource.  
+  Exactly one of `cidr` and `subnet_id` must be set.
+
+-> SNAT rules under the same private NAT gateway cannot have the same CIDR, but they can be proper subsets of other
+   CIDRs.
+
+* `subnet_id` - (Optional, String, ForceNew) Specifies the subnet ID of the match rule.  
+  Changing this will create a new resource.
+
+* `description` - (Optional, String) Specifies the description of the SNAT rule, which contain maximum of `255`
+  characters, and angle brackets (< and >) are not allowed.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `created_at` - The creation time of the SNAT rule.
+
+* `updated_at` - The latest update time of the SNAT rule.
+
+## Import
+
+SNAT rules can be imported using their `id`, e.g.
+
+```bash
+terraform import flexibleengine_nat_private_snat_rule.test df9b61e9-79c1-4a75-bfab-736e224ced71
+```

--- a/docs/resources/nat_private_transit_ip.md
+++ b/docs/resources/nat_private_transit_ip.md
@@ -1,0 +1,66 @@
+---
+subcategory: "NAT Gateway (NAT)"
+---
+
+# flexibleengine_nat_private_transit_ip
+
+Manages a transit IP resource of the **private** NAT within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+variable "subnet_id" {}
+variable "ipv4_address" {}
+variable "enterprise_project_id" {}
+
+resource "flexibleengine_nat_private_transit_ip" "test" {
+  subnet_id             = var.subnet_id
+  ip_address            = var.ipv4_address
+  enterprise_project_id = var.enterprise_project_id
+
+  tags = {
+    foo = "bar"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region where the transit IP is located.  
+  If omitted, the provider-level region will be used. Changing this will create a new resource.
+
+* `subnet_id` - (Required, String, ForceNew) Specifies the transit subnet ID to which the transit IP belongs.  
+  Changing this will create a new resource.
+
+* `ip_address` - (Optional, String, ForceNew) Specifies the IP address of the transit subnet.  
+  Changing this will create a new resource.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the ID of the enterprise project to which the transit
+  IP belongs.  
+  Changing this will create a new resource.
+
+* `tags` - (Optional, Map) Specifies the key/value pairs to associate with the transit IP.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID in UUID format.
+
+* `network_interface_id` - The network interface ID of the transit IP for private NAT.
+
+* `gateway_id` - The ID of the private NAT gateway to which the transit IP belongs.
+
+* `created_at` - The creation time of the transit IP for private NAT.
+
+* `updated_at` - The latest update time of the transit IP for private NAT.
+
+## Import
+
+Transit IPs can be imported using their `id`, e.g.
+
+```bash
+terraform import flexibleengine_nat_private_transit_ip.test 5a1d921c-1df5-477d-8481-317b3fb47b5d
+```

--- a/flexibleengine/acceptance/common.go
+++ b/flexibleengine/acceptance/common.go
@@ -1,0 +1,62 @@
+package acceptance
+
+import "fmt"
+
+// testSecGroup can be referred as `flexibleengine_networking_secgroup_v2.test`
+func testSecGroup(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_networking_secgroup_v2" "test" {
+  name                 = "%s"
+  delete_default_rules = true
+}
+`, name)
+}
+
+// testVpc can be referred as `flexibleengine_vpc_v1.test` and `flexibleengine_vpc_subnet_v1.test`
+func testVpc(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc_v1" "test" {
+  name = "%[1]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test" {
+  name       = "%[1]s"
+  vpc_id     = flexibleengine_vpc_v1.test.id
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+}
+`, name)
+}
+
+// testBaseNetwork vpc, subnet, security group
+func testBaseNetwork(name string) string {
+	return fmt.Sprintf(`
+# base security group without default rules
+%s
+
+# base vpc and subnet
+%s
+`, testSecGroup(name), testVpc(name))
+}
+
+// testBaseComputeResources vpc, subnet, security group, availability zone, keypair, image, flavor
+func testBaseComputeResources(name string) string {
+	return fmt.Sprintf(`
+# base test resources
+%s
+
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_compute_flavors_v2" "test" {
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core          = 2
+  memory_size       = 4
+}
+
+data "flexibleengine_images_image" "test" {
+  name = "OBS Ubuntu 18.04"
+}
+`, testBaseNetwork(name))
+}

--- a/flexibleengine/acceptance/data_source_flexibleengine_images_image_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_images_image_test.go
@@ -115,27 +115,6 @@ data "flexibleengine_images_image" "test" {
 `, osVersion)
 }
 
-func testBaseNetwork(rName string) string {
-	return fmt.Sprintf(`
-resource "flexibleengine_vpc_v1" "test" {
-  name = "%[1]s"
-  cidr = "192.168.0.0/16"
-}
-
-resource "flexibleengine_vpc_subnet_v1" "test" {
-  name       = "%[1]s"
-  vpc_id     = flexibleengine_vpc_v1.test.id
-  cidr       = "192.168.0.0/24"
-  gateway_ip = "192.168.0.1"
-}
-
-resource "flexibleengine_networking_secgroup_v2" "test" {
-  name                 = "%[1]s"
-  delete_default_rules = true
-}
-`, rName)
-}
-
 func testAccImsImageDataSource_base(rName string) string {
 	return fmt.Sprintf(`
 %[1]s

--- a/flexibleengine/acceptance/resource_flexibleengine_nat_private_dnat_rule_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_nat_private_dnat_rule_test.go
@@ -1,0 +1,760 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/nat/v3/dnats"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getPrivateDnatRuleResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NatV3Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating NAT v3 client: %s", err)
+	}
+
+	return dnats.Get(client, state.Primary.ID)
+}
+
+// The backend forwarding object is the ECS instance.
+func TestAccPrivateDnatRule_basic(t *testing.T) {
+	var (
+		obj dnats.Rule
+
+		rName = "flexibleengine_nat_private_dnat_rule.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPrivateDnatRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateDnatRule_basic_step_1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "gateway_id",
+						"flexibleengine_nat_private_gateway.test", "id"),
+					resource.TestCheckResourceAttr(rName, "protocol", "tcp"),
+					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
+						"flexibleengine_nat_private_transit_ip.test", "id"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "1000"),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttrPair(rName, "backend_interface_id",
+						"flexibleengine_compute_instance_v2.test", "network.0.port"),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "2000"),
+					resource.TestCheckResourceAttrSet(rName, "backend_type"),
+				),
+			},
+			{
+				Config: testAccPrivateDnatRule_basic_step_2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "protocol", "udp"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "3000"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "4000"),
+				),
+			},
+			{
+				// Check the ports of internal service and transit service.
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPrivateDnatRule_basic_step_3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "protocol", "any"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "0"),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "0"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The ports of internal service and transit service are both empty, ignore import check for them.
+				ImportStateVerifyIgnore: []string{
+					"internal_service_port",
+					"transit_service_port",
+				},
+			},
+		},
+	})
+}
+
+func testAccPrivateDnatRule_transitIpConfig(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc_v1" "transit_ip_used" {
+  name = "%[1]s-transit-ip"
+  cidr = "172.16.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "transit_ip_used" {
+  vpc_id     = flexibleengine_vpc_v1.transit_ip_used.id
+  name       = "%[1]s-transit-ip"
+  cidr       = cidrsubnet(flexibleengine_vpc_v1.transit_ip_used.cidr, 4, 1)
+  gateway_ip = cidrhost(cidrsubnet(flexibleengine_vpc_v1.transit_ip_used.cidr, 4, 1), 1)
+}
+
+resource "flexibleengine_nat_private_transit_ip" "test" {
+  subnet_id             = flexibleengine_vpc_subnet_v1.transit_ip_used.id
+  enterprise_project_id = "0"
+}
+`, name)
+}
+
+func testAccPrivateDnatRule_ecsPart(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_compute_instance_v2" "test" {
+  name              = "%[2]s"
+  flavor_id         = data.flexibleengine_compute_flavors_v2.test.flavors[0]
+  image_id          = data.flexibleengine_images_image.test.id
+  security_groups   = [flexibleengine_networking_secgroup_v2.test.name]
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+  admin_pass        = "Test@123"
+
+  network {
+    uuid = flexibleengine_vpc_subnet_v1.test.id
+  }
+
+  tags = {
+    foo = "bar"
+  }
+}
+
+resource "flexibleengine_nat_private_gateway" "test" {
+  subnet_id             = flexibleengine_vpc_subnet_v1.test.id
+  name                  = "%[2]s"
+  enterprise_project_id = "0"
+}
+`, testBaseComputeResources(name), name)
+}
+
+func testAccPrivateDnatRule_basic_step_1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "flexibleengine_nat_private_dnat_rule" "test" {
+  gateway_id            = flexibleengine_nat_private_gateway.test.id
+  protocol              = "tcp"
+  description           = "Created by acc test"
+  transit_ip_id         = flexibleengine_nat_private_transit_ip.test.id
+  transit_service_port  = 1000
+  backend_interface_id  = flexibleengine_compute_instance_v2.test.network[0].port
+  internal_service_port = 2000
+}
+`, testAccPrivateDnatRule_ecsPart(name), testAccPrivateDnatRule_transitIpConfig(name))
+}
+
+func testAccPrivateDnatRule_basic_step_2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "flexibleengine_nat_private_dnat_rule" "test" {
+  gateway_id            = flexibleengine_nat_private_gateway.test.id
+  protocol              = "udp"
+  transit_ip_id         = flexibleengine_nat_private_transit_ip.test.id
+  transit_service_port  = 3000
+  backend_interface_id  = flexibleengine_compute_instance_v2.test.network[0].port
+  internal_service_port = 4000
+}
+`, testAccPrivateDnatRule_ecsPart(name), testAccPrivateDnatRule_transitIpConfig(name))
+}
+
+func testAccPrivateDnatRule_basic_step_3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "flexibleengine_nat_private_dnat_rule" "test" {
+  gateway_id           = flexibleengine_nat_private_gateway.test.id
+  protocol             = "any"
+  transit_ip_id        = flexibleengine_nat_private_transit_ip.test.id
+  backend_interface_id = flexibleengine_compute_instance_v2.test.network[0].port
+}
+`, testAccPrivateDnatRule_ecsPart(name), testAccPrivateDnatRule_transitIpConfig(name))
+}
+
+// The backend forwarding object is the ELB loadbalancer.
+func TestAccPrivateDnatRule_elbBackend(t *testing.T) {
+	var (
+		obj dnats.Rule
+
+		rName = "flexibleengine_nat_private_dnat_rule.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPrivateDnatRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateDnatRule_elbBackend_step_1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "gateway_id",
+						"flexibleengine_nat_private_gateway.test", "id"),
+					resource.TestCheckResourceAttr(rName, "protocol", "tcp"),
+					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
+						"flexibleengine_nat_private_transit_ip.test", "id"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "1000"),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttrPair(rName, "backend_interface_id",
+						"data.flexibleengine_networking_port.test", "id"),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "2000"),
+				),
+			},
+			{
+				Config: testAccPrivateDnatRule_elbBackend_step_2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "protocol", "udp"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "3000"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "4000"),
+				),
+			},
+			{
+				// Check the ports of internal service and transit service.
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPrivateDnatRule_elbBackend_step_3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "protocol", "any"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "0"),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "0"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The ports of internal service and transit service are both empty, ignore import check for them.
+				ImportStateVerifyIgnore: []string{
+					"internal_service_port",
+					"transit_service_port",
+				},
+			},
+		},
+	})
+}
+
+func testAccPrivateDnatRule_elbBackend_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "flexibleengine_network_acl" "test" {
+  name = "%[3]s"
+
+  subnets = [
+    flexibleengine_vpc_subnet_v1.test.id
+  ]
+
+  inbound_rules = [
+    flexibleengine_network_acl_rule.test.id
+  ]
+}
+
+resource "flexibleengine_network_acl_rule" "test" {
+  name                   = "%[3]s"
+  protocol               = "tcp"
+  action                 = "allow"
+  source_ip_address      = flexibleengine_vpc_v1.test.cidr
+  source_port            = "8080"
+  destination_ip_address = "0.0.0.0/0"
+  destination_port       = "8081"
+}
+
+resource "flexibleengine_networking_secgroup_rule_v2" "in_v4_icmp_all" {
+  security_group_id = flexibleengine_networking_secgroup_v2.test.id
+  ethertype         = "IPv4"
+  direction         = "ingress"
+  protocol          = "icmp"
+  remote_ip_prefix  = "0.0.0.0/0"
+}
+
+resource "flexibleengine_networking_secgroup_rule_v2" "in_v4_elb_member_1" {
+  security_group_id = flexibleengine_networking_secgroup_v2.test.id
+  ethertype         = "IPv4"
+  direction         = "ingress"
+  protocol          = "tcp"
+  port_range_min    = 80
+  port_range_max    = 80
+  remote_ip_prefix  = flexibleengine_vpc_v1.test.cidr
+}
+
+resource "flexibleengine_networking_secgroup_rule_v2" "in_v4_elb_member_2" {
+  security_group_id = flexibleengine_networking_secgroup_v2.test.id
+  ethertype         = "IPv4"
+  direction         = "ingress"
+  protocol          = "tcp"
+  port_range_min    = 8081
+  port_range_max    = 8081
+  remote_ip_prefix  = flexibleengine_vpc_v1.test.cidr
+}
+
+resource "flexibleengine_networking_secgroup_rule_v2" "in_v4_all_group" {
+  security_group_id = flexibleengine_networking_secgroup_v2.test.id
+  ethertype         = "IPv4"
+  direction         = "ingress"
+  remote_group_id   = flexibleengine_networking_secgroup_v2.test.id
+}
+
+resource "flexibleengine_networking_secgroup_rule_v2" "out_v4_all" {
+  security_group_id = flexibleengine_networking_secgroup_v2.test.id
+  ethertype         = "IPv4"
+  direction         = "egress"
+  remote_ip_prefix  = "0.0.0.0/0"
+}
+
+resource "flexibleengine_vpc_eip" "test" {
+  publicip {
+    type = "5_bgp"
+  }
+
+  bandwidth {
+    name        = "%[3]s"
+    size        = 5
+    share_type  = "PER"
+    charge_mode = "traffic"
+  }
+}
+
+resource "flexibleengine_compute_floatingip_associate_v2" "test" {
+  floating_ip = flexibleengine_vpc_eip.test.address
+  instance_id = flexibleengine_compute_instance_v2.test.id
+}
+
+resource "flexibleengine_lb_loadbalancer_v3" "test" {
+  name           = "%[3]s"
+  vpc_id         = flexibleengine_vpc_v1.test.id
+  ipv4_subnet_id = flexibleengine_vpc_subnet_v1.test.subnet_id
+
+  availability_zone = [
+    data.flexibleengine_availability_zones.test.names[0]
+  ]
+}
+
+resource "flexibleengine_lb_listener_v3" "test" {
+  name            = "%[3]s"
+  protocol        = "HTTP"
+  protocol_port   = 8080
+  loadbalancer_id = flexibleengine_lb_loadbalancer_v3.test.id
+
+  idle_timeout     = 60
+  request_timeout  = 60
+  response_timeout = 60
+}
+
+resource "flexibleengine_lb_pool_v3" "test" {
+  protocol    = "HTTP"
+  lb_method   = "ROUND_ROBIN"
+  listener_id = flexibleengine_lb_listener_v3.test.id
+
+  persistence {
+    type = "HTTP_COOKIE"
+  }
+}
+
+resource "flexibleengine_lb_monitor_v3" "test" {
+  protocol    = "HTTP"
+  interval    = 20
+  timeout     = 15
+  max_retries = 10
+  url_path    = "/"
+  port        = 8080
+  pool_id     = flexibleengine_lb_pool_v3.test.id
+}
+
+resource "flexibleengine_lb_member_v3" "test" {
+  address       = flexibleengine_compute_instance_v2.test.access_ip_v4
+  protocol_port = 8080
+  pool_id       = flexibleengine_lb_pool_v3.test.id
+  subnet_id     = flexibleengine_vpc_subnet_v1.test.subnet_id
+}
+
+data "flexibleengine_networking_port" "test" {
+  network_id = flexibleengine_vpc_subnet_v1.test.id
+  fixed_ip   = flexibleengine_lb_loadbalancer_v3.test.ipv4_address
+}
+`, testAccPrivateDnatRule_ecsPart(name), testAccPrivateDnatRule_transitIpConfig(name), name)
+}
+
+func testAccPrivateDnatRule_elbBackend_step_1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_nat_private_dnat_rule" "test" {
+  gateway_id            = flexibleengine_nat_private_gateway.test.id
+  protocol              = "tcp"
+  description           = "Created by acc test"
+  transit_ip_id         = flexibleengine_nat_private_transit_ip.test.id
+  transit_service_port  = 1000
+  backend_interface_id  = data.flexibleengine_networking_port.test.id
+  internal_service_port = 2000
+}
+`, testAccPrivateDnatRule_elbBackend_base(name))
+}
+
+func testAccPrivateDnatRule_elbBackend_step_2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_nat_private_dnat_rule" "test" {
+  gateway_id            = flexibleengine_nat_private_gateway.test.id
+  protocol              = "udp"
+  transit_ip_id         = flexibleengine_nat_private_transit_ip.test.id
+  transit_service_port  = 3000
+  backend_interface_id  = data.flexibleengine_networking_port.test.id
+  internal_service_port = 4000
+}
+`, testAccPrivateDnatRule_elbBackend_base(name))
+}
+
+func testAccPrivateDnatRule_elbBackend_step_3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_nat_private_dnat_rule" "test" {
+  gateway_id           = flexibleengine_nat_private_gateway.test.id
+  protocol             = "any"
+  transit_ip_id        = flexibleengine_nat_private_transit_ip.test.id
+  backend_interface_id = data.flexibleengine_networking_port.test.id
+}
+`, testAccPrivateDnatRule_elbBackend_base(name))
+}
+
+// The backend forwarding object is the VIP.
+func TestAccPrivateDnatRule_vipBackend(t *testing.T) {
+	var (
+		obj dnats.Rule
+
+		rName = "flexibleengine_nat_private_dnat_rule.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPrivateDnatRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateDnatRule_vipBackend_step_1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "gateway_id",
+						"flexibleengine_nat_private_gateway.test", "id"),
+					resource.TestCheckResourceAttr(rName, "protocol", "tcp"),
+					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
+						"flexibleengine_nat_private_transit_ip.test", "id"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "1000"),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttrPair(rName, "backend_interface_id",
+						"flexibleengine_networking_vip_v2.test", "id"),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "2000"),
+				),
+			},
+			{
+				Config: testAccPrivateDnatRule_vipBackend_step_2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "protocol", "udp"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "3000"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "4000"),
+				),
+			},
+			{
+				// Check the ports of internal service and transit service.
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPrivateDnatRule_vipBackend_step_3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "protocol", "any"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "0"),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "0"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The ports of internal service and transit service are both empty, ignore import check for them.
+				ImportStateVerifyIgnore: []string{
+					"internal_service_port",
+					"transit_service_port",
+				},
+			},
+		},
+	})
+}
+
+func testAccPrivateDnatRule_vipBackend_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "flexibleengine_nat_private_gateway" "test" {
+  subnet_id             = flexibleengine_vpc_subnet_v1.test.id
+  name                  = "%[3]s"
+  enterprise_project_id = "0"
+}
+
+resource "flexibleengine_networking_vip_v2" "test" {
+  network_id = flexibleengine_vpc_subnet_v1.test.id
+}
+`, testBaseNetwork(name), testAccPrivateDnatRule_transitIpConfig(name), name)
+}
+
+func testAccPrivateDnatRule_vipBackend_step_1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_nat_private_dnat_rule" "test" {
+  gateway_id            = flexibleengine_nat_private_gateway.test.id
+  transit_ip_id         = flexibleengine_nat_private_transit_ip.test.id
+  protocol              = "tcp"
+  description           = "Created by acc test"
+  transit_service_port  = 1000
+  backend_interface_id  = flexibleengine_networking_vip_v2.test.id
+  internal_service_port = 2000
+}
+
+`, testAccPrivateDnatRule_vipBackend_base(name))
+}
+
+func testAccPrivateDnatRule_vipBackend_step_2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_nat_private_dnat_rule" "test" {
+  gateway_id            = flexibleengine_nat_private_gateway.test.id
+  transit_ip_id         = flexibleengine_nat_private_transit_ip.test.id
+  protocol              = "udp"
+  transit_service_port  = 3000
+  backend_interface_id  = flexibleengine_networking_vip_v2.test.id
+  internal_service_port = 4000
+}
+`, testAccPrivateDnatRule_vipBackend_base(name))
+}
+
+func testAccPrivateDnatRule_vipBackend_step_3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_nat_private_dnat_rule" "test" {
+  gateway_id           = flexibleengine_nat_private_gateway.test.id
+  transit_ip_id        = flexibleengine_nat_private_transit_ip.test.id
+  protocol             = "any"
+  backend_interface_id = flexibleengine_networking_vip_v2.test.id
+}
+`, testAccPrivateDnatRule_vipBackend_base(name))
+}
+
+func TestAccPrivateDnatRule_customIpAddress(t *testing.T) {
+	var (
+		obj dnats.Rule
+
+		rName = "flexibleengine_nat_private_dnat_rule.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPrivateDnatRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateDnatRule_customIpAddress_step_1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "gateway_id",
+						"flexibleengine_nat_private_gateway.test", "id"),
+					resource.TestCheckResourceAttr(rName, "protocol", "any"),
+					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
+						"flexibleengine_nat_private_transit_ip.test", "id"),
+				),
+			},
+			{
+				Config: testAccPrivateDnatRule_customIpAddress_step_2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "protocol", "tcp"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "1000"),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttr(rName, "backend_private_ip", "172.168.0.69"),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "2000"),
+				),
+			},
+			{
+				Config: testAccPrivateDnatRule_customIpAddress_step_3(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "protocol", "udp"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "3000"),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "backend_private_ip", "172.168.0.79"),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "4000"),
+				),
+			},
+			{
+				// Check the ports of internal service and transit service.
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccPrivateDnatRule_customIpAddress_step_4(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "protocol", "any"),
+					resource.TestCheckResourceAttr(rName, "transit_service_port", "0"),
+					resource.TestCheckResourceAttr(rName, "internal_service_port", "0"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The ports of internal service and transit service are both empty, ignore import check for them.
+				ImportStateVerifyIgnore: []string{
+					"internal_service_port",
+					"transit_service_port",
+				},
+			},
+		},
+	})
+}
+
+func testAccPrivateDnatRule_customIpAddress_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "flexibleengine_nat_private_gateway" "test" {
+  subnet_id             = flexibleengine_vpc_subnet_v1.test.id
+  name                  = "%[3]s"
+  enterprise_project_id = "0"
+}
+
+`, testBaseNetwork(name), testAccPrivateDnatRule_transitIpConfig(name), name)
+}
+
+// Default protocol 'any'
+func testAccPrivateDnatRule_customIpAddress_step_1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_nat_private_dnat_rule" "test" {
+  gateway_id         = flexibleengine_nat_private_gateway.test.id
+  transit_ip_id      = flexibleengine_nat_private_transit_ip.test.id
+  backend_private_ip = "172.168.0.69"
+}
+`, testAccPrivateDnatRule_customIpAddress_base(name))
+}
+
+func testAccPrivateDnatRule_customIpAddress_step_2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_nat_private_dnat_rule" "test" {
+  gateway_id            = flexibleengine_nat_private_gateway.test.id
+  transit_ip_id         = flexibleengine_nat_private_transit_ip.test.id
+  protocol              = "tcp"
+  description           = "Created by acc test"
+  transit_service_port  = 1000
+  backend_private_ip    = "172.168.0.69"
+  internal_service_port = 2000
+}
+`, testAccPrivateDnatRule_customIpAddress_base(name))
+}
+
+func testAccPrivateDnatRule_customIpAddress_step_3(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_nat_private_dnat_rule" "test" {
+  gateway_id            = flexibleengine_nat_private_gateway.test.id
+  transit_ip_id         = flexibleengine_nat_private_transit_ip.test.id
+  protocol              = "udp"
+  transit_service_port  = 3000
+  backend_private_ip    = "172.168.0.79"
+  internal_service_port = 4000
+}
+`, testAccPrivateDnatRule_customIpAddress_base(name))
+}
+
+func testAccPrivateDnatRule_customIpAddress_step_4(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_nat_private_dnat_rule" "test" {
+  gateway_id         = flexibleengine_nat_private_gateway.test.id
+  transit_ip_id      = flexibleengine_nat_private_transit_ip.test.id
+  protocol           = "any"
+  backend_private_ip = "172.168.0.79"
+}
+`, testAccPrivateDnatRule_customIpAddress_base(name))
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_nat_private_gateway_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_nat_private_gateway_test.go
@@ -1,0 +1,116 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/nat/v3/gateways"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/nat"
+)
+
+func getPrivateGatewayResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NatV3Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating NAT v3 client: %s", err)
+	}
+
+	return gateways.Get(client, state.Primary.ID)
+}
+
+func TestAccPrivateGateway_basic(t *testing.T) {
+	var (
+		obj gateways.Gateway
+
+		rName      = "flexibleengine_nat_private_gateway.test"
+		name       = acceptance.RandomAccResourceNameWithDash()
+		updateName = acceptance.RandomAccResourceNameWithDash()
+		baseConfig = testBaseNetwork(name)
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPrivateGatewayResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateGateway_basic_step_1(name, baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "subnet_id", "flexibleengine_vpc_subnet_v1.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttr(rName, "spec", nat.PrivateSpecTypeSmall),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName, "tags.key", "value"),
+				),
+			},
+			{
+				Config: testAccPrivateGateway_basic_step_2(updateName, baseConfig),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "subnet_id", "flexibleengine_vpc_subnet_v1.test", "id"),
+					resource.TestCheckResourceAttr(rName, "name", updateName),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttr(rName, "status", "ACTIVE"),
+					resource.TestCheckResourceAttr(rName, "tags.foo", "baaar"),
+					resource.TestCheckResourceAttr(rName, "tags.newKey", "value"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccPrivateGateway_basic_step_1(name, relatedConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_nat_private_gateway" "test" {
+  subnet_id             = flexibleengine_vpc_subnet_v1.test.id
+  name                  = "%[2]s"
+  description           = "Created by acc test"
+  enterprise_project_id = "0"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, relatedConfig, name)
+}
+
+func testAccPrivateGateway_basic_step_2(name, relatedConfig string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_nat_private_gateway" "test" {
+  subnet_id             = flexibleengine_vpc_subnet_v1.test.id
+  name                  = "%[2]s"
+  enterprise_project_id = "0"
+
+  tags = {
+    foo    = "baaar"
+    newKey = "value"
+  }
+}
+`, relatedConfig, name)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_nat_private_snat_rule_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_nat_private_snat_rule_test.go
@@ -1,0 +1,217 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/nat/v3/snats"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getPrivateSnatRuleResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NatV3Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating NAT v3 client: %s", err)
+	}
+
+	return snats.Get(client, state.Primary.ID)
+}
+
+func TestAccPrivateSnatRule_basic(t *testing.T) {
+	var (
+		obj snats.Rule
+
+		rName = "flexibleengine_nat_private_snat_rule.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPrivateSnatRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateSnatRule_basic_step_1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "gateway_id",
+						"flexibleengine_nat_private_gateway.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
+						"flexibleengine_nat_private_transit_ip.test", "id"),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttrPair(rName, "subnet_id",
+						"flexibleengine_vpc_subnet_v1.test", "id"),
+				),
+			},
+			{
+				Config: testAccPrivateSnatRule_basic_step_2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
+						"flexibleengine_nat_private_transit_ip.standby", "id"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccPrivateSnatRule_transitIpConfig(name string) string {
+	return fmt.Sprintf(`
+resource "flexibleengine_vpc_v1" "transit_ip_used" {
+  name = "%[1]s-transit-ip"
+  cidr = "172.16.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "transit_ip_used" {
+  vpc_id     = flexibleengine_vpc_v1.transit_ip_used.id
+  name       = "%[1]s-transit-ip"
+  cidr       = cidrsubnet(flexibleengine_vpc_v1.transit_ip_used.cidr, 4, 1)
+  gateway_ip = cidrhost(cidrsubnet(flexibleengine_vpc_v1.transit_ip_used.cidr, 4, 1), 1)
+}
+
+resource "flexibleengine_nat_private_transit_ip" "test" {
+  subnet_id             = flexibleengine_vpc_subnet_v1.transit_ip_used.id
+  enterprise_project_id = "0"
+}
+
+resource "flexibleengine_nat_private_transit_ip" "standby" {
+  subnet_id             = flexibleengine_vpc_subnet_v1.transit_ip_used.id
+  enterprise_project_id = "0"
+}
+`, name)
+}
+
+func testAccPrivateSnatRule_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+%[2]s
+
+resource "flexibleengine_nat_private_gateway" "test" {
+  subnet_id             = flexibleengine_vpc_subnet_v1.test.id
+  name                  = "%[3]s"
+  enterprise_project_id = "0"
+}
+`, testBaseNetwork(name), testAccPrivateSnatRule_transitIpConfig(name), name)
+}
+
+func testAccPrivateSnatRule_basic_step_1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_nat_private_snat_rule" "test" {
+  gateway_id    = flexibleengine_nat_private_gateway.test.id
+  description   = "Created by acc test"
+  transit_ip_id = flexibleengine_nat_private_transit_ip.test.id
+  subnet_id     = flexibleengine_vpc_subnet_v1.test.id
+}
+`, testAccPrivateSnatRule_base(name))
+}
+
+func testAccPrivateSnatRule_basic_step_2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_nat_private_snat_rule" "test" {
+  gateway_id    = flexibleengine_nat_private_gateway.test.id
+  transit_ip_id = flexibleengine_nat_private_transit_ip.standby.id
+  subnet_id     = flexibleengine_vpc_subnet_v1.test.id
+}
+`, testAccPrivateSnatRule_base(name))
+}
+
+func TestAccPrivateSnatRule_cidr(t *testing.T) {
+	var (
+		obj snats.Rule
+
+		rName = "flexibleengine_nat_private_snat_rule.test"
+		name  = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getPrivateSnatRuleResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateSnatRule_cidr_step_1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "gateway_id",
+						"flexibleengine_nat_private_gateway.test", "id"),
+					resource.TestCheckResourceAttr(rName, "description", "Created by acc test"),
+					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
+						"flexibleengine_nat_private_transit_ip.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "cidr",
+						"flexibleengine_vpc_subnet_v1.test", "cidr"),
+				),
+			},
+			{
+				Config: testAccPrivateSnatRule_cidr_step_2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "description", ""),
+					resource.TestCheckResourceAttrPair(rName, "transit_ip_id",
+						"flexibleengine_nat_private_transit_ip.standby", "id"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccPrivateSnatRule_cidr_step_1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_nat_private_snat_rule" "test" {
+  gateway_id    = flexibleengine_nat_private_gateway.test.id
+  description   = "Created by acc test"
+  transit_ip_id = flexibleengine_nat_private_transit_ip.test.id
+  cidr          = flexibleengine_vpc_subnet_v1.test.cidr
+}
+`, testAccPrivateSnatRule_base(name))
+}
+
+func testAccPrivateSnatRule_cidr_step_2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_nat_private_snat_rule" "test" {
+  gateway_id    = flexibleengine_nat_private_gateway.test.id
+  transit_ip_id = flexibleengine_nat_private_transit_ip.standby.id
+  cidr          = flexibleengine_vpc_subnet_v1.test.cidr
+}
+`, testAccPrivateSnatRule_base(name))
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_nat_private_transit_ip_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_nat_private_transit_ip_test.go
@@ -1,0 +1,152 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/nat/v3/transitips"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func getPrivateTransitIpResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	client, err := cfg.NatV3Client(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating NAT v3 client: %s", err)
+	}
+
+	return transitips.Get(client, state.Primary.ID)
+}
+
+func TestAccPrivateTransitIp_basic(t *testing.T) {
+	var (
+		obj transitips.TransitIp
+
+		rName1 = "flexibleengine_nat_private_transit_ip.test"
+		rName2 = "flexibleengine_nat_private_transit_ip.random_ip_address"
+		name   = acceptance.RandomAccResourceNameWithDash()
+	)
+
+	rc1 := acceptance.InitResourceCheck(
+		rName1,
+		&obj,
+		getPrivateTransitIpResourceFunc,
+	)
+	rc2 := acceptance.InitResourceCheck(
+		rName2,
+		&obj,
+		getPrivateTransitIpResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc1.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPrivateTransitIp_basic_step_1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc1.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName1, "subnet_id",
+						"flexibleengine_vpc_subnet_v1.test", "id"),
+					resource.TestCheckResourceAttr(rName1, "ip_address", "192.168.0.68"),
+					resource.TestCheckResourceAttr(rName1, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(rName1, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName1, "tags.key", "value"),
+					resource.TestCheckResourceAttrSet(rName1, "created_at"),
+					resource.TestCheckResourceAttrSet(rName1, "updated_at"),
+					resource.TestCheckResourceAttrPair(rName2, "subnet_id",
+						"flexibleengine_vpc_subnet_v1.test", "id"),
+					resource.TestCheckResourceAttrSet(rName2, "ip_address"),
+					resource.TestCheckResourceAttr(rName2, "enterprise_project_id", "0"),
+					resource.TestCheckResourceAttr(rName2, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(rName2, "tags.key", "value"),
+					resource.TestCheckResourceAttrSet(rName2, "created_at"),
+					resource.TestCheckResourceAttrSet(rName2, "updated_at"),
+				),
+			},
+			{
+				Config: testAccPrivateTransitIp_basic_step_2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc1.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName1, "ip_address", "192.168.0.88"),
+					resource.TestCheckResourceAttr(rName1, "tags.foo", "baaar"),
+					resource.TestCheckResourceAttr(rName1, "tags.newkey", "value"),
+					rc2.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName2, "tags.foo", "baaar"),
+					resource.TestCheckResourceAttr(rName2, "tags.newkey", "value"),
+				),
+			},
+			{
+				ResourceName:      rName1,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      rName2,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccPrivateTransitIp_basic_step_1(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_nat_private_transit_ip" "test" {
+  subnet_id             = flexibleengine_vpc_subnet_v1.test.id
+  ip_address            = "192.168.0.68"
+  enterprise_project_id = "0"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+
+resource "flexibleengine_nat_private_transit_ip" "random_ip_address" {
+  subnet_id             = flexibleengine_vpc_subnet_v1.test.id
+  enterprise_project_id = "0"
+
+  tags = {
+    foo = "bar"
+    key = "value"
+  }
+}
+`, testBaseNetwork(name), name)
+}
+
+func testAccPrivateTransitIp_basic_step_2(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_nat_private_transit_ip" "test" {
+  subnet_id             = flexibleengine_vpc_subnet_v1.test.id
+  ip_address            = "192.168.0.88"
+  enterprise_project_id = "0"
+
+  tags = {
+    foo    = "baaar"
+    newkey = "value"
+  }
+}
+
+resource "flexibleengine_nat_private_transit_ip" "random_ip_address" {
+  subnet_id             = flexibleengine_vpc_subnet_v1.test.id
+  enterprise_project_id = "0"
+
+  tags = {
+    foo    = "baaar"
+    newkey = "value"
+  }
+}
+`, testBaseNetwork(name), name)
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -34,6 +34,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/ims"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/lb"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/modelarts"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/nat"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/obs"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/rds"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/sfs"
@@ -501,6 +502,11 @@ func Provider() *schema.Provider {
 			"flexibleengine_images_image_share_accepter": ims.ResourceImsImageShareAccepter(),
 
 			"flexibleengine_kms_grant": dew.ResourceKmsGrant(),
+
+			"flexibleengine_nat_private_dnat_rule":  nat.ResourcePrivateDnatRule(),
+			"flexibleengine_nat_private_gateway":    nat.ResourcePrivateGateway(),
+			"flexibleengine_nat_private_snat_rule":  nat.ResourcePrivateSnatRule(),
+			"flexibleengine_nat_private_transit_ip": nat.ResourcePrivateTransitIp(),
 
 			"flexibleengine_obs_bucket_acl": obs.ResourceOBSBucketAcl(),
 


### PR DESCRIPTION
add new resources:
1. flexibleengine_nat_private_dnat_rule
2. flexibleengine_nat_private_gateway
3. flexibleengine_nat_private_snat_rule
4. flexibleengine_nat_private_transit_ip

Test results:
```bash
make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccPrivateGateway_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccPrivateGateway_basic -timeout 720m
=== RUN   TestAccPrivateGateway_basic
=== PAUSE TestAccPrivateGateway_basic
=== CONT  TestAccPrivateGateway_basic
--- PASS: TestAccPrivateGateway_basic (90.01s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      90.059s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccPrivateDnatRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccPrivateDnatRule_basic -timeout 720m
=== RUN   TestAccPrivateDnatRule_basic
=== PAUSE TestAccPrivateDnatRule_basic
=== CONT  TestAccPrivateDnatRule_basic
--- PASS: TestAccPrivateDnatRule_basic (252.26s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      252.305s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccPrivateDnatRule_elbBackend'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccPrivateDnatRule_elbBackend -timeout 720m
=== RUN   TestAccPrivateDnatRule_elbBackend
=== PAUSE TestAccPrivateDnatRule_elbBackend
=== CONT  TestAccPrivateDnatRule_elbBackend
--- PASS: TestAccPrivateDnatRule_elbBackend (273.06s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      273.127s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccPrivateDnatRule_vipBackend'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccPrivateDnatRule_vipBackend -timeout 720m
=== RUN   TestAccPrivateDnatRule_vipBackend
=== PAUSE TestAccPrivateDnatRule_vipBackend
=== CONT  TestAccPrivateDnatRule_vipBackend
--- PASS: TestAccPrivateDnatRule_vipBackend (131.01s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      131.057s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccPrivateDnatRule_customIpAddress'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccPrivateDnatRule_customIpAddress -timeout 720m
=== RUN   TestAccPrivateDnatRule_customIpAddress
=== PAUSE TestAccPrivateDnatRule_customIpAddress
=== CONT  TestAccPrivateDnatRule_customIpAddress
--- PASS: TestAccPrivateDnatRule_customIpAddress (139.66s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      139.704s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccPrivateSnatRule_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccPrivateSnatRule_basic -timeout 720m
=== RUN   TestAccPrivateSnatRule_basic
=== PAUSE TestAccPrivateSnatRule_basic
=== CONT  TestAccPrivateSnatRule_basic
--- PASS: TestAccPrivateSnatRule_basic (94.56s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      94.612s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccPrivateSnatRule_cidr'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccPrivateSnatRule_cidr -timeout 720m
=== RUN   TestAccPrivateSnatRule_cidr
=== PAUSE TestAccPrivateSnatRule_cidr
=== CONT  TestAccPrivateSnatRule_cidr
--- PASS: TestAccPrivateSnatRule_cidr (93.45s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      93.499s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccPrivateTransitIp_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccPrivateTransitIp_basic -timeout 720m
=== RUN   TestAccPrivateTransitIp_basic
=== PAUSE TestAccPrivateTransitIp_basic
=== CONT  TestAccPrivateTransitIp_basic
--- PASS: TestAccPrivateTransitIp_basic (97.29s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      97.345s


```