### PR TITLE
fix: fix docs of APIG service.

### DIFF
--- a/docs/resources/api_gateway_api.md
+++ b/docs/resources/api_gateway_api.md
@@ -97,7 +97,7 @@ The following arguments are supported:
 The `http_backend` object supports the following:
 
 * `protocol` - (Required, String) Specifies the backend request protocol. The value can be 'HTTP' and 'HTTPS'.
-* `method` - (Optional, String) Specifies the backend request method, including 'GET','POST','PUT' and etc..
+* `method` - (Required, String) Specifies the backend request method, including 'GET','POST','PUT' and etc..
 * `uri` - (Required, String) Specifies the backend request path. The value must comply with URI specifications.
 * `vpc_channel` - (Optional, String) Specifies the VPC channel ID. This parameter and `url_domain` are alternative.
 * `url_domain` - (Optional, String) Specifies the backend service address. An endpoint URL is in the format of
@@ -110,7 +110,7 @@ The `function_backend` object supports the following:
 
 * `function_urn` - (Required, String) Specifies the function URN.
 * `invocation_type` - (Required, String) Specifies the invocation mode, which can be 'async' or 'sync'.
-* `version` - (Optional, String) Specifies the function version.
+* `version` - (Required, String) Specifies the function version.
 * `timeout` - (Optional, Int) Timeout duration (in ms) for API Gateway to request for FunctionGraph. Defaults to 50000.
 
 The `mock_backend` object supports the following:
@@ -126,7 +126,7 @@ The `request_parameter` object supports the following:
   with a letter. Only letters, digits, periods (.), hyphens (-), and underscores (_) are allowed.
 * `location` - (Required, String) Specifies the input parameter location, which can be 'PATH', 'QUERY' or 'HEADER'.
 * `type` - (Required, String) Specifies the input parameter type, which can be 'STRING' or 'NUMBER'.
-* `required` - (Optional, Bool) Specifies whether the parameter is mandatory or not.
+* `required` - (Required, Bool) Specifies whether the parameter is mandatory or not.
 * `default` - (Optional, String) Specifies the default value when the parameter is optional.
 * `description` - (Optional, String) Specifies the description of the parameter. The description cannot exceed 255
   characters.
@@ -146,7 +146,7 @@ The `backend_parameter` object supports the following:
 * `description` - (Optional, String) Specifies the description of the parameter. The description cannot exceed 255
   characters.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
@@ -157,8 +157,8 @@ In addition to all arguments above, the following attributes are exported:
 
 This resource provides the following timeouts configuration options:
 
-* `create` - Default is 10 minute.
-* `delete` - Default is 10 minute.
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/api_gateway_group.md
+++ b/docs/resources/api_gateway_group.md
@@ -30,12 +30,19 @@ The following arguments are supported:
 * `description` - (Optional, String) Specifies the description of the API group. The description cannot exceed 255
   characters.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the API group.
 * `status` - Status of the API group.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/apig_api.md
+++ b/docs/resources/apig_api.md
@@ -181,6 +181,9 @@ The `backend_params` block supports:
 * `description` - (Optional, String) Specifies the description of the constant or system parameter, which contain a
   maximum of 255 characters, and the angle brackets (< and >) are not allowed.
 
+* `system_param_type` - (Optional, String) Specifies the type of the system parameter.  
+  The valid values are **frontend**, **backend** and **internal**, defaults to **internal**.
+
 <a name="apig_api_mock"></a>
 The `mock` block supports:
 
@@ -356,13 +359,13 @@ The `conditions` block supports:
 * `type` - (Optional, String) Specifies the condition type of the backend policy. The valid values are **Equal**,
   **Enumerated** and **Matching**, default to **Equal**.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the APIG API.
-* `register_time` - Time when the API is registered, in UTC format.
-* `update_time` - Time when the API was last modified, in UTC format.
+* `registered_at` - Time when the API is registered, in UTC format.
+* `updated_at` - Time when the API was last modified, in UTC format.
 
 ## Import
 

--- a/docs/resources/apig_api_publishment.md
+++ b/docs/resources/apig_api_publishment.md
@@ -63,7 +63,7 @@ The following arguments are supported:
 
 * `version_id` - (Optional, String) Specifies the version ID of the current publishment.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
@@ -71,7 +71,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `env_name` - Environment name to which the current version of the API is published.
 
-* `publish_time` - Time when the current version was published.
+* `publish_at` - Time when the current version was published.
 
 * `histories` - All publish informations of the API. The structure is documented below.
 

--- a/docs/resources/apig_application.md
+++ b/docs/resources/apig_application.md
@@ -42,7 +42,7 @@ The following arguments are supported:
   maximum of 255 characters and the angle brackets (< and >) are not allowed. Chinese characters must be in UTF-8 or
   Unicode format.
 
-* `app_codes` - (Required, List) Specifies an array of one or more application codes which the APIG application belongs
+* `app_codes` - (Optional, List) Specifies an array of one or more application codes which the APIG application belongs
   to. Up to five application codes can be created. The code consists of 64 to 180 characters, starting with a letter,
   digit, plus sign (+) or slash (/). Only letters, digits and following special special characters are allowed: !@#$%+-_
   /=
@@ -52,13 +52,13 @@ The following arguments are supported:
 
   -> **NOTE:** The `secret_action` is a one-time action.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the APIG application.
-* `registraion_time` - Registration time, in RFC-3339 format.
-* `update_time` - Time when the API group was last modified, in RFC-3339 format.
+* `registration_time` - Registration time, in RFC-3339 format.
+* `update_at` - Time when the API group was last modified, in RFC-3339 format.
 * `app_key` - App key.
 * `app_secret` - App secret.
 

--- a/docs/resources/apig_custom_authorizer.md
+++ b/docs/resources/apig_custom_authorizer.md
@@ -41,27 +41,21 @@ The following arguments are supported:
   custom authorizer belongs to.
   Changing this will create a new custom authorizer resource.
 
-* `name` - (Required, String, ForceNew) Specifies the name of the custom authorizer.
+* `name` - (Required, String) Specifies the name of the custom authorizer.
   The custom authorizer name consists of 3 to 64 characters, starting with a letter.
   Only letters, digits and underscores (_) are allowed.
-  Changing this will create a new custom authorizer resource.
 
-* `type` - (Required, String, ForceNew) Specifies the custom authoriz type.
-  The valid values are *FRONTEND* and *BACKEND*.
-  Changing this will create a new custom authorizer resource.
+* `type` - (Optional, String, ForceNew) Specifies the custom authoriz type.
+  The valid values are *FRONTEND* and *BACKEND*. Changing this will create a new custom authorizer resource.
 
-* `function_urn` - (Required, String, ForceNew) Specifies the uniform function URN of the function graph resource.
-  Changing this will create a new custom authorizer resource.
+* `function_urn` - (Required, String) Specifies the uniform function URN of the function graph resource.
 
-* `is_body_send` - (Optional, Bool, ForceNew) Specifies whether to send the body.
-  Changing this will create a new custom authorizer resource.
+* `is_body_send` - (Optional, Bool) Specifies whether to send the body.
 
-* `cache_age` - (Optional, String) Specifies the maximum cache age.
-  Changing this will create a new custom authorizer resource.
+* `cache_age` - (Optional, Int) Specifies the maximum cache age.
 
-* `user_data` - (Optional, String, ForceNew) Specifies the user data, which can contain a maximum of 2,048 characters.
+* `user_data` - (Optional, String) Specifies the user data, which can contain a maximum of 2,048 characters.
   The user data is used by APIG to invoke the specified authentication function when accessing the backend service.
-  Changing this will create a new custom authorizer resource.
 
   -> **NOTE:** The user data will be displayed in plain text on the console.
 
@@ -70,24 +64,21 @@ The following arguments are supported:
 
 The `identity` block supports:
 
-* `name` - (Required, String, ForceNew) Specifies the name of the parameter to be verified.
+* `name` - (Required, String) Specifies the name of the parameter to be verified.
   The parameter includes front-end and back-end parameters.
-  Changing this will create a new custom authorizer resource.
 
-* `location` - (Required, String, ForceNew) Specifies the parameter location, which support 'HEADER' and 'QUERY'.
-  Changing this will create a new custom authorizer resource.
+* `location` - (Required, String) Specifies the parameter location, which support 'HEADER' and 'QUERY'.
 
-* `validation` - (Required, String, ForceNew) Specifies the parameter verification expression.
+* `validation` - (Optional, String) Specifies the parameter verification expression.
   If omitted, the custom authorizer will not perform verification.
   The valid value is range form 1 to 2,048.
-  Changing this will create a new custom authorizer resource.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the custom authorizer.
-* `create_time` - Time when the APIG custom authorizer was created.
+* `create_at` - Time when the APIG custom authorizer was created.
 
 ## Import
 

--- a/docs/resources/apig_environment.md
+++ b/docs/resources/apig_environment.md
@@ -39,12 +39,12 @@ The following arguments are supported:
   maximum of 255 characters and the angle brackets (< and >) are not allowed. Chinese characters must be in UTF-8 or
   Unicode format.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the APIG environment.
-* `create_time` - Time when the APIG environment was created, in RFC-3339 format.
+* `create_at` - Time when the APIG environment was created, in RFC-3339 format.
 
 ## Import
 

--- a/docs/resources/apig_group.md
+++ b/docs/resources/apig_group.md
@@ -71,14 +71,26 @@ The `variable` block supports:
 
   -> **NOTE:** The variable value will be displayed in plain text on the console.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the API group.
-* `registraion_time` - Registration time, in RFC-3339 format.
-* `update_time` - Time when the API group was last modified, in RFC-3339 format.
-* `environment/variable/variable_id` - ID of the environment variable.
+* `registration_at` - Registration time, in RFC-3339 format.
+* `update_at` - Time when the API group was last modified, in RFC-3339 format.
+* `environment` - The array of one or more environments of the associated group.  
+  The [object](#group_environment_attr) structure is documented below.
+
+<a name="group_environment_attr"></a>
+The `environment` block supports:
+
+* `variable` - The array of one or more environment variables.  
+  The [object](#group_environment_variable_attr) structure is documented below.
+
+<a name="group_environment_variable_attr"></a>
+The `variable` block supports:
+
+* `id` - The variable ID.
 
 ## Import
 

--- a/docs/resources/apig_instance.md
+++ b/docs/resources/apig_instance.md
@@ -84,11 +84,15 @@ The following arguments are supported:
 * `security_group_id` - (Required, String) Specifies the ID of the security group to which the APIG dedicated instance
   belongs to.
 
-* `available_zones` - (Required, List, ForceNew) Specifies an array of available zone names for the APIG dedicated
+* `availability_zones` - (Required, List, ForceNew) Specifies an array of available zone names for the APIG dedicated
   instance. Changing this will create a new APIG dedicated instance resource.
 
 * `description` - (Optional, String) Specifies the description about the APIG dedicated instance. The description
   contain a maximum of 255 characters and the angle brackets (< and >) are not allowed.
+
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project ID to which the dedicated
+  instance belongs.  
+  This parameter is required for enterprise users. Changing this will create a new resource.
 
 * `maintain_begin` - (Optional, String) Specifies a start time of the maintenance time window in the format 'xx:00:00'.
   The value of xx can be 02, 06, 10, 14, 18 or 22.
@@ -98,13 +102,24 @@ The following arguments are supported:
 
 * `eip_id` - (Optional, String) Specifies the eip ID associated with the APIG dedicated instance.
 
-## Attributes Reference
+* `ipv6_enable` - (Optional, Bool, ForceNew) Specifies whether public access with an IPv6 address is supported.  
+  Changing this will create a new resource.
+
+* `loadbalancer_provider` - (Optional, String, ForceNew) Specifies the provider type of load balancer used by the
+  dedicated instance.  
+  The valid values are as follows:
+  + **lvs**: Linux virtual server.
+  + **elb**: Elastic load balance.
+
+  Changing this will create a new resource.
+
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the APIG dedicated instance.
 * `maintain_end` - End time of the maintenance time window, 4-hour difference between the start time and end time.
-* `create_time` - Time when the APIG instance is created, in RFC-3339 format.
+* `create_at` - Time when the APIG instance is created, in RFC-3339 format.
 * `status` - Status of the APIG dedicated instance.
 * `supported_features` - The supported features of the APIG dedicated instance.
 * `egress_address` - The egress (nat) public ip address.
@@ -115,9 +130,9 @@ In addition to all arguments above, the following attributes are exported:
 
 This resource provides the following timeouts configuration options:
 
-* `create` - Default is 40 minute.
-* `update` - Default is 10 minute.
-* `delete` - Default is 10 minute.
+* `create` - Default is 40 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/apig_response.md
+++ b/docs/resources/apig_response.md
@@ -70,13 +70,13 @@ The `rule` block supports:
 
 * `status_code` - (Optional, Int) Specifies the HTTP status code of the API response rule.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the API custom response.
-* `create_time` - Time when the API custom response is created.
-* `update_time` - Time when the API custom response was last modified.
+* `create_at` - Time when the API custom response is created.
+* `update_at` - Time when the API custom response was last modified.
 
 ## Import
 

--- a/docs/resources/apig_throttling_policy.md
+++ b/docs/resources/apig_throttling_policy.md
@@ -106,16 +106,16 @@ The following arguments are supported:
   The `throttle` object of the `user_throttles` structure is documented below.
 
 * `app_throttles` - (Optional, List) Specifies an array of one or more special throttling policies for APP limit.
-  The `throttle` object of the `user_throttles` structure is documented below.
+  The `throttle` object of the `app_throttles` structure is documented below.
 
-The `throttle` block supports:
+The `user_throttles` and `app_throttles` block supports:
 
 * `max_api_requests` - (Required, Int) Specifies the maximum number of times an API can be accessed within a specified
   period.
 
 * `throttling_object_id` - (Required, String) Specifies the object ID which the special throttling policy belongs.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
@@ -129,7 +129,7 @@ In addition to all arguments above, the following attributes are exported:
   + `throttling_object_name` - The object name which the special application throttling policy belongs.
   + `id` - ID of the special application throttling policy.
 
-* `create_time` - Time when the API throttling policy was created.
+* `create_at` - Time when the API throttling policy was created.
 
 ## Import
 

--- a/docs/resources/apig_vpc_channel.md
+++ b/docs/resources/apig_vpc_channel.md
@@ -53,8 +53,11 @@ The following arguments are supported:
   Only letters, digits and underscores (_) are allowed.
   Chinese characters must be in UTF-8 or Unicode format.
 
-* `port` - (Optional, Int) Specifies the host port of the VPC channel.
+* `port` - (Required, Int) Specifies the host port of the VPC channel.
   The valid value is range from 1 to 65535.
+
+* `members` - (Required, List) Specifies an array of one or more backend server IDs or IP addresses that bind the VPC
+  channel. The object structure is documented below.
 
 * `member_type` - (Optional, String) Specifies the type of the backend service.
   The valid types are *ECS* and *EIP*, default to *ECS*.
@@ -84,9 +87,13 @@ The following arguments are supported:
 * `interval` - (Optional, Int) Specifies the interval between consecutive checks, in second.
   The valid value is range from 5 to 300, default to 10.
 
-* `members` - (Optional, List) Specifies an array of one or more backend server IDs or IP addresses that bind the VPC
-  channel.
-  The object structure is documented below.
+* `http_code` - (Optional, String) Specifies the response codes for determining a successful HTTP response.  
+  The valid value ranges from `100` to `599` and the valid formats are as follows:
+  + The multiple values, for example, **200,201,202**.
+  + The range, for example, **200-299**.
+  + Both multiple values and ranges, for example, **201,202,210-299**.
+
+  It is Required if the `protocol` is **HTTP**.
 
 The `members` block supports:
 
@@ -100,12 +107,12 @@ The `members` block supports:
 * `weight` - (Optional, Int) Specifies the backend server weight.
   The valid values are range from 1 to 100, default to 1.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - ID of the VPC channel.
-* `create_time` - Time when the channel created, in UTC format.
+* `create_at` - Time when the channel created, in UTC format.
 * `status` - The status of VPC channel, supports *Normal* and *Abnormal*.
 
 ## Import


### PR DESCRIPTION
fix docs of APIG service.

1、docs/resources/apig_application.md
`app_codes` is optional
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/81291c46-1a81-4744-9842-eb1ab04ed5b5)

2、docs/resources/apig_custom_authorizer.md
`validation` is optional, the unit test has its parent field but do not have the field.