### PR TITLE
feat(sfs): support enhanced in sfs turbo

### DIFF
--- a/docs/resources/sfs_turbo.md
+++ b/docs/resources/sfs_turbo.md
@@ -42,7 +42,9 @@ The following arguments are supported:
 * `name` - (Required, String, ForceNew) Specifies the name of an SFS Turbo file system. The value contains 4 to 64
   characters and must start with a letter. Changing this will create a new resource.
 
-* `size` - (Required, Int) Specifies the capacity of a sharing file system, in GB. The value ranges from 500 to 32768.
+* `size` - (Required, Int) Specifies the capacity of a sharing file system, in GB.
+  + If `share_type` is set to **STANDARD** or **PERFORMANCE**, the value ranges from 500 to 32768, and ranges from
+  10240 to 327680 for an enhanced file system.
 
   -> The file system capacity can only be expanded, not reduced.
 
@@ -62,6 +64,9 @@ The following arguments are supported:
 
 * `security_group_id` - (Required, String, ForceNew) Specifies the security group ID. Changing this will create a new
   resource.
+
+* `enhanced` - (Optional, Bool, ForceNew) Specifies whether the file system is enhanced or not. Changing this will
+  create a new resource.
 
 * `crypt_key_id` - (Optional, String, ForceNew) Specifies the ID of a KMS key to encrypt the file system. Changing this
   will create a new resource.

--- a/flexibleengine/acceptance/resource_flexibleengine_sfs_turbo_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_sfs_turbo_test.go
@@ -31,6 +31,7 @@ func TestAccSFSTurbo_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", turboName),
 					resource.TestCheckResourceAttr(resourceName, "share_proto", "NFS"),
 					resource.TestCheckResourceAttr(resourceName, "share_type", "STANDARD"),
+					resource.TestCheckResourceAttr(resourceName, "enhanced", "false"),
 					resource.TestCheckResourceAttr(resourceName, "size", "500"),
 					resource.TestCheckResourceAttr(resourceName, "status", "200"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
@@ -46,8 +47,8 @@ func TestAccSFSTurbo_basic(t *testing.T) {
 				Config: testAccSFSTurbo_update(randSuffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSFSTurboExists(resourceName, &turbo),
-					resource.TestCheckResourceAttr(resourceName, "size", "500"),
-					resource.TestCheckResourceAttr(resourceName, "status", "200"),
+					resource.TestCheckResourceAttr(resourceName, "size", "600"),
+					resource.TestCheckResourceAttr(resourceName, "status", "221"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar_update"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value_update"),
 				),
@@ -74,6 +75,7 @@ func TestAccSFSTurbo_crypt(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "name", turboName),
 					resource.TestCheckResourceAttr(resourceName, "share_proto", "NFS"),
 					resource.TestCheckResourceAttr(resourceName, "share_type", "STANDARD"),
+					resource.TestCheckResourceAttr(resourceName, "enhanced", "false"),
 					resource.TestCheckResourceAttr(resourceName, "size", "500"),
 					resource.TestCheckResourceAttr(resourceName, "status", "200"),
 					resource.TestCheckResourceAttrSet(resourceName, "crypt_key_id"),
@@ -185,7 +187,7 @@ data "flexibleengine_availability_zones" "myaz" {}
 
 resource "flexibleengine_sfs_turbo" "sfs-turbo1" {
   name              = "sfs-turbo-acc-%s"
-  size              = 500
+  size              = 600
   share_proto       = "NFS"
   vpc_id            = flexibleengine_vpc_v1.test.id
   subnet_id         = flexibleengine_vpc_subnet_v1.test.id


### PR DESCRIPTION
```
make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccSFSTurbo_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccSFSTurbo_basic -timeout 720m
=== RUN   TestAccSFSTurbo_basic
=== PAUSE TestAccSFSTurbo_basic
=== CONT  TestAccSFSTurbo_basic
--- PASS: TestAccSFSTurbo_basic (387.60s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      387.654s

make testacc TEST='./flexibleengine/acceptance' TESTARGS='-run TestAccSFSTurbo_crypt'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/acceptance -v -run TestAccSFSTurbo_crypt -timeout 720m
=== RUN   TestAccSFSTurbo_crypt
=== PAUSE TestAccSFSTurbo_crypt
=== CONT  TestAccSFSTurbo_crypt
--- PASS: TestAccSFSTurbo_crypt (302.78s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine/acceptance      302.826s
```