### PR TITLE
fix(DNS/zone): docs issues and incorrect attributes for schema fields

### DIFF
--- a/docs/data-sources/dns_zone_v2.md
+++ b/docs/data-sources/dns_zone_v2.md
@@ -16,23 +16,24 @@ data "flexibleengine_dns_zone_v2" "zone_1" {
 
 ## Argument Reference
 
-* `region` - (Optional) The region in which to obtain the V2 DNS client.
-  A DNS client is needed to retrieve zone ids. If omitted, the
-  `region` argument of the provider is used.
+* `region` - (Optional, String) The region in which to obtain the V2 DNS client.
+  A DNS client is needed to retrieve zone ids. If omitted, the `region` argument of the provider is used.
 
-* `name` - (Optional) The name of the zone.
+* `name` - (Optional, String) The name of the zone.
 
-* `description` - (Optional) A description of the zone.
+* `description` - (Optional, String) A description of the zone.
 
-* `email` - (Optional) The email contact for the zone record.
+* `email` - (Optional, String) The email contact for the zone record.
 
-* `status` - (Optional) The zone's status.
+* `status` - (Optional, String) The zone's status.
 
-* `ttl` - (Optional) The time to live (TTL) of the zone.
+* `ttl` - (Optional, Int) The time to live (TTL) of the zone.
 
-* `zone_type` - (Optional) The type of the zone. Can either be `public` or `private`.
+* `zone_type` - (Optional, String) The type of the zone. Can either be `public` or `private`.
 
-## Attributes Reference
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
 
 `id` is set to the ID of the found zone. In addition, the following attributes
 are exported:

--- a/docs/resources/dns_zone_v2.md
+++ b/docs/resources/dns_zone_v2.md
@@ -42,25 +42,25 @@ resource "flexibleengine_dns_zone_v2" "my_private_zone" {
 
 The following arguments are supported:
 
-* `region` - (Optional, ForceNew) The region in which to create the DNS zone.
+* `region` - (Optional, String, ForceNew) The region in which to create the DNS zone.
   If omitted, the `region` argument of the provider is used.
   Changing this creates a new DNS zone.
 
-* `name` - (Required, ForceNew) The name of the zone. Note the `.` at the end of the name.
+* `name` - (Required, String, ForceNew) The name of the zone. Note the `.` at the end of the name.
   Changing this creates a new DNS zone.
 
-* `email` - (Optional) The email contact for the zone record.
+* `email` - (Optional, String) The email contact for the zone record.
 
 * `zone_type` - (Optional, ForceNew) The type of zone. Can either be `public` or `private`.
   Default is `public`. Changing this creates a new DNS zone.
 
-* `router` - (Optional) Router configuration block which is required if zone_type is private.
+* `router` - (Optional, List) Router configuration block which is required if zone_type is private.
   The router structure is documented below.
 
-* `ttl` - (Optional) The time to live (TTL) of the zone. TTL ranges from 1 to 2147483647 seconds.
+* `ttl` - (Optional, Int) The time to live (TTL) of the zone. TTL ranges from 1 to 2147483647 seconds.
   Default is  `300`.
 
-* `description` - (Optional) A description of the zone. Max length is `255` characters.
+* `description` - (Optional, String) A description of the zone. Max length is `255` characters.
 
 * `tags` - (Optional, Map) The key/value pairs to associate with the zone.
 
@@ -69,22 +69,25 @@ The following arguments are supported:
 
 The `router` block supports:
 
-* `router_id` - (Required) The VPC UUID.
+* `router_id` - (Required, String) The VPC UUID.
 
-* `router_region` - (Optional) The region of the VPC. Defaults to the `region`.
+* `router_region` - (Optional, String) The region of the VPC. Defaults to the `region`.
 
-## Attributes Reference
+## Attribute Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
-* `region` - See Argument Reference above.
-* `name` - See Argument Reference above.
-* `email` - See Argument Reference above.
-* `zone_type` - See Argument Reference above.
-* `ttl` - See Argument Reference above.
-* `description` - See Argument Reference above.
+* `id` - Specifies a resource ID in UUID format.
+
 * `masters` - An array of master DNS servers.
-* `value_specs` - See Argument Reference above.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/flexibleengine/data_source_flexibleengine_dns_zone_v2.go
+++ b/flexibleengine/data_source_flexibleengine_dns_zone_v2.go
@@ -18,59 +18,45 @@ func dataSourceDNSZoneV2() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-
-			"name": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-
-			"pool_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
-			"project_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
 			"email": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
-			"status": {
+			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
-			"zone_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-			},
-
-			"ttl": {
-				Type:     schema.TypeInt,
-				Optional: true,
-			},
-
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-
+			"status": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ttl": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"zone_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"masters": {
 				Type:     schema.TypeSet,
-				Optional: true,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-
+			"pool_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"project_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"serial": {
 				Type:     schema.TypeInt,
-				Optional: true,
 				Computed: true,
 			},
 		},


### PR DESCRIPTION
### flexibleengine_dns_zone_v2
```
=== RUN   TestAccDNSZoneV2DataSource_basic

--- PASS: TestAccDNSZoneV2DataSource_basic (69.62s)
PASS
```

### flexibleengine_dns_zone_v2
```
=== RUN   TestAccDNSV2Zone_basic
=== PAUSE TestAccDNSV2Zone_basic
=== CONT  TestAccDNSV2Zone_basic
--- PASS: TestAccDNSV2Zone_basic (113.47s)
=== RUN   TestAccDNSV2Zone_private
=== PAUSE TestAccDNSV2Zone_private
=== CONT  TestAccDNSV2Zone_private
--- PASS: TestAccDNSV2Zone_private (111.93s)
=== RUN   TestAccDNSV2Zone_readTTL
=== PAUSE TestAccDNSV2Zone_readTTL
=== CONT  TestAccDNSV2Zone_readTTL
--- PASS: TestAccDNSV2Zone_readTTL (78.87s)
PASS
```