### PR TITLE
docs(csbs): fix docs issues.

### DIFF
--- a/docs/data-sources/csbs_backup_policy_v1.md
+++ b/docs/data-sources/csbs_backup_policy_v1.md
@@ -20,13 +20,16 @@ data "flexibleengine_csbs_backup_policy_v1" "csbs_policy" {
 
 The following arguments are supported:
 
-* `id` - (Optional) Specifies the ID of backup policy.
+* `region` - (Optional, String) The region in which to query the data source. If omitted, the provider-level region
+  will be used.
 
-* `name` - (Optional) Specifies the backup policy name.
+* `id` - (Optional, String) Specifies the ID of backup policy.
 
-* `status` - (Optional) Specifies the backup policy status.
+* `name` - (Optional, String) Specifies the backup policy name.
 
-## Attributes Reference
+* `status` - (Optional, String) Specifies the backup policy status.
+
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
@@ -34,39 +37,46 @@ In addition to all arguments above, the following attributes are exported:
 
 * `provider_id` - Provides the Backup provider ID.
 
-* `parameters` - Specifies the parameters of a backup policy.
+* `common` - General backup policy parameters, which are blank by default.
 
-* `scheduled_operation` block supports the following arguments:
+* `scheduled_operation` -  Backup plan information.
+  The [scheduled_operation](#csbs_scheduled_operation) object structure is documented below.
 
-  + `name` - Specifies Scheduling period name.
+* `resource` - Backup Object. The [resource](#csbs_resource) object structure is documented below.
 
-  + `description` - Specifies Scheduling period description.
+<a name="csbs_scheduled_operation"></a>
+The `scheduled_operation` block supports:
 
-  + `enabled` - Specifies whether the scheduling period is enabled.
+* `name` - Specifies Scheduling period name.
 
-  + `max_backups` - Specifies maximum number of backups that can be automatically created for a backup object.
+* `description` - Specifies Scheduling period description.
 
-  + `retention_duration_days` - Specifies duration of retaining a backup, in days.
+* `enabled` - Specifies whether the scheduling period is enabled.
 
-  + `permanent` - Specifies whether backups are permanently retained.
+* `max_backups` - Specifies maximum number of backups that can be automatically created for a backup object.
 
-  + `trigger_pattern` - Specifies Scheduling policy of the scheduler.
+* `retention_duration_days` - Specifies duration of retaining a backup, in days.
 
-  + `operation_type` - Specifies Operation type, which can be backup.
+* `permanent` - Specifies whether backups are permanently retained.
 
-  + `id` -  Specifies Scheduling period ID.
+* `trigger_pattern` - Specifies Scheduling policy of the scheduler.
 
-  + `trigger_id` -  Specifies Scheduler ID.
+* `operation_type` - Specifies Operation type, which can be backup.
 
-  + `trigger_name` -  Specifies Scheduler name.
+* `id` -  Specifies Scheduling period ID.
 
-  + `trigger_type` -  Specifies Scheduler type.
+* `trigger_id` -  Specifies Scheduler ID.
 
-* `resource` block supports the following arguments:
+* `trigger_name` -  Specifies Scheduler name.
 
-  + `id` - Specifies the ID of the object to be backed up.
+* `trigger_type` -  Specifies Scheduler type.
 
-  + `type` - Entity object type of the backup object.
+<a name="csbs_resource"></a>
+The `resource` block supports:
 
-  + `name` - Specifies backup object name.
+* `id` - Specifies the ID of the object to be backed up.
+
+* `type` - Entity object type of the backup object.
+
+* `name` - Specifies backup object name.
   

--- a/docs/data-sources/csbs_backup_v1.md
+++ b/docs/data-sources/csbs_backup_v1.md
@@ -20,25 +20,28 @@ data "flexibleengine_csbs_backup_v1" "csbs" {
 
 The following arguments are supported:
 
-* `id` - (Optional) Specifies the ID of backup.
+* `region` - (Optional, String) The region in which to query the data source. If omitted, the provider-level region
+  will be used.
 
-* `backup_name` - (Optional) Specifies the backup name.
+* `id` - (Optional, String) Specifies the ID of backup.
 
-* `status` - (Optional) Specifies the backup status.
+* `backup_name` - (Optional, String) Specifies the backup name.
 
-* `resource_name` - (Optional) Specifies the backup object name.
+* `status` - (Optional, String) Specifies the backup status.
 
-* `backup_record_id` - (Optional) Specifies the backup record ID.
+* `resource_name` - (Optional, String) Specifies the backup object name.
 
-* `resource_type` - (Optional) Specifies the type of backup objects.
+* `backup_record_id` - (Optional, String) Specifies the backup record ID.
 
-* `resource_id` - (Optional) Specifies the backup object ID.
+* `resource_type` - (Optional, String) Specifies the type of backup objects.
 
-* `policy_id` - (Optional) Specifies the Policy Id.
+* `resource_id` - (Optional, String) Specifies the backup object ID.
 
-* `vm_ip` - (Optional) Specifies the ip of VM.
+* `policy_id` - (Optional, String) Specifies the Policy Id.
 
-## Attributes Reference
+* `vm_ip` - (Optional, String) Specifies the ip of VM.
+
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
@@ -50,48 +53,54 @@ In addition to all arguments above, the following attributes are exported:
 
 * `size` - Specifies the backup capacity.
 
-* `volume_backups` - block supports the following arguments:
+* `volume_backups` - The [volume_backups](#csbs_volume_backups) object structure is documented below.
 
-  + `status` -  Status of backup Volume.
+* `vm_metadata` - The [vm_metadata](#csbs_vm_metadata) object structure is documented below.
 
-  + `space_saving_ratio` -  Specifies the space saving rate.
+<a name="csbs_volume_backups"></a>
+The `volume_backups` block supports:
 
-  + `name` -  It gives EVS disk backup name.
+* `status` -  Status of backup Volume.
 
-  + `bootable` -  Specifies whether the disk is bootable.
+* `space_saving_ratio` -  Specifies the space saving rate.
 
-  + `average_speed` -  Specifies the average speed.
+* `name` -  It gives EVS disk backup name.
 
-  + `source_volume_size` -  Shows source volume size in GB.
+* `bootable` -  Specifies whether the disk is bootable.
 
-  + `source_volume_id` -  It specifies source volume ID.
+* `average_speed` -  Specifies the average speed.
 
-  + `incremental` -  Shows whether incremental backup is used.
+* `source_volume_size` -  Shows source volume size in GB.
 
-  + `snapshot_id` -  ID of snapshot.
+* `source_volume_id` -  It specifies source volume ID.
 
-  + `source_volume_name` -  Specifies source volume name.
+* `incremental` -  Shows whether incremental backup is used.
 
-  + `image_type` -  It specifies backup. The default value is backup.
+* `snapshot_id` -  ID of snapshot.
 
-  + `id` -  Specifies Cinder backup ID.
+* `source_volume_name` -  Specifies source volume name.
 
-  + `size` -  Specifies accumulated size (MB) of backups.
+* `image_type` -  It specifies backup. The default value is backup.
 
-* `vm_metadata` - block supports the following arguments:
+* `id` -  Specifies Cinder backup ID.
 
-  + `name` - Name of backup data.
+* `size` -  Specifies accumulated size (MB) of backups.
 
-  + `eip` - Specifies elastic IP address of the ECS.
+<a name="csbs_vm_metadata"></a>
+The `vm_metadata` block supports:
 
-  + `cloud_service_type` - Specifies ECS type.
+* `name` - Name of backup data.
 
-  + `ram` - Specifies memory size of the ECS, in MB.
+* `eip` - Specifies elastic IP address of the ECS.
 
-  + `vcpus` - Specifies CPU cores corresponding to the ECS.
+* `cloud_service_type` - Specifies ECS type.
 
-  + `private_ip` - It specifies internal IP address of the ECS.
+* `ram` - Specifies memory size of the ECS, in MB.
 
-  + `disk` - Shows system disk size corresponding to the ECS specifications.
+* `vcpus` - Specifies CPU cores corresponding to the ECS.
 
-  + `image_type` - Specifies image type.
+* `private_ip` - It specifies internal IP address of the ECS.
+
+* `disk` - Shows system disk size corresponding to the ECS specifications.
+
+* `image_type` - Specifies image type.

--- a/docs/resources/csbs_backup_policy_v1.md
+++ b/docs/resources/csbs_backup_policy_v1.md
@@ -34,45 +34,51 @@ Provides a FlexibleEngine Backup Policy of Resources.
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the name of backup policy. The value consists of 1 to 255 characters and
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the CSBS backup policy resource.
+  If omitted, the provider-level region will be used. Changing this will create a new CSBS backup policy resource.
+
+* `name` - (Required, String) Specifies the name of backup policy. The value consists of 1 to 255 characters and
   can contain only letters, digits, underscores (_), and hyphens (-).
 
-* `description` - (Optional) Backup policy description. The value consists of 0 to 255 characters and
+* `description` - (Optional, String) Backup policy description. The value consists of 0 to 255 characters and
   must not contain a greater-than sign (>) or less-than sign (<).
 
-* `provider_id` - (Required) Specifies backup provider ID. Default value is **fc4d5750-22e7-4798-8a46-f48f62c4c1da**
+* `provider_id` - (Optional, String, ForceNew) Specifies backup provider ID. Default value is
+  **fc4d5750-22e7-4798-8a46-f48f62c4c1da**
 
-* `common` - (Optional) General backup policy parameters, which are blank by default.
+* `common` - (Optional, Map) General backup policy parameters, which are blank by default.
 
-* `scheduled_operation` block supports the following arguments:
+* `scheduled_operation` - (Required, Set)  Backup plan information.
 
-    + `name` - (Optional) Specifies Scheduling period name.The value consists of 1 to 255 characters and
+    + `name` - (Optional, String) Specifies Scheduling period name.The value consists of 1 to 255 characters and
       can contain only letters, digits, underscores (_), and hyphens (-).
 
-    + `description` - (Optional) Specifies Scheduling period description.The value consists of 0 to 255 characters and
-      must not contain a greater-than sign (>) or less-than sign (<).
+    + `description` - (Optional, String) Specifies Scheduling period description.The value consists of 0 to 255
+      characters and must not contain a greater-than sign (>) or less-than sign (<).
 
-    + `enabled` - (Optional) Specifies whether the scheduling period is enabled. Default value is **true**
+    + `enabled` - (Optional, Bool) Specifies whether the scheduling period is enabled. Default value is **true**.
 
-    + `max_backups` - (Optional) Specifies maximum number of backups that can be automatically created for a backup object.
+    + `max_backups` - (Optional, Int) Specifies maximum number of backups that can be automatically created for a
+      backup object.
 
-    + `retention_duration_days` - (Optional) Specifies duration of retaining a backup, in days.
+    + `retention_duration_days` - (Optional, Int) Specifies duration of retaining a backup, in days.
 
-    + `permanent` - (Optional) Specifies whether backups are permanently retained.
+    + `permanent` - (Optional, Bool) Specifies whether backups are permanently retained.
 
-    + `trigger_pattern` - (Required) Specifies Scheduling policy of the scheduler.
+    + `trigger_pattern` - (Required, String) Specifies Scheduling policy of the scheduler.
 
-    + `operation_type` - (Required) Specifies Operation type, which can be backup.
+    + `operation_type` - (Required, String) Specifies Operation type, which can be backup.
 
-* `resource` block supports the following arguments:
+* `resource` - (Required, List) Backup Object.
 
-    + `id` - (Required) Specifies the ID of the object to be backed up.
+    + `id` - (Required, String) Specifies the ID of the object to be backed up.
 
-    + `type` - (Required) Entity object type of the backup object. If the type is VMs, the value is **OS::Nova::Server**.
+    + `type` - (Required, String) Entity object type of the backup object.
+      If the type is VMs, the value is **OS::Nova::Server**.
 
-    + `name` - (Required) Specifies backup object name.
+    + `name` - (Required, String) Specifies backup object name.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
@@ -80,15 +86,26 @@ In addition to all arguments above, the following attributes are exported:
 
 * `id` - Backup Policy ID.
 
-* scheduled_operation - Backup plan information
+* `scheduled_operation` -  Backup plan information.
+  The [scheduled_operation](#csbs_scheduled_operation) object structure is documented below.
 
-    + `id` -  Specifies Scheduling period ID.
+<a name="csbs_scheduled_operation"></a>
+The `scheduled_operation` block supports:
 
-    + `trigger_id` -  Specifies Scheduler ID.
+* `id` -  Specifies Scheduling period ID.
 
-    + `trigger_name` -  Specifies Scheduler name.
+* `trigger_id` -  Specifies Scheduler ID.
 
-    + `trigger_type` -  Specifies Scheduler type.
+* `trigger_name` -  Specifies Scheduler name.
+
+* `trigger_type` -  Specifies Scheduler type.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/csbs_backup_v1.md
+++ b/docs/resources/csbs_backup_v1.md
@@ -25,18 +25,22 @@ Provides a FlexibleEngine Backup of Resources.
 
 The following arguments are supported:
 
-* `backup_name` - (Optional) Name for the backup. The value consists of 1 to 255 characters and can contain
-  only letters, digits, underscores (_), and hyphens (-). Changing backup_name creates a new backup.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the CSBS backup resource.
+  If omitted, the provider-level region will be used. Changing this will create a new CSBS backup resource.
 
-* `description` - (Optional) Backup description. The value consists of 0 to 255 characters and must not contain
-  a greater-than sign (>) or less-than sign (<). Changing description creates a new backup.
+* `backup_name` - (Optional, String, ForceNew) Name for the backup. The value consists of 1 to 255 characters and can
+  contain only letters, digits, underscores (_), and hyphens (-). Changing backup_name creates a new backup.
 
-* `resource_id` - (Required) ID of the target to which the backup is restored. Changing this creates a new backup.
+* `description` - (Optional, String, ForceNew) Backup description. The value consists of 0 to 255 characters and must
+  not contain a greater-than sign (>) or less-than sign (<). Changing description creates a new backup.
 
-* `resource_type` - (Optional) Type of the target to which the backup is restored. The default value is
-  **OS::Nova::Server** for an ECS. Changing this creates a new backup.
+* `resource_id` - (Required, String, ForceNew) ID of the target to which the backup is restored.
+  Changing this creates a new backup.
 
-## Attributes Reference
+* `resource_type` - (Optional, String, ForceNew) Type of the target to which the backup is restored. The default value
+  is **OS::Nova::Server** for an ECS. Changing this creates a new backup.
+
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
@@ -44,51 +48,64 @@ In addition to all arguments above, the following attributes are exported:
 
 * `backup_record_id` - Specifies backup record ID.
 
-* `volume_backups` block supports the following arguments:
+* `volume_backups` - The [volume_backups](#csbs_volume_backups) object structure is documented below.
 
-  + `status` -  Status of backup Volume.
+* `vm_metadata` - The [vm_metadata](#csbs_vm_metadata) object structure is documented below.
 
-  + `space_saving_ratio` -  Specifies space saving rate.
+<a name="csbs_volume_backups"></a>
+The `volume_backups` block supports:
 
-  + `name` -  It gives EVS disk backup name.
+* `status` -  Status of backup Volume.
 
-  + `bootable` -  Specifies whether the disk is bootable.
+* `space_saving_ratio` -  Specifies space saving rate.
 
-  + `average_speed` -  Specifies the average speed.
+* `name` -  It gives EVS disk backup name.
 
-  + `source_volume_size` -  Shows source volume size in GB.
+* `bootable` -  Specifies whether the disk is bootable.
 
-  + `source_volume_id` -  It specifies source volume ID.
+* `average_speed` -  Specifies the average speed.
 
-  + `incremental` -  Shows whether incremental backup is used.
+* `source_volume_size` -  Shows source volume size in GB.
 
-  + `snapshot_id` -  ID of snapshot.
+* `source_volume_id` -  It specifies source volume ID.
 
-  + `source_volume_name` -  Specifies source volume name.
+* `incremental` -  Shows whether incremental backup is used.
 
-  + `image_type` -  It specifies backup. The default value is backup.
+* `snapshot_id` -  ID of snapshot.
 
-  + `id` -  Specifies Cinder backup ID.
+* `source_volume_name` -  Specifies source volume name.
 
-  + `size` -  Specifies accumulated size (MB) of backups.
+* `image_type` -  It specifies backup. The default value is backup.
 
-* `vm_metadata` block supports the following arguments:
+* `id` -  Specifies Cinder backup ID.
 
-  + `name` - Name of backup data.
+* `size` -  Specifies accumulated size (MB) of backups.
 
-  + `eip` - Specifies elastic IP address of the ECS.
+<a name="csbs_vm_metadata"></a>
+The `vm_metadata` block supports:
 
-  + `cloud_service_type` - Specifies ECS type.
+* `name` - Name of backup data.
 
-  + `ram` - Specifies memory size of the ECS, in MB.
+* `eip` - Specifies elastic IP address of the ECS.
 
-  + `vcpus` - Specifies CPU cores corresponding to the ECS.
+* `cloud_service_type` - Specifies ECS type.
 
-  + `private_ip` - It specifies internal IP address of the ECS.
+* `ram` - Specifies memory size of the ECS, in MB.
 
-  + `disk` - Shows system disk size corresponding to the ECS specifications.
+* `vcpus` - Specifies CPU cores corresponding to the ECS.
 
-  + `image_type` - Specifies image type.
+* `private_ip` - It specifies internal IP address of the ECS.
+
+* `disk` - Shows system disk size corresponding to the ECS specifications.
+
+* `image_type` - Specifies image type.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.
 
 ## Import
 


### PR DESCRIPTION
fix docs issues.

### 1、resource_flexibleengine_csbs_backup_policy_v1
`provider_id` is optional, in the following image do not have `provider_id` field but it is still created successfully
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/7c9c5e34-cee8-4e59-b608-fedcfd6e51fa)

