### PR TITLE
docs(dds): fix docs issues.

### DIFF
--- a/docs/data-sources/dds_flavor_v3.md
+++ b/docs/data-sources/dds_flavor_v3.md
@@ -18,11 +18,12 @@ data "flexibleengine_dds_flavor_v3" "flavor" {
 
 ## Argument Reference
 
-* `region` - (Optional) The region in which to obtain the V3 dds client.
+* `region` - (Optional, String) The region in which to obtain the V3 dds client. If omitted, the provider-level region
+  will be used.
 
-* `engine_name` - (Optional) The engine name of the dds, now only DDS-Community is supported.
+* `engine_name` - (Optional, String) The engine name of the dds, now only DDS-Community is supported.
 
-* `speccode` - (Optional) The spec code of a dds flavor.
+* `spec_code` - (Optional, String) The spec code of a dds flavor.
 
 ## Available value for attributes
 
@@ -45,11 +46,11 @@ DDS-Community | replica | 4 | 16 | dds.mongodb.s3.xlarge.4.repset
 DDS-Community | replica | 8 | 32 | dds.mongodb.s3.2xlarge.4.repset
 DDS-Community | replica | 16 | 64 | dds.mongodb.s3.4xlarge.4.repset
 
-## Attributes Reference
+## Attribute Reference
 
 * `region` - See Argument Reference above.
 * `engine_name` - See Argument Reference above.
-* `speccode` - See Argument Reference above.
+* `spec_code` - See Argument Reference above.
 * `type` - The type of the dds flavor.
 * `vcpus` - The vcpus of the dds flavor.
 * `ram` - The ram of the dds flavor.

--- a/docs/data-sources/dds_flavors_v3.md
+++ b/docs/data-sources/dds_flavors_v3.md
@@ -18,6 +18,9 @@ data "flexibleengine_dds_flavors_v3" "flavor" {
 
 ## Argument Reference
 
+* `region` - (Optional, String) The region in which to query the data source. If omitted, the provider-level region
+  will be used.
+
 * `engine_name` - (Optional, String) Specifies the engine name of the dds, the default value is
   "DDS-Community".
 
@@ -28,15 +31,16 @@ data "flexibleengine_dds_flavors_v3" "flavor" {
 
 * `memory` - (Optional, String) Specifies the ram of the dds flavor in GB.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Specifies a data source ID.
 
-* `flavors` - Indicates the flavors information. Structure is documented below.
+* `flavors` - Indicates the flavors information. The [flavors](#dds_flavors) object structure is documented below.
 
-The `flavors` block contains:
+<a name="dds_flavors"></a>
+The `flavors` block supports:
 
 * `spec_code` - The name of the dds flavor.
 * `type` - See `type` above.

--- a/docs/resources/dds_instance_v3.md
+++ b/docs/resources/dds_instance_v3.md
@@ -105,69 +105,77 @@ resource "flexibleengine_dds_instance_v3" "instance" {
 
 The following arguments are supported:
 
-* `region` - (Optional) Specifies the region of the DDS instance. Changing this creates
+* `region` - (Optional, String, ForceNew) Specifies the region of the DDS instance. Changing this creates
   a new instance.
 
-* `name` - (Required) Specifies the DB instance name. The DB instance name of the same
+* `name` - (Required, String, ForceNew) Specifies the DB instance name. The DB instance name of the same
   type is unique in the same tenant. Changing this creates a new instance.
 
-* `datastore` - (Required) Specifies database information. The structure is described
-  below. Changing this creates a new instance.
+* `datastore` - (Required, List, ForceNew) Specifies database information. The [datastore](#dds_datastore) object
+  structure is documented below. Changing this creates a new instance.
 
-* `availability_zone` - (Required) Specifies the ID of the availability zone. Changing
+* `availability_zone` - (Required, String, ForceNew) Specifies the ID of the availability zone. Changing
   this creates a new instance.
 
-* `vpc_id` - (Required) Specifies the VPC ID. Changing this creates a new instance.
+* `vpc_id` - (Required, String, ForceNew) Specifies the VPC ID. Changing this creates a new instance.
 
-* `subnet_id` - (Required) Specifies the ID of the VPC Subnet. Changing this creates a new instance.
+* `subnet_id` - (Required, String, ForceNew) Specifies the ID of the VPC Subnet. Changing this creates a new instance.
 
-* `security_group_id` - (Required) Specifies the security group ID of the DDS instance.
+* `security_group_id` - (Required, String, ForceNew) Specifies the security group ID of the DDS instance.
   Changing this creates a new instance.
 
-* `password` - (Required) Specifies the Administrator password of the database instance.
+* `password` - (Required, String, ForceNew) Specifies the Administrator password of the database instance.
   Changing this creates a new instance.
 
-* `disk_encryption_id` - (Required) Specifies the disk encryption ID of the instance.
+* `disk_encryption_id` - (Optional, String, ForceNew) Specifies the disk encryption ID of the instance.
   Changing this creates a new instance.
 
-* `mode` - (Required) Specifies the mode of the database instance. Changing this creates a new instance.
+* `mode` - (Required, String, ForceNew) Specifies the mode of the database instance.Changing this creates a new instance.
 
-* `flavor` - (Required) Specifies the flavors information. The structure is described below.
+* `flavor` - (Required, List, ForceNew) Specifies the flavors information. The [flavor](#dds_flavor) object structure
+  is documented below. Changing this creates a new instance.
+
+* `backup_strategy` - (Optional, List, ForceNew) Specifies the advanced backup policy.
+  The [backup_strategy](#dds_backup_strategy) object structure is documented below. Changing this creates a new instance.
+
+* `ssl` - (Optional, Bool, ForceNew) Specifies whether to enable or disable SSL. Defaults to true.
   Changing this creates a new instance.
 
-* `backup_strategy` - (Optional) Specifies the advanced backup policy. The structure is
-  described below. Changing this creates a new instance.
+* `tags` - (Optional, Map) The key/value pairs to associate with the DDS instance.
 
-* `ssl` - (Optional) Specifies whether to enable or disable SSL. Defaults to true.
-  Changing this creates a new instance.
-
-* `tags` - (Optional) The key/value pairs to associate with the DDS instance.
-
+<a name="dds_datastore"></a>
 The `datastore` block supports:
 
-* `type` - (Required) Specifies the DB engine. Only DDS-Community is supported now.
+* `type` - (Required, String, ForceNew) Specifies the DB engine. Only DDS-Community is supported now.
+  Changing this will create a new resource.
 
-* `version` - (Required) Specifies the DB instance version. The valid values are 3.4, 4.0 and 4.2.
+* `version` - (Required, String, ForceNew) Specifies the DB instance version. The valid values are 3.4, 4.0 and 4.2.
+  Changing this will create a new resource.
 
-* `storage_engine` - (Optional) Specifies the storage engine of the DB instance. The valid values are
-  `wiredTiger` and `rocksDB`.
+* `storage_engine` - (Optional, String, ForceNew) Specifies the storage engine of the DB instance. The valid values are
+  `wiredTiger` and `rocksDB`.Changing this will create a new resource.
 
+<a name="dds_flavor"></a>
 The `flavor` block supports:
 
-* `type` - (Required) Specifies the node type. Valid value: mongos, shard, config, replica.
+* `type` - (Required, String, ForceNew) Specifies the node type. Valid value: mongos, shard, config, replica.
+  Changing this creates a new resource.
 
-* `num` - (Required) Specifies the node quantity. Valid value:
+* `num` - (Required, Int, ForceNew) Specifies the node quantity. Valid value:
   + the number of mongos ranges from 2 to 12.
   + the number of shard ranges from 2 to 12.
   + config: the value is 1.
   + replica: the value is 1.
+  Changing this creates a new resource.
 
-* `storage` - (Optional) Specifies the disk type. Valid value: ULTRAHIGH which indicates the type SSD.
+* `storage` - (Optional, String, ForceNew) Specifies the disk type. Valid value: ULTRAHIGH which indicates the type SSD.
+  Changing this creates a new resource.
 
-* `size` - (Optional) Specifies the disk size. The value must be a multiple of 10. The unit is GB. This parameter
-  is mandatory for nodes except mongos and invalid for mongos.
+* `size` - (Optional, Int, ForceNew) Specifies the disk size. The value must be a multiple of 10. The unit is GB.
+  This parameter is mandatory for nodes except mongos and invalid for mongos. Changing this creates a new resource.
 
-* `spec_code` - (Required) Specifies the resource specification code. Valid values:
+* `spec_code` - (Required, String, ForceNew) Specifies the resource specification code.
+  Changing this creates a new resource. Valid values:
 
 engine_name | type | vcpus | ram | speccode
 ---- | --- | ---
@@ -188,21 +196,22 @@ DDS-Community | replica | 4 | 16 | dds.mongodb.s3.xlarge.4.repset
 DDS-Community | replica | 8 | 32 | dds.mongodb.s3.2xlarge.4.repset
 DDS-Community | replica | 16 | 64 | dds.mongodb.s3.4xlarge.4.repset
 
+<a name="dds_backup_strategy"></a>
 The `backup_strategy` block supports:
 
-* `start_time` - (Required) Specifies the backup time window. Automated backups will be triggered
+* `start_time` - (Required, String) Specifies the backup time window. Automated backups will be triggered
   during the backup time window. The value cannot be empty. It must be a valid value in the
   "hh:mm-HH:MM" format. The current time is in the UTC format.
   + The HH value must be 1 greater than the hh value.
   + The values from mm and MM must be the same and must be set to any of the following 00, 15, 30, or 45.
 
-* `keep_days` - (Optional) Specifies the number of days to retain the generated backup files.
+* `keep_days` - (Required, Int) Specifies the number of days to retain the generated backup files.
   The value range is from 0 to 732.
   + If this parameter is set to 0, the automated backup policy is not set.
   + If this parameter is not transferred, the automated backup policy is enabled by default.
     Backup files are stored for seven days by default.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
@@ -210,9 +219,10 @@ In addition to all arguments above, the following attributes are exported:
 * `status` - Indicates the the DB instance status.
 * `db_username` - Indicates the DB Administator name.
 * `port` - Indicates the database port number. The port range is 2100 to 9500.
-* `nodes` - Indicates the instance nodes information. Structure is documented below.
+* `nodes` - Indicates the instance nodes information.The [nodes](#dds_nodes) object structure is documented below.
 
-The `nodes` block contains:
+<a name="dds_nodes"></a>
+The `nodes` block supports:
 
 * `id` - Indicates the node ID.
 * `name` - Indicates the node name.
@@ -224,3 +234,10 @@ The `nodes` block contains:
   mongos nodes of cluster instances, primary nodes and secondary nodes of replica set instances,
   and single node instances.
 * `status` - Indicates the node status.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.

--- a/flexibleengine/data_source_flexibleengine_dds_flavor_v3_test.go
+++ b/flexibleengine/data_source_flexibleengine_dds_flavor_v3_test.go
@@ -43,5 +43,6 @@ func testAccCheckDDSFlavorV3DataSourceID(n string) resource.TestCheckFunc {
 var testAccDDSFlavorV3DataSource_basic = `
 data "flexibleengine_dds_flavor_v3" "flavor" {
   engine_name = "DDS-Community"
+  spec_code   = "dds.mongodb.s3.medium.4.repset"
 }
 `


### PR DESCRIPTION
### 1、data_source_flexibleengine_dds_flavor_v3
```hcl
=== RUN   TestAccDDSFlavorV3DataSource_basic
--- PASS: TestAccDDSFlavorV3DataSource_basic (37.46s)
PASS

coverage: 1.8% of statements in ../../terraform-provider-flexibleengine/...

Process finished with the exit code 0
```

![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/148b8fc6-0fe0-413b-a9fb-39b38f214367)

---

### 2、data_source_flexibleengine_dds_instance_v3.md
`disk_encryption_id` is optional, the following image do not have the field, but it is created successfully
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/0a154efa-37ea-4437-b916-e06b7bba27c4)

