### PR TITLE
docs(as/cbr/cse): processing Fields Referencing Huawei Cloud

### DIFF
--- a/docs/data-sources/as_groups.md
+++ b/docs/data-sources/as_groups.md
@@ -7,8 +7,7 @@ subcategory: "Auto Scaling (AS)"
 Use this data source to get a list of AS groups.
 
 ```hcl
-data "flexibleengine_as_groups" "groups" {
-}
+data "flexibleengine_as_groups" "groups" {}
 ```
 
 ## Argument Reference
@@ -29,6 +28,9 @@ The following arguments are supported:
   - **ERROR**: indicates that the AS group malfunctions.
   - **DELETING**: indicates that the AS group is being deleted.
   - **FREEZED**: indicates that the AS group has been frozen.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project id of the AS group.
+  Changing this will create a new resource.
 
 ## Attribute Reference
 

--- a/docs/resources/cbr_vault.md
+++ b/docs/resources/cbr_vault.md
@@ -151,6 +151,9 @@ The following arguments are supported:
   + **disk** (EVS Disks)
   + **turbo** (SFS Turbo file systems)
 
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the cbr vault resource.
+  Changing this will create a new resource.
+
 * `protection_type` - (Required, String, ForceNew) Specifies the protection type of the CBR vault.
   The valid values are **backup** and **replication**. Vaults of type **disk** don't support **replication**.
   Changing this will create a new vault.

--- a/docs/resources/cse_microservice_engine.md
+++ b/docs/resources/cse_microservice_engine.md
@@ -35,6 +35,9 @@ The following arguments are supported:
   The name must start with a letter and cannot end with a hyphen (-).
   Changing this will create a new engine.
 
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the cse microservice
+  engine resource. Changing this will create a new resource.
+
 * `flavor` - (Required, String, ForceNew) Specifies the flavor of the dedicated microservice engine.
   Changing this will create a new engine.
 

--- a/flexibleengine/acceptance/data_source_flexibleengine_as_groups_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_as_groups_test.go
@@ -27,6 +27,12 @@ func TestAccDataSourceASGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(dataSourceName, "groups.0.scaling_group_name", name),
 				),
 			},
+			{
+				Config: testAccDataSourceASGroup_enterpriseProjectId(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+				),
+			},
 		},
 	})
 }
@@ -39,6 +45,15 @@ data "flexibleengine_as_groups" "groups" {
   name = flexibleengine_as_group.acc_as_group.scaling_group_name
 
   depends_on = [flexibleengine_as_group.acc_as_group]
+}
+`, testASGroup_basic(name))
+}
+
+func testAccDataSourceASGroup_enterpriseProjectId(name string) string {
+	return fmt.Sprintf(`
+%s
+data "flexibleengine_as_groups" "groups" {
+  enterprise_project_id = 0
 }
 `, testASGroup_basic(name))
 }


### PR DESCRIPTION
# 1、resrouce_flexibleengine_cbr_vault
### 1.1 script test
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/ab9aecf8-098a-4ff3-a4b0-ff7ce69c26a9)
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/4faad1f7-3a78-408f-a763-6edab3d39beb)
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/a9f023f4-29ba-4d47-9205-5f7d963bde4e)



# 2、resrouce_flexibleengine_cse_microservice_engine
### 2.1 script test
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/e842e754-1a2e-4371-924b-d0f1c3825683)
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/6997dc7e-cf0a-4a70-bc08-71866f071c14)
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/83bed4a7-c3b8-4d9c-9239-5913dc88d470)


### 2.2 unit test already has the enterprise_project_id field.

# 3、data_source_flexibleengine_as_groups
### 3.1 unit test
```hcl
=== RUN TestAccDataSourceASGroup_basic
=== PAUSE TestAccDataSourceASGroup_basic
=== CONT TestAccDataSourceASGroup_basic
--- PASS: TestAccDataSourceASGroup_basic (191.11s)
PASS

coverage: 3.7% of statements in ../../../terraform-provider-flexibleengine/...
```

### 3.2 script test
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/a884b437-47af-4973-8652-9f265780f512)
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/36da55a0-bf33-4e80-bb2f-ad80748dcfc2)
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/10f2ad7b-026f-4c09-9d8c-d4febab106e8)