### PR TITLE
docs(elb): fix docs issues

### DIFF
--- a/docs/data-sources/elb_certificate.md
+++ b/docs/data-sources/elb_certificate.md
@@ -27,7 +27,7 @@ The following arguments are supported:
 
   -> **NOTE:** The certificate name is not unique. Only returns the last created one when matched multiple certificates.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 

--- a/docs/data-sources/lb_certificate_v2.md
+++ b/docs/data-sources/lb_certificate_v2.md
@@ -23,23 +23,22 @@ data "flexibleengine_lb_certificate_v2" "by_name" {
 The arguments of this data source act as filters for querying the available Certificates in the current region.
 The given filters must match exactly one Certificate whose data will be exported as attributes.
 
-* `id` - (Optional) The id of the specific Certificate to retrieve.
+* `id` - (Optional, String) The id of the specific Certificate to retrieve.
 
-* `name` - (Optional) Human-readable name for the Certificate. Does not have
-    to be unique.
+* `name` - (Optional, String) Human-readable name for the Certificate. Does not have to be unique.
 
-* `description` - (Optional) Human-readable description for the Certificate.
+* `description` - (Optional, String) Human-readable description for the Certificate.
 
-* `domain` - (Optional) The domain of the Certificate.
+* `domain` - (Optional, String) The domain of the Certificate.
 
-## Attributes Reference
+## Attribute Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
-* `name` - See Argument Reference above.
-* `description` - See Argument Reference above.
-* `domain` - See Argument Reference above.
 * `private_key` - The private encrypted key of the Certificate, PEM format.
+
 * `certificate` - The public encrypted key of the Certificate, PEM format.
+
 * `update_time` - Indicates the update time.
+
 * `create_time` - Indicates the creation time.

--- a/docs/data-sources/lb_loadbalancer_v2.md
+++ b/docs/data-sources/lb_loadbalancer_v2.md
@@ -18,6 +18,9 @@ data "flexibleengine_lb_loadbalancer_v2" "test" {
 
 ## Argument Reference
 
+* `region` - (Optional, String) The region in which to query the data source. If omitted, the provider-level region
+  will be used.
+
 * `name` - (Optional, String) Specifies the name of the load balancer.
 
 * `id` - (Optional, String) Specifies the data source ID of the load balancer in UUID format.
@@ -28,10 +31,12 @@ data "flexibleengine_lb_loadbalancer_v2" "test" {
 
 * `vip_address` - (Optional, String) Specifies the private IP address of the load balancer.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `vip_port_id` - The ID of the port bound to the private IP address of the load balancer.
+
 * `status` - The operating status of the load balancer.
+
 * `tags` - The tags associated with the load balancer.

--- a/docs/resources/elb_backend.md
+++ b/docs/resources/elb_backend.md
@@ -24,27 +24,20 @@ resource "flexibleengine_elb_backend" "backend" {
 
 The following arguments are supported:
 
-* `listener_id` - (Required) Specifies the listener ID.
+* `listener_id` - (Required, String, ForceNew) Specifies the listener ID. Changing this will create a new resource.
 
-* `server_id` - (Required) Specifies the backend member ID.
+* `server_id` - (Required, String, ForceNew) Specifies the backend member ID. Changing this will create a new resource.
 
-* `address` - (Required) Specifies the private IP address of the backend member.
+* `address` - (Required, String, ForceNew) Specifies the private IP address of the backend member.
+  Changing this will create a new resource.
 
-## Attributes Reference
+## Attribute Reference
 
-The following attributes are exported:
+All the arguments above can also be exported attributes.
 
-* `id` - Specifies the backend member ID.
-* `listener_id` - See Argument Reference above.
-* `server_id` - See Argument Reference above.
-* `address` - See Argument Reference above.
-* `server_address` - Specifies the floating IP address assigned to the backend member.
-* `status` - Specifies the backend ECS status. The value is ACTIVE, PENDING,
-    or ERROR.
-* `health_status` - Specifies the health check status. The value is NORMAL,
-    ABNORMAL, or UNAVAILABLE.
-* `update_time` - Specifies the time when information about the backend member
-    was updated.
-* `create_time` - Specifies the time when the backend member was created.
-* `server_name` - Specifies the backend member name.
-* `listeners` - Specifies the listener to which the backend member belongs.
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.

--- a/docs/resources/elb_certificate.md
+++ b/docs/resources/elb_certificate.md
@@ -84,7 +84,7 @@ The following arguments are supported:
 * `description` - (Optional, String) Specifies the description of the certificate.
 
 * `type` - (Optional, String, ForceNew) Specifies the certificate type. The default value is "server".
-  The value can be one of the following:
+  Changing this creates a new certificate. The value can be one of the following:
   + server: indicates the server certificate.
   + client: indicates the CA certificate.
 
@@ -96,22 +96,17 @@ The following arguments are supported:
 * `domain` - (Optional, String) Specifies the domain of the certificate. The value contains a maximum of 100 characters.
   This parameter is valid only when `type` is set to "server".
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Specifies a resource ID in UUID format.
+
 * `update_time` - Indicates the update time.
+
 * `create_time` - Indicates the creation time.
-* `expire_time` - Indicates the expire time.
 
-## Timeouts
-
-This resource provides the following timeouts configuration options:
-
-* `create` - Default is 10 minute.
-* `update` - Default is 10 minute.
-* `delete` - Default is 5 minute.
+* `expire_time` - Indicates the expired time.
 
 ## Import
 

--- a/docs/resources/elb_health.md
+++ b/docs/resources/elb_health.md
@@ -27,51 +27,49 @@ resource "flexibleengine_elb_health" "healthcheck" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to create the elb health. If
-    omitted, the `region` argument of the provider is used. Changing this
-    creates a new elb health.
+* `region` - (Optional, String, ForceNew) The region in which to create the elb health. If
+  omitted, the `region` argument of the provider is used. Changing this creates a new elb health.
 
-* `listener_id` - (Required) Specifies the ID of the listener to which the health
-    check belongs.
+* `listener_id` - (Required, String, ForceNew) Specifies the ID of the listener to which the health
+  check belongs. Changing this creates a new elb health.
 
-* `healthcheck_protocol` - (Optional) Specifies the protocol used for the health
-    check. The value can be HTTP or TCP (case-insensitive).
+* `healthcheck_protocol` - (Optional, String) Specifies the protocol used for the health
+  check. The value can be HTTP or TCP (case-insensitive).
 
-* `healthcheck_uri` - (Optional) Specifies the URI for health check. This parameter
-    is valid when healthcheck_ protocol is HTTP. The value is a string of 1 to 80
-    characters that must start with a slash (/) and can only contain letters, digits,
-    and special characters, such as -/.%?#&.
+* `healthcheck_uri` - (Optional, String) Specifies the URI for health check. This parameter
+  is valid when healthcheck_ protocol is HTTP. The value is a string of 1 to 80
+  characters that must start with a slash (/) and can only contain letters, digits,
+  and special characters, such as -/.%?#&.
 
-* `healthcheck_connect_port` - (Optional) Specifies the port used for the health
-    check. The value ranges from 1 to 65535.
+* `healthcheck_connect_port` - (Optional, Int) Specifies the port used for the health
+  check. The value ranges from 1 to 65535.
 
-* `healthy_threshold` - (Optional) Specifies the threshold at which the health
-    check result is success, that is, the number of consecutive successful health
-    checks when the health check result of the backend server changes from fail
-    to success. The value ranges from 1 to 10.
+* `healthy_threshold` - (Optional, Int) Specifies the threshold at which the health
+  check result is success, that is, the number of consecutive successful health
+  checks when the health check result of the backend server changes from fail
+  to success. The value ranges from 1 to 10.
 
-* `unhealthy_threshold` - (Optional) Specifies the threshold at which the health
-    check result is fail, that is, the number of consecutive failed health checks
-    when the health check result of the backend server changes from success to fail.
-    The value ranges from 1 to 10.
+* `unhealthy_threshold` - (Optional, Int) Specifies the threshold at which the health
+  check result is fail, that is, the number of consecutive failed health checks
+  when the health check result of the backend server changes from success to fail.
+  The value ranges from 1 to 10.
 
-* `healthcheck_timeout` - (Optional) Specifies the maximum timeout duration
-    (s) for the health check. The value ranges from 1 to 50.
+* `healthcheck_timeout` - (Optional, Int) Specifies the maximum timeout duration
+  (s) for the health check. The value ranges from 1 to 50.
 
-* `healthcheck_interval` - (Optional) Specifies the maximum interval (s) for
-    health check. The value ranges from 1 to 5.
+* `healthcheck_interval` - (Optional, Int) Specifies the maximum interval (s) for
+  health check. The value ranges from 1 to 5.
 
-## Attributes Reference
+## Attribute Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - Specifies the health check ID.
-* `region` - See Argument Reference above.
-* `listener_id` - See Argument Reference above.
-* `healthcheck_protocol` - See Argument Reference above.
-* `healthcheck_uri` - See Argument Reference above.
-* `healthcheck_connect_port` - See Argument Reference above.
-* `healthy_threshold` - See Argument Reference above.
-* `unhealthy_threshold` - See Argument Reference above.
-* `healthcheck_timeout` - See Argument Reference above.
-* `healthcheck_interval` - See Argument Reference above.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.

--- a/docs/resources/elb_ipgroup.md
+++ b/docs/resources/elb_ipgroup.md
@@ -33,28 +33,23 @@ The following arguments are supported:
 
 * `description` - (Optional, String) Specifies the description of the ip group.
 
-* `ip_list` - (Required, List) Specifies an array of one or more ip addresses. The ip_list object structure is
-  documented below.
+* `ip_list` - (Required, List) Specifies an array of one or more ip addresses. The [ip_list](#elb_ip_list) object
+  structure is documented below.
 
+<a name="elb_ip_list"></a>
 The `ip_list` block supports:
 
 * `ip` - (Required, String) IP address or CIDR block.
 
 * `description` - (Optional, String) Human-readable description for the ip.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The uuid of the ip group.
 
-## Timeouts
-
-This resource provides the following timeouts configuration options:
-
-* `create` - Default is 10 minute.
-* `update` - Default is 10 minute.
-* `delete` - Default is 5 minute.
+## Import
 
 ELB IP group can be imported using the IP group ID, e.g.
 

--- a/docs/resources/elb_listener.md
+++ b/docs/resources/elb_listener.md
@@ -37,107 +37,88 @@ resource "flexibleengine_elb_listener" "listener" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to create the elb listener. If
-    omitted, the `region` argument of the provider is used. Changing this
-    creates a new elb listener.
+* `region` - (Optional, String, ForceNew) The region in which to create the elb listener. If
+  omitted, the `region` argument of the provider is used. Changing this creates a new elb listener.
 
-* `loadbalancer_id` - (Required) Specifies the ID of the load balancer to which
-    the listener belongs.
+* `loadbalancer_id` - (Required, String, ForceNew) Specifies the ID of the load balancer to which
+  the listener belongs. Changing this creates a new elb listener.
 
-* `name` - (Required) Specifies the load balancer name. The name is a string
-    of 1 to 64 characters that consist of letters, digits, underscores (_), and
-    hyphens (-).
+* `name` - (Optional, String) Specifies the load balancer name. The name is a string
+  of 1 to 64 characters that consist of letters, digits, underscores (_), and hyphens (-).
 
-* `protocol` - (Required) Specifies the listening protocol used for layer 4
-    or 7. The value can be HTTP, TCP, HTTPS, or UDP.
+* `protocol` - (Required, String, ForceNew) Specifies the listening protocol used for layer 4
+  or 7. The value can be HTTP, TCP, HTTPS, or UDP. Changing this creates a new elb listener.
 
-* `protocol_port` - (Required) Specifies the listening port. The value ranges from 1
-    to 65535.
+* `protocol_port` - (Required, Int) Specifies the listening port. The value ranges from 1 to 65535.
 
-* `backend_protocol` - (Required) Specifies the backend protocol. If the value
-    of protocol is UDP, the value of this parameter can only be UDP. The value can
-    be HTTP, TCP, or UDP.
+* `backend_protocol` - (Required, String, ForceNew) Specifies the backend protocol. If the value
+  of protocol is UDP, the value of this parameter can only be UDP. The value can
+  be HTTP, TCP, or UDP. Changing this creates a new elb listener.
 
-* `backend_port` - (Required) Specifies the backend port. The value ranges from
-    1 to 65535.
+* `backend_port` - (Required, Int) Specifies the backend port. The value ranges from 1 to 65535.
 
-* `lb_algorithm` - (Required) Specifies the load balancing algorithm for the
-    listener. The value can be roundrobin, leastconn, or source.
+* `lb_algorithm` - (Required, String) Specifies the load balancing algorithm for the
+  listener. The value can be round-robin, leastconn, or source.
 
-* `description` - (Optional) Provides supplementary information about the listener.
-    The value is a string of 0 to 128 characters and cannot be <>.
+* `description` - (Optional, String) Provides supplementary information about the listener.
+  The value is a string of 0 to 128 characters and cannot be <>.
 
-* `session_sticky` - (Optional) Specifies whether to enable sticky session.
-    The value can be true or false. The Sticky session is enabled when the value
-    is true, and is disabled when the value is false. If the value of protocol is
-    HTTP, HTTPS, or TCP, and the value of lb_algorithm is not roundrobin, the value
-    of this parameter can only be false.
+* `session_sticky` - (Optional, Bool, ForceNew) Specifies whether to enable sticky session.
+  The value can be true or false. The Sticky session is enabled when the value
+  is true, and is disabled when the value is false. If the value of protocol is
+  HTTP, HTTPS, or TCP, and the value of lb_algorithm is not round-robin, the value
+  of this parameter can only be false. Changing this creates a new elb listener.
 
-* `session_sticky_type` - (Optional) Specifies the cookie processing method.
-    The value is insert. insert indicates that the cookie is inserted by the load
-    balancer. This parameter is valid when protocol is set to HTTP, and session_sticky
-    to true. The default value is insert. This parameter is invalid when protocol
-    is set to TCP or UDP, which means the parameter is empty.
+* `session_sticky_type` - (Optional, String, ForceNew) Specifies the cookie processing method.
+  The value is insert. insert indicates that the cookie is inserted by the load
+  balancer. This parameter is valid when protocol is set to HTTP, and session_sticky
+  to true. The default value is insert. This parameter is invalid when protocol
+  is set to TCP or UDP, which means the parameter is empty. Changing this creates a new elb listener.
 
-* `cookie_timeout` - (Optional) Specifies the cookie timeout period (minutes).
-    This parameter is valid when protocol is set to HTTP, session_sticky to true,
-    and session_sticky_type to insert. This parameter is invalid when protocol is
-    set to TCP or UDP. The value ranges from 1 to 1440.
+* `cookie_timeout` - (Optional, Int, ForceNew) Specifies the cookie timeout period (minutes).
+  This parameter is valid when protocol is set to HTTP, session_sticky to true,
+  and session_sticky_type to insert. This parameter is invalid when protocol is
+  set to TCP or UDP. The value ranges from 1 to 1440. Changing this creates a new elb listener.
 
-* `tcp_timeout` - (Optional) Specifies the TCP timeout period (minutes). This
-    parameter is valid when protocol is set to TCP. The value ranges from 1 to 5.
+* `tcp_timeout` - (Optional, Int) Specifies the TCP timeout period (minutes). This
+  parameter is valid when protocol is set to TCP. The value ranges from 1 to 5.
 
-* `tcp_draining` - (Optional) Specifies whether to maintain the TCP connection
-    to the backend ECS after the ECS is deleted. This parameter is valid when protocol
-    is set to TCP. The value can be true or false.
+* `tcp_draining` - (Optional, Bool) Specifies whether to maintain the TCP connection
+  to the backend ECS after the ECS is deleted. This parameter is valid when protocol
+  is set to TCP. The value can be true or false.
 
-* `tcp_draining_timeout` - (Optional) Specifies the timeout duration (minutes)
-    for the TCP connection to the backend ECS after the ECS is deleted. This parameter
-    is valid when protocol is set to TCP, and tcp_draining to true. The value ranges
-    from 0 to 60.
+* `tcp_draining_timeout` - (Optional, Int) Specifies the timeout duration (minutes)
+  for the TCP connection to the backend ECS after the ECS is deleted. This parameter
+  is valid when protocol is set to TCP, and tcp_draining to true. The value ranges from 0 to 60.
 
-* `certificate_id` - (Optional) Specifies the ID of the SSL certificate used
-    for security authentication when HTTPS is used to make API calls. This parameter
-    is mandatory if the value of protocol is HTTPS. The value can be obtained by
-    viewing the details of the SSL certificate.
+* `certificate_id` - (Optional, String, ForceNew) Specifies the ID of the SSL certificate used
+  for security authentication when HTTPS is used to make API calls. This parameter
+  is mandatory if the value of protocol is HTTPS. The value can be obtained by
+  viewing the details of the SSL certificate. Changing this creates a new elb listener.
 
-* `udp_timeout` - (Optional) Specifies the UDP timeout duration (minutes). This
-    parameter is valid when protocol is set to UDP. The value ranges from 1 to 1440.
+* `udp_timeout` - (Optional, Int) Specifies the UDP timeout duration (minutes). This
+  parameter is valid when protocol is set to UDP. The value ranges from 1 to 1440.
 
-* `ssl_protocols` - (Optional) Specifies the SSL protocol standard supported
-    by a tracker, which is used for enabling specified encryption protocols. This
-    parameter is valid only when the value of protocol is set to HTTPS. The value
-    is TLSv1.2 or TLSv1.2 TLSv1.1 TLSv1. The default value is TLSv1.2.
+* `ssl_protocols` - (Optional, String, ForceNew) Specifies the SSL protocol standard supported
+  by a tracker, which is used for enabling specified encryption protocols. This
+  parameter is valid only when the value of protocol is set to HTTPS. The value
+  is TLSv1.2 or TLSv1.2 TLSv1.1 TLSv1. The default value is TLSv1.2. Changing this creates a new elb listener.
 
-* `ssl_ciphers` - (Optional) Specifies the cipher suite of an encryption protocol.
-    This parameter is valid only when the value of protocol is set to HTTPS. The
-    value is Default, Extended, or Strict. The default value is Default. The value
-    can only be set to Extended if the value of ssl_protocols is set to TLSv1.2
-    TLSv1.1 TLSv1.
+* `ssl_ciphers` - (Optional, String) Specifies the cipher suite of an encryption protocol.
+  This parameter is valid only when the value of protocol is set to HTTPS. The
+  value is Default, Extended, or Strict. The default value is Default. The value
+  can only be set to Extended if the value of ssl_protocols is set to TLSv1.2 TLSv1.1 TLSv1.
 
-## Attributes Reference
+## Attribute Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - Specifies the listener ID.
-* `region` - See Argument Reference above.
-* `name` - See Argument Reference above.
-* `description` - See Argument Reference above.
-* `loadbalancer_id` - See Argument Reference above.
-* `protocol` - See Argument Reference above.
-* `protocol_port` - See Argument Reference above.
-* `backend_protocol` - See Argument Reference above.
-* `backend_port` - See Argument Reference above.
-* `lb_algorithm` - See Argument Reference above.
-* `session_sticky` - See Argument Reference above.
-* `session_sticky_type` - See Argument Reference above.
-* `cookie_timeout` - See Argument Reference above.
-* `tcp_timeout` - See Argument Reference above.
-* `tcp_draining` - See Argument Reference above.
-* `tcp_draining_timeout` - See Argument Reference above.
-* `certificate_id` - See Argument Reference above.
-* `udp_timeout` - See Argument Reference above.
-* `ssl_protocols` - See Argument Reference above.
-* `ssl_ciphers` - See Argument Reference above.
-* `admin_state_up` - Specifies the status of the load balancer. Value range:
-    false: The load balancer is disabled. true: The load balancer runs properly.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.

--- a/docs/resources/elb_loadbalancer.md
+++ b/docs/resources/elb_loadbalancer.md
@@ -52,67 +52,58 @@ resource "flexibleengine_elb_loadbalancer" "elb" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to create the loadbalancer. If
-    omitted, the `region` argument of the provider is used. Changing this
-    creates a new loadbalancer.
+* `region` - (Optional, String, ForceNew) The region in which to create the loadbalancer. If
+  omitted, the `region` argument of the provider is used. Changing this creates a new loadbalancer.
 
-* `name` - (Required) Specifies the load balancer name. The name is a string
-    of 1 to 64 characters that consist of letters, digits, underscores (_),
-    and hyphens (-).
+* `name` - (Optional, String) Specifies the load balancer name. The name is a string
+  of 1 to 64 characters that consist of letters, digits, underscores (_), and hyphens (-).
 
-* `type` - (Required) Specifies the load balancer type. The value can be
-    Internal or External.
+* `type` - (Required, String, ForceNew) Specifies the load balancer type. The value can be
+  Internal or External. Changing this creates a new loadbalancer.
 
-* `vpc_id` - (Required) Specifies the VPC ID.
+* `vpc_id` - (Required, String, ForceNew) Specifies the VPC ID. Changing this creates a new loadbalancer.
 
-* `description` - (Optional) Provides supplementary information about the
-    listener. The value is a string of 0 to 128 characters and cannot be <>.
+* `description` - (Optional, String) Provides supplementary information about the
+  listener. The value is a string of 0 to 128 characters and cannot be <>.
 
-* `vip_address` - (Optional) Specifies the IP address provided by ELB.
-    When type is set to External, the value of this parameter is the elastic
-    IP address. When type is set to Internal, the value of this parameter is
-    the private network IP address. You can select an existing elastic IP address
-    and create a public network load balancer. When this parameter is configured,
-    parameter `bandwidth` is invalid.
+* `vip_address` - (Optional, String, ForceNew) Specifies the IP address provided by ELB.
+  When type is set to External, the value of this parameter is the elastic
+  IP address. When type is set to Internal, the value of this parameter is
+  the private network IP address. You can select an existing elastic IP address
+  and create a public network load balancer. When this parameter is configured,
+  parameter `bandwidth` is invalid. Changing this creates a new loadbalancer.
 
-* `bandwidth` - (Optional) Specifies the bandwidth (Mbit/s). This parameter
-    is valid when type is set to External, and it is invalid when type
-    is set to Internal. The value ranges from 1 to 300.
+* `bandwidth` - (Optional, Int) Specifies the bandwidth (Mbit/s). This parameter
+  is valid when type is set to External, and it is invalid when type
+  is set to Internal. The value ranges from 1 to 300.
 
-* `vip_subnet_id` - (Optional) Specifies the ID of the private network
-    to be added. This parameter is mandatory when type is set to Internal,
-    and it is invalid when type is set to External.
+* `vip_subnet_id` - (Optional, String, ForceNew) Specifies the ID of the private network
+  to be added. This parameter is mandatory when type is set to Internal,
+  and it is invalid when type is set to External. Changing this creates a new loadbalancer.
 
-* `security_group_id` - (Optional) Specifies the security group ID. The
-    value is a string of 1 to 200 characters that consists of uppercase and
-    lowercase letters, digits, and hyphens (-). This parameter is mandatory
-    when type is set to Internal, and it is invalid when type is set to External.
+* `security_group_id` - (Optional, String, ForceNew) Specifies the security group ID. The
+  value is a string of 1 to 200 characters that consists of uppercase and
+  lowercase letters, digits, and hyphens (-). This parameter is mandatory
+  when type is set to Internal, and it is invalid when type is set to External.
+  Changing this creates a new loadbalancer.
 
-* `az` - (Optional) Specifies the ID of the availability zone (AZ). This
-    parameter is mandatory when type is set to Internal, and it is invalid
-    when type is set to External.
+* `az` - (Optional, String, ForceNew) Specifies the ID of the availability zone (AZ). This
+  parameter is mandatory when type is set to Internal, and it is invalid
+  when type is set to External. Changing this creates a new loadbalancer.
 
-* `admin_state_up` - (Optional) Specifies the status of the load balancer. Defaults to true.
-    + true: indicates that the load balancer is running.
-    + false: indicates that the load balancer is stopped.
+* `tenantid` - (Optional, String, ForceNew) Specifies the tenant ID. This parameter is mandatory
+  only when type is set to Internal. Changing this creates a new loadbalancer.
 
-* `tenantid` - (Optional) Specifies the tenant ID. This parameter is mandatory
-    only when type is set to Internal.
+## Attribute Reference
 
-## Attributes Reference
-
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - Specifies the load balancer ID.
-* `region` - See Argument Reference above.
-* `name` - See Argument Reference above.
-* `description` - See Argument Reference above.
-* `vpc_id` - See Argument Reference above.
-* `bandwidth` - See Argument Reference above.
-* `type` - See Argument Reference above.
-* `admin_state_up` - See Argument Reference above.
-* `vip_subnet_id` - See Argument Reference above.
-* `az` - See Argument Reference above.
-* `security_group_id` - See Argument Reference above.
-* `vip_address` - See Argument Reference above.
-* `tenantid` - See Argument Reference above.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 5 minutes.

--- a/docs/resources/lb_certificate_v2.md
+++ b/docs/resources/lb_certificate_v2.md
@@ -79,31 +79,32 @@ EOT
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to obtain the V2 Networking client.
-    A Networking client is needed to create an LB certificate. If omitted, the
-    `region` argument of the provider is used. Changing this creates a new
-    LB certificate.
+* `region` - (Optional, String, ForceNew) The region in which to obtain the V2 Networking client.
+  A Networking client is needed to create an LB certificate. If omitted, the
+  `region` argument of the provider is used. Changing this creates a new LB certificate.
 
-* `name` - (Optional) Human-readable name for the Certificate. Does not have
-    to be unique.
+* `name` - (Optional, String) Human-readable name for the Certificate. Does not have to be unique.
 
-* `private_key` - (Required) The private encrypted key of the Certificate, PEM format.
+* `private_key` - (Required, String) The private encrypted key of the Certificate, PEM format.
 
-* `certificate` - (Required) The public encrypted key of the Certificate, PEM format.
+* `certificate` - (Required, String) The public encrypted key of the Certificate, PEM format.
 
-* `description` - (Optional) Human-readable description for the Certificate.
+* `description` - (Optional, String) Human-readable description for the Certificate.
 
-* `domain` - (Optional) The domain of the Certificate.
+* `domain` - (Optional, String) The domain of the Certificate.
 
-## Attributes Reference
+## Attribute Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
-* `region` - See Argument Reference above.
-* `name` - See Argument Reference above.
-* `description` - See Argument Reference above.
-* `domain` - See Argument Reference above.
-* `private_key` - See Argument Reference above.
-* `certificate` - See Argument Reference above.
 * `update_time` - Indicates the update time.
+
 * `create_time` - Indicates the creation time.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 5 minutes.

--- a/docs/resources/lb_l7policy_v2.md
+++ b/docs/resources/lb_l7policy_v2.md
@@ -44,53 +44,42 @@ resource "flexibleengine_lb_l7policy_v2" "l7policy_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to obtain the V2 Networking client.
-    A Networking client is needed to create an . If omitted, the
-    `region` argument of the provider is used. Changing this creates a new
-    L7 Policy.
+* `region` - (Optional, String, ForceNew) The region in which to obtain the V2 Networking client.
+  A Networking client is needed to create an . If omitted, the
+  `region` argument of the provider is used. Changing this creates a new L7 Policy.
 
-* `name` - (Optional) Human-readable name for the L7 Policy. Does not have
-    to be unique.
+* `name` - (Optional, String) Human-readable name for the L7 Policy. Does not have to be unique.
 
-* `description` - (Optional) Human-readable description for the L7 Policy.
+* `description` - (Optional, String) Human-readable description for the L7 Policy.
 
-* `action` - (Required) The L7 Policy action - can either be REDIRECT_TO_POOL,
-    or REDIRECT_TO_LISTENER. Changing this creates a new L7 Policy.
+* `action` - (Required, String, ForceNew) The L7 Policy action - can either be REDIRECT_TO_POOL,
+  or REDIRECT_TO_LISTENER. Changing this creates a new L7 Policy.
 
-* `listener_id` - (Required) The Listener on which the L7 Policy will be associated with.
-    Changing this creates a new L7 Policy.
+* `listener_id` - (Required, String, ForceNew) The Listener on which the L7 Policy will be associated with.
+  Changing this creates a new L7 Policy.
 
-* `position` - (Optional) The position of this policy on the listener. Positions start at 1.
-    Changing this creates a new L7 Policy.
+* `position` - (Optional, Int, ForceNew) The position of this policy on the listener. Positions start at 1.
+  Changing this creates a new L7 Policy.
 
-* `redirect_pool_id` - (Optional) Requests matching this policy will be redirected to
-    the pool with this ID. Only valid if action is REDIRECT_TO_POOL.
+* `redirect_pool_id` - (Optional, String) Requests matching this policy will be redirected to
+  the pool with this ID. Only valid if action is REDIRECT_TO_POOL.
 
-* `redirect_listener_id` - (Optional) Requests matching this policy will be redirected to
-    the listener with this ID. Only valid if action is REDIRECT_TO_LISTENER.
+* `redirect_listener_id` - (Optional, String) Requests matching this policy will be redirected to
+  the listener with this ID. Only valid if action is REDIRECT_TO_LISTENER.
 
-* `admin_state_up` - (Optional) The administrative state of the L7 Policy.
-    This value can only be true (UP).
+## Attribute Reference
 
-* `tenant_id` - (Optional) The UUID of the tenant who owns the L7 Policy.
-    Only administrative users can specify a tenant UUID other than their own.
-    Changing this creates a new L7 Policy.
+In addition to all arguments above, the following attributes are exported:
 
-## Attributes Reference
+* `id` - The unique ID for the L7 policy.
 
-The following attributes are exported:
+## Timeouts
 
-* `id` - The unique ID for the L7 {olicy.
-* `region` - See Argument Reference above.
-* `tenant_id` - See Argument Reference above.
-* `name` - See Argument Reference above.
-* `description` - See Argument Reference above.
-* `action` - See Argument Reference above.
-* `listener_id` - See Argument Reference above.
-* `position` - See Argument Reference above.
-* `redirect_pool_id` - See Argument Reference above.
-* `redirect_listener_id` - See Argument Reference above.
-* `admin_state_up` - See Argument Reference above.
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/lb_l7rule_v2.md
+++ b/docs/resources/lb_l7rule_v2.md
@@ -51,50 +51,38 @@ resource "flexibleengine_lb_l7rule_v2" "l7rule_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to obtain the V2 Networking client.
-    A Networking client is needed to create an . If omitted, the
-    `region` argument of the provider is used. Changing this creates a new
-    L7 Rule.
+* `region` - (Optional, String, ForceNew) The region in which to obtain the V2 Networking client.
+  A Networking client is needed to create an . If omitted, the
+  `region` argument of the provider is used. Changing this creates a new L7 Rule.
 
-* `description` - (Optional) Human-readable description for the L7 Rule.
+* `type` - (Required, String, ForceNew) The L7 Rule type - can either be HOST_NAME or PATH.
+  Changing this creates a new L7 Rule.
 
-* `type` - (Required) The L7 Rule type - can either be HOST_NAME or PATH.
-    Changing this creates a new L7 Rule.
+* `compare_type` - (Required, String) The comparison type for the L7 rule - can either be
+  STARTS_WITH, EQUAL_TO or REGEX
 
-* `compare_type` - (Required) The comparison type for the L7 rule - can either be
-    STARTS_WITH, EQUAL_TO or REGEX
+* `l7policy_id` - (Required, String, ForceNew) The ID of the L7 Policy to query. Changing this creates a new L7 Rule.
 
-* `l7policy_id` - (Required) The ID of the L7 Policy to query. Changing this creates a new
-    L7 Rule.
+* `value` - (Required, String) The value to use for the comparison. For example, the file type to compare.
 
-* `value` - (Required) The value to use for the comparison. For example, the file type to
-    compare.
+* `key` - (Optional, String, ForceNew) The key to use for the comparison. For example, the name of the cookie to
+  evaluate. Valid when `type` is set to COOKIE or HEADER. Changing this creates a new L7 Rule.
 
-* `key` - (Optional) The key to use for the comparison. For example, the name of the cookie to
-    evaluate. Valid when `type` is set to COOKIE or HEADER. Changing this creates a new L7 Rule.
+## Attribute Reference
 
-* `admin_state_up` - (Optional) The administrative state of the L7 Rule.
-    The value can only be true (UP).
-
-* `tenant_id` - (Optional) The UUID of the tenant who owns the L7 Rule.
-    Only administrative users can specify a tenant UUID other than their own.
-    Changing this creates a new L7 Rule.
-
-## Attributes Reference
-
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - The unique ID for the L7 Rule.
-* `region` - See Argument Reference above.
-* `tenant_id` - See Argument Reference above.
-* `type` - See Argument Reference above.
-* `compare_type` - See Argument Reference above.
-* `l7policy_id` - See Argument Reference above.
-* `value` - See Argument Reference above.
-* `key` - See Argument Reference above.
-* `invert` - See Argument Reference above.
-* `admin_state_up` - See Argument Reference above.
+
 * `listener_id` - The ID of the Listener owning this resource.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/lb_listener_v2.md
+++ b/docs/resources/lb_listener_v2.md
@@ -111,31 +111,29 @@ resource "flexibleengine_lb_listener_v2" "listener_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to create the listener resource.
-    If omitted, the `region` argument of the provider is used.
-    Changing this creates a new listener.
+* `region` - (Optional, String, ForceNew) The region in which to create the listener resource.
+  If omitted, the `region` argument of the provider is used. Changing this creates a new listener.
 
-* `loadbalancer_id` - (Required) The load balancer on which to provision this
-    listener. Changing this creates a new listener.
+* `loadbalancer_id` - (Required, String, ForceNew) The load balancer on which to provision this
+  listener. Changing this creates a new listener.
 
-* `protocol` - (Required) The protocol - can either be TCP, UDP, HTTP or TERMINATED_HTTPS.
-    Changing this creates a new listener.
+* `protocol` - (Required, String, ForceNew) The protocol - can either be TCP, UDP, HTTP or TERMINATED_HTTPS.
+  Changing this creates a new listener.
 
-* `protocol_port` - (Required) The port on which to listen for client traffic.
-    Changing this creates a new listener.
+* `protocol_port` - (Required, Int, ForceNew) The port on which to listen for client traffic.
+  Changing this creates a new listener.
 
-* `default_pool_id` - (Optional) The ID of the default pool with which the
-    listener is associated. Changing this creates a new listener.
+* `default_pool_id` - (Optional, String, ForceNew) The ID of the default pool with which the
+  listener is associated. Changing this creates a new listener.
 
-* `name` - (Optional) Human-readable name for the listener. Does not have
-    to be unique.
+* `name` - (Optional, String) Human-readable name for the listener. Does not have to be unique.
 
-* `description` - (Optional) Human-readable description for the listener.
+* `description` - (Optional, String) Human-readable description for the listener.
 
-* `tags` - (Optional) The key/value pairs to associate with the listener.
+* `tags` - (Optional, Map) The key/value pairs to associate with the listener.
 
 * `http2_enable` - (Optional, Bool) Specifies whether to use HTTP/2. The default value is false.
-    This parameter is valid only when the protocol is set to *TERMINATED_HTTPS*.
+  This parameter is valid only when the protocol is set to *TERMINATED_HTTPS*.
 
 * `transparent_client_ip_enable` - (Optional, Bool) Specifies whether to pass source IP addresses of the clients to
   backend servers.
@@ -155,21 +153,20 @@ The following arguments are supported:
   server, in seconds. This parameter is available only for HTTP and HTTPS listeners. The value ranges from 1 to 300,
   and the default value is 60.
 
-* `default_tls_container_ref` - (Optional) A reference to a Barbican Secrets
-    container which stores TLS information. This is required if the protocol
-    is `TERMINATED_HTTPS`. See
-    [here](https://wiki.openstack.org/wiki/Network/LBaaS/docs/how-to-create-tls-loadbalancer)
-    for more information.
+* `default_tls_container_ref` - (Optional, String) A reference to a Barbican Secrets
+  container which stores TLS information. This is required if the protocol is `TERMINATED_HTTPS`. See
+  [here](https://wiki.openstack.org/wiki/Network/LBaaS/docs/how-to-create-tls-loadbalancer)
+  for more information.
 
-* `sni_container_refs` - (Optional) A list of references to Barbican Secrets
-    containers which store SNI information. See
-    [here](https://wiki.openstack.org/wiki/Network/LBaaS/docs/how-to-create-tls-loadbalancer)
-    for more information.
+* `sni_container_refs` - (Optional, List) A list of references to Barbican Secrets
+  containers which store SNI information. See
+  [here](https://wiki.openstack.org/wiki/Network/LBaaS/docs/how-to-create-tls-loadbalancer)
+  for more information.
 
-* `tls_ciphers_policy` - (Optional) Specifies the security policy used by the listener.
-    This parameter is valid only when the load balancer protocol is set to TERMINATED_HTTPS.
-    The value can be tls-1-0, tls-1-1, tls-1-2, or tls-1-2-strict, and the default value is tls-1-0.
-    For details of cipher suites for each security policy, see the table below.
+* `tls_ciphers_policy` - (Optional, String) Specifies the security policy used by the listener.
+  This parameter is valid only when the load balancer protocol is set to TERMINATED_HTTPS.
+  The value can be tls-1-0, tls-1-1, tls-1-2, or tls-1-2-strict, and the default value is tls-1-0.
+  For details of cipher suites for each security policy, see the table below.
 
 <table>
   <tr>
@@ -197,18 +194,16 @@ The following arguments are supported:
   </tr>
 </table>
 
-## Attributes Reference
+## Attribute Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - The unique ID for the listener.
-* `protocol` - See Argument Reference above.
-* `protocol_port` - See Argument Reference above.
-* `name` - See Argument Reference above.
-* `default_port_id` - See Argument Reference above.
-* `description` - See Argument Reference above.
-* `http2_enable` - See Argument Reference above.
-* `default_tls_container_ref` - See Argument Reference above.
-* `sni_container_refs` - See Argument Reference above.
-* `tls_ciphers_policy` - See Argument Reference above.
-* `tags` - See Argument Reference above.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.

--- a/docs/resources/lb_loadbalancer_v2.md
+++ b/docs/resources/lb_loadbalancer_v2.md
@@ -24,55 +24,44 @@ resource "flexibleengine_lb_loadbalancer_v2" "lb_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to create the loadbalancer resource.
-    If omitted, the `region` argument of the provider is used.
-    Changing this creates a new loadbalancer.
+* `region` - (Optional, String, ForceNew) The region in which to create the loadbalancer resource.
+  If omitted, the `region` argument of the provider is used. Changing this creates a new loadbalancer.
 
-* `vip_subnet_id` - (Required) The `ipv4_subnet_id` or `ipv6_subnet_id` of the
-    VPC Subnet on which to allocate the loadbalancer's address.
-    A tenant can only create Loadbalancers on networks authorized
-    by policy (e.g. networks that belong to them or networks that
-    are shared).  Changing this creates a new loadbalancer.
+* `vip_subnet_id` - (Required, String, ForceNew) The `ipv4_subnet_id` or `ipv6_subnet_id` of the
+  VPC Subnet on which to allocate the loadbalancer's address.
+  A tenant can only create Loadbalancers on networks authorized
+  by policy (e.g. networks that belong to them or networks that
+  are shared).  Changing this creates a new loadbalancer.
 
-* `name` - (Optional) Human-readable name for the loadbalancer. Does not have
-    to be unique.
+* `name` - (Optional, String) Human-readable name for the loadbalancer. Does not have to be unique.
 
-* `description` - (Optional) Human-readable description for the loadbalancer.
+* `description` - (Optional, String) Human-readable description for the loadbalancer.
 
-* `vip_address` - (Optional) The ip address of the load balancer.
-    Changing this creates a new loadbalancer.
+* `vip_address` - (Optional, String, ForceNew) The ip address of the load balancer.
+  Changing this creates a new loadbalancer.
 
-* `tags` - (Optional) The key/value pairs to associate with the loadbalancer.
+* `tags` - (Optional, Map) The key/value pairs to associate with the loadbalancer.
 
-* `loadbalancer_provider` - (Optional) The name of the provider. Currently, only
-    vlb is supported. Changing this creates a new loadbalancer.
+* `loadbalancer_provider` - (Optional, String, ForceNew) The name of the provider. Currently, only
+  vlb is supported. Changing this creates a new loadbalancer.
 
-* `security_group_ids` - (Optional) A list of security group IDs to apply to the
-    loadbalancer. The security groups must be specified by ID and not name (as
-    opposed to how they are configured with the Compute Instance).
+* `security_group_ids` - (Optional, List) A list of security group IDs to apply to the
+  loadbalancer. The security groups must be specified by ID and not name (as
+  opposed to how they are configured with the Compute Instance).
 
-* `admin_state_up` - (Optional) The administrative state of the loadbalancer.
-    A valid value is true (UP) or false (DOWN).
+## Attribute Reference
 
-* `tenant_id` - (Optional) The UUID of the tenant who owns the loadbalancer.
-    Only administrative users can specify a tenant UUID other than their own.
-    Changing this creates a new loadbalancer.
+In addition to all arguments above, the following attributes are exported:
 
-## Attributes Reference
-
-The following attributes are exported:
-
-* `region` - See Argument Reference above.
-* `vip_subnet_id` - See Argument Reference above.
-* `name` - See Argument Reference above.
-* `description` - See Argument Reference above.
-* `tenant_id` - See Argument Reference above.
-* `vip_address` - See Argument Reference above.
-* `admin_state_up` - See Argument Reference above.
-* `tags` - See Argument Reference above.
-* `loadbalancer_provider` - See Argument Reference above.
-* `security_group_ids` - See Argument Reference above.
 * `vip_port_id` - The Port ID of the Load Balancer IP.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 5 minutes.
 
 ## Import
 

--- a/docs/resources/lb_loadbalancer_v3.md
+++ b/docs/resources/lb_loadbalancer_v3.md
@@ -224,14 +224,21 @@ The following arguments are supported:
 * `min_l7_flavor_id` - (Optional, String) Specifies the ID of the minimum Layer-7 flavor for elastic scaling.
   This parameter cannot be left blank if there are HTTP or HTTPS listeners.
 
+* `enterprise_project_id` - (Optional, String, ForceNew) Specifies the enterprise project id of the resource.
+  Changing this will create a new resource.
+
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `ipv4_port_id` - The ID of the port bound to the private IPv4 address of the loadbalancer.
+
 * `ipv4_eip` - The ipv4 eip address of the Load Balancer.
+
 * `ipv6_eip` - The ipv6 eip address of the Load Balancer.
+
 * `ipv6_eip_id` - The ipv6 eip id of the Load Balancer.
+
 * `ipv6_address` - The ipv6 address of the Load Balancer.
 
 ## Timeouts
@@ -255,7 +262,7 @@ API response, security or some other reason. The missing attributes include: `ip
 `bandwidth_charge_mode`, `sharetype`,  `bandwidth_size` and `bandwidth_id`.
 It is generally recommended running `terraform plan` after importing a loadbalancer.
 You can then decide if changes should be applied to the loadbalancer, or the resource
-definition should be updated to align with the loadbalancer. Also you can ignore changes as below.
+definition should be updated to align with the loadbalancer. Also, you can ignore changes as below.
 
 ```hcl
 resource "flexibleengine_lb_loadbalancer_v3" "loadbalancer_1" {

--- a/docs/resources/lb_member_v2.md
+++ b/docs/resources/lb_member_v2.md
@@ -23,47 +23,39 @@ resource "flexibleengine_lb_member_v2" "example_member" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to obtain the V2 Networking client.
-    A Networking client is needed to create an . If omitted, the
-    `region` argument of the provider is used. Changing this creates a new
-    member.
+* `region` - (Optional, String, ForceNew) The region in which to obtain the V2 Networking client.
+  A Networking client is needed to be created. If omitted, the `region` argument of the provider is used.
+  Changing this creates a new member.
 
-* `pool_id` - (Required) The id of the pool that this member will be
-    assigned to.
+* `pool_id` - (Required, String, ForceNew) The id of the pool that this member will be
+  assigned to. Changing this creates a new member.
 
-* `subnet_id` - (Required) The `ipv4_subnet_id` or `ipv6_subnet_id` of the
-    VPC Subnet in which to access the member
+* `subnet_id` - (Required, String, ForceNew) The `ipv4_subnet_id` or `ipv6_subnet_id` of the
+  VPC Subnet in which to access the member. Changing this creates a new member.
 
-* `name` - (Optional) Human-readable name for the member.
+* `address` - (Required, String, ForceNew) The IP address of the member to receive traffic from
+  the load balancer. Changing this creates a new member.
 
-* `address` - (Required) The IP address of the member to receive traffic from
-    the load balancer. Changing this creates a new member.
+* `protocol_port` - (Required, Int, ForceNew) The port on which to listen for client traffic.
+  Changing this creates a new member.
 
-* `protocol_port` - (Required) The port on which to listen for client traffic.
-    Changing this creates a new member.
+* `name` - (Optional, String) Human-readable name for the member.
 
-* `weight` - (Optional)  A positive integer value that indicates the relative
-    portion of traffic that this member should receive from the pool. For
-    example, a member with a weight of 10 receives five times as much traffic
-    as a member with a weight of 2.
+* `weight` - (Optional, Int)  A positive integer value that indicates the relative
+  portion of traffic that this member should receive from the pool. For
+  example, a member with a weight of 10 receives five times as much traffic
+  as a member with a weight of 2.
 
-* `admin_state_up` - (Optional) The administrative state of the member.
-    A valid value is true (UP) or false (DOWN).
+## Attribute Reference
 
-* `tenant_id` - (Optional) The UUID of the tenant who owns the member.
-    Only administrative users can specify a tenant UUID other than their own.
-    Changing this creates a new member.
-
-## Attributes Reference
-
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - The unique ID for the member.
-* `name` - See Argument Reference above.
-* `weight` - See Argument Reference above.
-* `admin_state_up` - See Argument Reference above.
-* `tenant_id` - See Argument Reference above.
-* `subnet_id` - See Argument Reference above.
-* `pool_id` - See Argument Reference above.
-* `address` - See Argument Reference above.
-* `protocol_port` - See Argument Reference above.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.

--- a/docs/resources/lb_monitor_v2.md
+++ b/docs/resources/lb_monitor_v2.md
@@ -24,61 +24,46 @@ resource "flexibleengine_lb_monitor_v2" "monitor_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to obtain the V2 Networking client.
-    A Networking client is needed to create an . If omitted, the
-    `region` argument of the provider is used. Changing this creates a new
-    monitor.
+* `region` - (Optional, String, ForceNew) The region in which to create the resources.
+  If omitted, the `region` argument of the provider is used. Changing this creates a new resource.
 
-* `pool_id` - (Required) The id of the pool that this monitor will be assigned to.
+* `pool_id` - (Required, String, ForceNew) The id of the pool that this monitor will be assigned to.
+  Changing this creates a new monitor.
 
-* `name` - (Optional) The Name of the Monitor.
+* `type` - (Required, String, ForceNew) The type of probe, which is PING, TCP, HTTP, or HTTPS,
+  that is sent by the load balancer to verify the member state. Changing this creates a new monitor.
 
-* `type` - (Required) The type of probe, which is PING, TCP, HTTP, or HTTPS,
-    that is sent by the load balancer to verify the member state. Changing this
-    creates a new monitor.
+* `delay` - (Required, Int) The time, in seconds, between sending probes to members.
 
-* `delay` - (Required) The time, in seconds, between sending probes to members.
+* `timeout` - (Required, Int) Maximum number of seconds for a monitor to wait for a
+  ping reply before it times out. The value must be less than the delay value.
 
-* `timeout` - (Required) Maximum number of seconds for a monitor to wait for a
-    ping reply before it times out. The value must be less than the delay
-    value.
+* `max_retries` - (Required, Int) Number of permissible ping failures before
+  changing the member's status to INACTIVE. Must be a number between 1 and 10.
 
-* `max_retries` - (Required) Number of permissible ping failures before
-    changing the member's status to INACTIVE. Must be a number between 1
-    and 10..
+* `name` - (Optional, String) The Name of the Monitor.
 
-* `url_path` - (Optional) Required for HTTP(S) types. URI path that will be
-    accessed if monitor type is HTTP or HTTPS.
+* `url_path` - (Optional, String) Required for HTTP(S) types. URI path that will be
+  accessed if monitor type is HTTP or HTTPS.
 
-* `http_method` - (Optional) Required for HTTP(S) types. The HTTP method used
-    for requests by the monitor. If this attribute is not specified, it
-    defaults to "GET".
+* `http_method` - (Optional, String) Required for HTTP(S) types. The HTTP method used
+  for requests by the monitor. If this attribute is not specified, it defaults to "GET".
 
-* `expected_codes` - (Optional) Required for HTTP(S) types. Expected HTTP codes
-    for a passing HTTP(S) monitor. You can either specify a single status like
-    "200", or a range like "200-202".
+* `expected_codes` - (Optional, String) Required for HTTP(S) types. Expected HTTP codes
+  for a passing HTTP(S) monitor. You can either specify a single status like "200", or a range like "200-202".
 
-* `port` - (Optional) Specifies the health check port. The value ranges from 1 to 65536.
+* `port` - (Optional, Int) Specifies the health check port. The value ranges from 1 to 65536.
 
-* `admin_state_up` - (Optional) The administrative state of the monitor.
-    A valid value is true (UP) or false (DOWN).
+## Attribute Reference
 
-* `tenant_id` - (Optional) The UUID of the tenant who owns the monitor.
-    Only administrative users can specify a tenant UUID other than their own.
-    Changing this creates a new monitor.
-
-## Attributes Reference
-
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - The unique ID for the monitor.
-* `tenant_id` - See Argument Reference above.
-* `type` - See Argument Reference above.
-* `delay` - See Argument Reference above.
-* `timeout` - See Argument Reference above.
-* `max_retries` - See Argument Reference above.
-* `url_path` - See Argument Reference above.
-* `http_method` - See Argument Reference above.
-* `expected_codes` - See Argument Reference above.
-* `admin_state_up` - See Argument Reference above.
-* `port` - See Argument Reference above.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.

--- a/docs/resources/lb_pool_v2.md
+++ b/docs/resources/lb_pool_v2.md
@@ -27,64 +27,72 @@ resource "flexibleengine_lb_pool_v2" "pool_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to obtain the V2 Networking client.
-    A Networking client is needed to create an . If omitted, the
-    `region` argument of the provider is used. Changing this creates a new
-    pool.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the `region` argument of the provider is used. Changing this creates a new pool.
+
+* `protocol` - (Required, String, ForceNew) The protocol - can either be TCP, UDP or HTTP.
+
+  + When the protocol used by the listener is UDP, the protocol of the backend pool must be UDP.
+  + When the protocol used by the listener is TCP, the protocol of the backend pool must be TCP.
+  + When the protocol used by the listener is HTTP or TERMINATED_HTTPS, the protocol of the backend pool must be HTTP.
+
+  Changing this creates a new pool.
+
+* `lb_method` - (Required, String) The load balancing algorithm to
+  distribute traffic to the pool's members. Must be one of
+  ROUND_ROBIN, LEAST_CONNECTIONS, or SOURCE_IP.
 
 * `name` - (Optional, String) Human-readable name for the pool.
 
 * `description` - (Optional, String) Human-readable description for the pool.
 
-* `protocol` = (Required) The protocol - can either be TCP, UDP or HTTP.
-
-    + When the protocol used by the listener is UDP, the protocol of the backend pool must be UDP.
-    + When the protocol used by the listener is TCP, the protocol of the backend pool must be TCP.
-    + When the protocol used by the listener is HTTP or TERMINATED_HTTPS, the protocol of the backend pool must be HTTP.
-
-    Changing this creates a new pool.
-
 * `loadbalancer_id` - (Optional, String, ForceNew) The load balancer on which to provision this
-    pool. Changing this creates a new pool.
-    Note: One of LoadbalancerID or ListenerID must be provided.
+  pool. Changing this creates a new pool.
+  Note: One of LoadbalancerID or ListenerID must be provided.
 
 * `listener_id` - (Optional, String, ForceNew) The Listener on which the members of the pool
-    will be associated with. Changing this creates a new pool.
-    Note: One of LoadbalancerID or ListenerID must be provided.
+  will be associated with. Changing this creates a new pool.
+  Note: One of LoadbalancerID or ListenerID must be provided.
 
-* `lb_method` - (Required, String) The load balancing algorithm to
-    distribute traffic to the pool's members. Must be one of
-    ROUND_ROBIN, LEAST_CONNECTIONS, or SOURCE_IP.
+* `persistence` - (Optional, List, ForceNew) Omit this field to prevent session persistence. Indicates
+  whether connections in the same session will be processed by the same Pool member or not.
+  The [persistence](#lb_persistence) object structure is documented below.
+  Changing this creates a new pool.
 
-* `persistence` - (Optional, List, ForceNew) Omit this field to prevent session persistence.  Indicates
-    whether connections in the same session will be processed by the same Pool
-    member or not. Changing this creates a new pool.
-
-* `admin_state_up` - (Optional, Bool) The administrative state of the pool.
-    A valid value is true (UP) or false (DOWN).
-
-The `persistence` argument supports:
+<a name="lb_persistence"></a>
+The `persistence` block supports:
 
 * `type` - (Required, String, ForceNew) The type of persistence mode. The current specification
-    supports SOURCE_IP, HTTP_COOKIE, and APP_COOKIE.
+  supports SOURCE_IP, HTTP_COOKIE, and APP_COOKIE. Changing this will create a new resource.
 
 * `cookie_name` - (Optional, String, ForceNew) The name of the cookie if persistence mode is set
-    appropriately. Required if `type = APP_COOKIE`.
+  appropriately. It is Required if `type = APP_COOKIE`. Changing this will create a new resource.
 
 * `timeout` - (Optional, Int, ForceNew) Specifies the sticky session timeout duration in minutes. This parameter is
-  invalid when type is set to APP_COOKIE. The value range varies depending on the protocol of the backend server group:
+  invalid when type is set to APP_COOKIE. Changing this will create a new resource.
+  The value range varies depending on the protocol of the backend server group:
 
   + When the protocol of the backend server group is TCP or UDP, the value ranges from 1 to 60.
   + When the protocol of the backend server group is HTTP or HTTPS, the value ranges from 1 to 1440.
 
-## Attributes Reference
+## Attribute Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - The unique ID for the pool.
-* `name` - See Argument Reference above.
-* `description` - See Argument Reference above.
-* `protocol` - See Argument Reference above.
-* `lb_method` - See Argument Reference above.
-* `persistence` - See Argument Reference above.
-* `admin_state_up` - See Argument Reference above.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+ELB pool can be imported using the ELB pool ID, e.g.
+
+```shell
+terraform import flexibleengine_lb_pool_v2.pool_1 3e3632db-36c6-4b28-a92e-e72e6562daa6
+```

--- a/docs/resources/lb_pool_v3.md
+++ b/docs/resources/lb_pool_v3.md
@@ -29,20 +29,23 @@ resource "flexibleengine_lb_pool_v3" "pool_1" {
 The following arguments are supported:
 
 * `region` - (Optional, String, ForceNew) Specifies the region in which to create the ELB pool resource.
+  If omitted, the provider-level region will be used. Changing this will create a new ELB pool resource.
+
+* `protocol` - (Required, String, ForceNew) Specifies the protocol used by the pool. The value can be TCP, UDP,
+  HTTP, HTTPS or QUIC.
+  + When the protocol used by the listener is UDP, the protocol of the backend pool must be UDP or QUIC.
+  + When the protocol used by the listener is TCP, the protocol of the backend pool must be TCP.
+  + When the protocol used by the listener is HTTP, the protocol of the backend pool must be HTTP.
+  + When the protocol used by the listener is HTTPS, the protocol of the backend pool must be HTTPS.
+  + When the protocol used by the listener is TERMINATED_HTTPS, the protocol of the backend pool must be HTTP.
   Changing this creates a new pool.
+
+* `lb_method` - (Required, String) Specifies the load balancing algorithm to distribute traffic to the pool's members.
+  Must be one of ROUND_ROBIN, LEAST_CONNECTIONS, or SOURCE_IP.
 
 * `name` - (Optional, String) Specifies the name for the pool.
 
 * `description` - (Optional, String) Specifies the description for the pool.
-
-* `protocol` - (Required, String, ForceNew) Specifies the protocol used by the pool. The value can be TCP, UDP,
-  HTTP, HTTPS or QUIC.
-    + When the protocol used by the listener is UDP, the protocol of the backend pool must be UDP or QUIC.
-    + When the protocol used by the listener is TCP, the protocol of the backend pool must be TCP.
-    + When the protocol used by the listener is HTTP, the protocol of the backend pool must be HTTP.
-    + When the protocol used by the listener is HTTPS, the protocol of the backend pool must be HTTPS.
-    + When the protocol used by the listener is TERMINATED_HTTPS, the protocol of the backend pool must be HTTP.
-  Changing this creates a new pool.
 
 * `loadbalancer_id` - (Optional, String, ForceNew) Specifies the load balancer on which to provision this pool.
   Changing this creates a new pool. Note:  Exactly one of LoadbalancerID or ListenerID must be provided.
@@ -51,13 +54,11 @@ The following arguments are supported:
   associated with.
   Changing this creates a new pool. Note:  Exactly one of LoadbalancerID or ListenerID must be provided.
 
-* `lb_method` - (Required, String) Specifies the load balancing algorithm to distribute traffic to the pool's members.
-  Must be one of ROUND_ROBIN, LEAST_CONNECTIONS, or SOURCE_IP.
-
 * `persistence` - (Optional, List, ForceNew) Specifies the omit this field to prevent session persistence.
   Indicates whether connections in the same session will be processed by the same Pool member or not.
-  Changing this creates a new pool.
+  The [persistence](#lb_persistence) object structure is documented below. Changing this creates a new pool.
 
+<a name="lb_persistence"></a>
 The `persistence` argument supports:
 
 * `type` - (Required, String, ForceNew) Specifies the type of persistence mode. The current specification supports
@@ -71,7 +72,7 @@ The `persistence` argument supports:
   + When the protocol of the backend server group is TCP or UDP, the value ranges from 1 to 60.
   + When the protocol of the backend server group is HTTP or HTTPS, the value ranges from 1 to 1440.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes is exported:
 

--- a/docs/resources/lb_whitelist_v2.md
+++ b/docs/resources/lb_whitelist_v2.md
@@ -22,24 +22,24 @@ resource "flexibleengine_lb_whitelist_v2" "whitelist_1" {
 
 The following arguments are supported:
 
-* `listener_id` - (Required) The Listener ID that the whitelist will be associated with.
+* `listener_id` - (Required, String, ForceNew) The Listener ID that the whitelist will be associated with.
   Changing this creates a new whitelist.
 
-* `enable_whitelist` - (Optional) Specify whether to enable access control.
+* `enable_whitelist` - (Optional, Bool) Specify whether to enable access control.
 
-* `whitelist` - (Optional) Specifies the IP addresses in the whitelist. Use commas(,) to separate
+* `whitelist` - (Optional, String) Specifies the IP addresses in the whitelist. Use commas(,) to separate
   the multiple IP addresses.
 
-* `tenant_id` - (Optional) The UUID of the tenant who owns the whitelist.
-  Only administrative users can specify a tenant UUID other than their own.
-  Changing this creates a new whitelist.
+## Attribute Reference
 
-## Attributes Reference
-
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - The unique ID for the whitelist.
-* `tenant_id` - See Argument Reference above.
-* `listener_id` - See Argument Reference above.
-* `enable_whitelist` - See Argument Reference above.
-* `whitelist` - See Argument Reference above.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.

--- a/flexibleengine/acceptance/resource_flexibleengine_elb_certificate_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_elb_certificate_test.go
@@ -64,6 +64,11 @@ func TestAccElbV3Certificate_client(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "type", "client"),
 				),
 			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -182,12 +187,6 @@ i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
 i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+8Kg==
 -----END CERTIFICATE-----
 EOT
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
 }
 `, name)
 }
@@ -252,12 +251,6 @@ i34R7EQDtFeiSvBdeKRsPp8c0KT8H1B4lXNkkCQs2WX5p4lm99+ZtLD4glw8x6Ic
 i1YhgnQbn5E0hz55OLu5jvOkKQjPCW+9Aa==
 -----END CERTIFICATE-----
 EOT
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
 }
 `, name)
 }

--- a/flexibleengine/acceptance/resource_flexibleengine_lb_loadbalancer_v3_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_lb_loadbalancer_v3_test.go
@@ -133,9 +133,10 @@ func testAccElbV3LoadBalancerConfig_basic(rName string) string {
 %s
 
 resource "flexibleengine_lb_loadbalancer_v3" "test" {
-  name            = "%s"
-  ipv4_subnet_id  = flexibleengine_vpc_subnet_v1.test.subnet_id
-  ipv6_network_id = flexibleengine_vpc_subnet_v1.test.id
+  name           		 = "%s"
+  ipv4_subnet_id  	     = flexibleengine_vpc_subnet_v1.test.subnet_id
+  ipv6_network_id        = flexibleengine_vpc_subnet_v1.test.id
+  enterprise_project_id  = 0  
 
   availability_zone = [
     data.flexibleengine_availability_zones.test.names[0]
@@ -154,10 +155,11 @@ func testAccElbV3LoadBalancerConfig_update(rName, rNameUpdate string) string {
 %s
 
 resource "flexibleengine_lb_loadbalancer_v3" "test" {
-  name              = "%s"
-  cross_vpc_backend = true
-  ipv4_subnet_id    = flexibleengine_vpc_subnet_v1.test.subnet_id
-  ipv6_network_id   = flexibleengine_vpc_subnet_v1.test.id
+  name              	 = "%s"
+  cross_vpc_backend 	 = true
+  ipv4_subnet_id   	     = flexibleengine_vpc_subnet_v1.test.subnet_id
+  ipv6_network_id   	 = flexibleengine_vpc_subnet_v1.test.id
+  enterprise_project_id  = 0 
 
   availability_zone = [
     data.flexibleengine_availability_zones.test.names[0]

--- a/flexibleengine/resource_flexibleengine_lb_l7policy_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_l7policy_v2.go
@@ -38,13 +38,6 @@ func resourceL7PolicyV2() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-
 			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -94,6 +87,15 @@ func resourceL7PolicyV2() *schema.Resource {
 				Default:      true,
 				Optional:     true,
 				ValidateFunc: validateTrueOnly,
+				Deprecated:   "admin_state_up is deprecated",
+			},
+
+			"tenant_id": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 		},
 	}

--- a/flexibleengine/resource_flexibleengine_lb_l7rule_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_l7rule_v2.go
@@ -38,13 +38,6 @@ func resourceL7RuleV2() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -95,6 +88,15 @@ func resourceL7RuleV2() *schema.Resource {
 				Default:      true,
 				Optional:     true,
 				ValidateFunc: validateTrueOnly,
+				Deprecated:   "admin_state_up is deprecated",
+			},
+
+			"tenant_id": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 		},
 	}

--- a/flexibleengine/resource_flexibleengine_lb_loadbalancer_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_loadbalancer_v2.go
@@ -77,28 +77,31 @@ func resourceLoadBalancerV2() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"flavor": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"admin_state_up": {
-				Type:     schema.TypeBool,
-				Default:  true,
-				Optional: true,
-			},
-
-			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-
 			"vip_port_id": {
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+
+			"flavor": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Deprecated: "flavor is deprecated",
+			},
+
+			"admin_state_up": {
+				Type:       schema.TypeBool,
+				Default:    true,
+				Optional:   true,
+				Deprecated: "admin_state_up is deprecated",
+			},
+
+			"tenant_id": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 		},
 	}

--- a/flexibleengine/resource_flexibleengine_lb_member_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_member_v2.go
@@ -37,13 +37,6 @@ func resourceMemberV2() *schema.Resource {
 				Optional: true,
 			},
 
-			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-
 			"address": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -76,16 +69,25 @@ func resourceMemberV2() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"admin_state_up": {
-				Type:     schema.TypeBool,
-				Default:  true,
-				Optional: true,
-			},
-
 			"pool_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+			},
+
+			"admin_state_up": {
+				Type:       schema.TypeBool,
+				Default:    true,
+				Optional:   true,
+				Deprecated: "admin_state_up is deprecated",
+			},
+
+			"tenant_id": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 		},
 	}

--- a/flexibleengine/resource_flexibleengine_lb_monitor_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_monitor_v2.go
@@ -43,13 +43,6 @@ func resourceMonitorV2() *schema.Resource {
 				Optional: true,
 			},
 
-			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-
 			"type": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -82,14 +75,24 @@ func resourceMonitorV2() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			"admin_state_up": {
-				Type:     schema.TypeBool,
-				Default:  true,
-				Optional: true,
-			},
 			"port": {
 				Type:     schema.TypeInt,
 				Optional: true,
+			},
+
+			"admin_state_up": {
+				Type:       schema.TypeBool,
+				Default:    true,
+				Optional:   true,
+				Deprecated: "admin_state_up is deprecated",
+			},
+
+			"tenant_id": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 		},
 	}

--- a/flexibleengine/resource_flexibleengine_lb_whitelist_v2.go
+++ b/flexibleengine/resource_flexibleengine_lb_whitelist_v2.go
@@ -23,13 +23,6 @@ func resourceWhitelistV2() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-
 			"listener_id": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -45,6 +38,14 @@ func resourceWhitelistV2() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				DiffSuppressFunc: suppressLBWhitelistDiffs,
+			},
+
+			"tenant_id": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 		},
 	}


### PR DESCRIPTION
### 1. Deprecated docs

These deprecated documents are modified only and do not run unit test

* elb_backend
* elb_health
* elb_listener
* elb_loadbalancer
* lb_certificate_v2



### 2. lb_loadbalancer_v3

type: resource
field: `enterprise_project_id`
reason: add the field due to the unit test is passed
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/474c4d45-62b8-47ed-b522-524403b0fa51)

### 3. deprecated
`tenant_id`, `admin_state_up`,`value_specs` is deprecated
