### PR TITLE
docs(GaussDB): fix docs issues

### DIFF
--- a/docs/data-sources/gaussdb_cassandra_instances.md
+++ b/docs/data-sources/gaussdb_cassandra_instances.md
@@ -25,15 +25,19 @@ data "flexibleengine_gaussdb_cassandra_instances" "this" {
 
 * `subnet_id` - (Optional, String) Specifies the network ID of a subnet.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Indicates the ID of the data source.
 
-* `instances` - An array of available instances.
+* `instances` - An array of available instances. The [instances](#gaussdb_instances) object structure is documented
+  below.
 
+<a name="gaussdb_instances"></a>
 The `instances` block supports:
+
+* `id` - The id of the instance.
 
 * `region` - The region of the instance.
 
@@ -65,30 +69,43 @@ The `instances` block supports:
 
 * `private_ips` - Indicates the list of private IP address of the nodes.
 
-* `datastore` - Indicates the database information. Structure is documented below.
+* `datastore` - Indicates the database information. The [datastore](#gaussdb_datastore) object structure is documented
+  below.
 
-* `backup_strategy` - Indicates the advanced backup policy. Structure is documented below.
+* `backup_strategy` - Indicates the advanced backup policy. The [backup_strategy](#gaussdb_backup_strategy) object
+  structure is documented below.
 
-* `nodes` - Indicates the instance nodes information. Structure is documented below.
+* `nodes` - Indicates the instance nodes information. The [nodes](#gaussdb_nodes) object structure is documented below.
 
 * `tags` - Indicates the key/value tags of the instance.
 
+<a name="gaussdb_datastore"></a>
 The `datastore` block supports:
 
 * `engine` - Indicates the database engine.
+
 * `storage_engine` - Indicates the database storage engine.
+
 * `version` - Indicates the database version.
 
+<a name="gaussdb_backup_strategy"></a>
 The `backup_strategy` block supports:
 
 * `start_time` - Indicates the backup time window.
+
 * `keep_days` - Indicates the number of days to retain the generated
 
-The `nodes` block contains:
+<a name="gaussdb_nodes"></a>
+The `nodes` block supports:
 
 * `id` - Indicates the node ID.
+
 * `name` - Indicates the node name.
+
 * `private_ip` - Indicates the private IP address of a node.
+
 * `status` - Indicates the node status.
+
 * `support_reduce` - Indicates whether the node support reduce.
+
 * `availability_zone` - Indicates the availability zone where the node resides.

--- a/docs/resources/gaussdb_cassandra_instance.md
+++ b/docs/resources/gaussdb_cassandra_instance.md
@@ -93,13 +93,15 @@ The following arguments are supported:
 * `force_import` - (Optional, Bool) If specified, try to import the instance instead of creating if the name already
   existed.
 
-* `datastore` - (Optional, List, ForceNew) Specifies the database information. Structure is documented below. Changing
-  this parameter will create a new resource.
+* `datastore` - (Optional, List, ForceNew) Specifies the database information. The [datastore](#gaussdb_datastore)
+  object structure is documented below. Changing this parameter will create a new resource.
 
-* `backup_strategy` - (Optional, List) Specifies the advanced backup policy. Structure is documented below.
+* `backup_strategy` - (Optional, List) Specifies the advanced backup policy. The [backup_strategy](#gaussdb_backup_strategy)
+  object structure is documented below.
 
 * `tags` - (Optional, Map) The key/value pairs to associate with the instance.
 
+<a name="gaussdb_datastore"></a>
 The `datastore` block supports:
 
 * `engine` - (Required, String, ForceNew) Specifies the database engine. Only "GeminiDB-Cassandra" is supported now.
@@ -111,6 +113,7 @@ The `datastore` block supports:
 * `storage_engine` - (Required, String, ForceNew) Specifies the storage engine. Only "rocksDB" is supported now.
   Changing this parameter will create a new resource.
 
+<a name="gaussdb_backup_strategy"></a>
 The `backup_strategy` block supports:
 
 * `start_time` - (Required, String) Specifies the backup time window. Automated backups will be triggered during the
@@ -127,21 +130,34 @@ The `backup_strategy` block supports:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Indicates the DB instance ID.
+
 * `status` - Indicates the DB instance status.
+
 * `port` - Indicates the database port.
+
 * `mode` - Indicates the instance type.
+
 * `db_user_name` - Indicates the default username.
-* `nodes` - Indicates the instance nodes information. Structure is documented below.
+
+* `nodes` - Indicates the instance nodes information. The [nodes](#gaussdb_nodes) object structure is documented below.
+
 * `private_ips` - Indicates the IP address list of the db.
+
 * `lb_ip_address` - Indicates the LB IP address of the db.
+
 * `lb_port` - Indicates the LB port of the db.
 
-The `nodes` block contains:
+<a name="gaussdb_nodes"></a>
+The `nodes` block supports:
 
 * `id` - Indicates the node ID.
+
 * `name` - Indicates the node name.
+
 * `status` - Indicates the node status.
+
 * `support_reduce` - Indicates whether the node support reduce or not.
+
 * `private_ip` - Indicates the private IP address of a node.
 
 ## Timeouts

--- a/docs/resources/gaussdb_influx_instance.md
+++ b/docs/resources/gaussdb_influx_instance.md
@@ -94,13 +94,15 @@ The following arguments are supported:
 * `force_import` - (Optional, Bool) If specified, try to import the instance instead of creating if the name already
   existed.
 
-* `datastore` - (Optional, List, ForceNew) Specifies the database information. Structure is documented below. Changing
-  this parameter will create a new resource.
+* `datastore` - (Optional, List, ForceNew) Specifies the database information. The [datastore](#gaussdb_datastore)
+  object structure is documented below. Changing this parameter will create a new resource.
 
-* `backup_strategy` - (Optional, List) Specifies the advanced backup policy. Structure is documented below.
+* `backup_strategy` - (Optional, List) Specifies the advanced backup policy. The [backup_strategy](#gaussdb_backup_strategy)
+  object structure is documented below.
 
 * `tags` - (Optional, Map) The key/value pairs to associate with the instance.
 
+<a name="gaussdb_datastore"></a>
 The `datastore` block supports:
 
 * `engine` - (Required, String, ForceNew) Specifies the database engine. Only **influxdb** is supported now.
@@ -112,6 +114,7 @@ The `datastore` block supports:
 * `storage_engine` - (Required, String, ForceNew) Specifies the storage engine. Only **rocksDB** is supported now.
   Changing this parameter will create a new resource.
 
+<a name="gaussdb_backup_strategy"></a>
 The `backup_strategy` block supports:
 
 * `start_time` - (Required, String) Specifies the backup time window. Automated backups will be triggered during the
@@ -128,21 +131,34 @@ The `backup_strategy` block supports:
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Indicates the DB instance ID.
+
 * `status` - Indicates the DB instance status.
+
 * `port` - Indicates the database port.
+
 * `mode` - Indicates the instance type.
+
 * `db_user_name` - Indicates the default username.
-* `nodes` - Indicates the instance nodes information. Structure is documented below.
+
+* `nodes` - Indicates the instance nodes information. The [nodes](#gaussdb_nodes) object structure is documented below.
+
 * `private_ips` - Indicates the IP address list of the db.
+
 * `lb_ip_address` - Indicates the LB IP address of the db.
+
 * `lb_port` - Indicates the LB port of the db.
 
-The `nodes` block contains:
+<a name="gaussdb_nodes"></a>
+The `nodes` block supports:
 
 * `id` - Indicates the node ID.
+
 * `name` - Indicates the node name.
+
 * `status` - Indicates the node status.
+
 * `support_reduce` - Indicates whether the node support reduce or not.
+
 * `private_ip` - Indicates the private IP address of a node.
 
 ## Timeouts


### PR DESCRIPTION
### 1. gaussdb_cassandra_instance

**type: ​**resource
**field:** `enterprise_project_id`
**reason:** The service does not support the field.

![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/e0d77c25-7ae6-4b0f-b8b1-482f1a297159)
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/bd2cbb8d-2b88-45d3-ac0c-7a3a0f980f21)

