### PR TITLE
docs(ims): fix docs issues

### DIFF
--- a/docs/data-sources/images_image.md
+++ b/docs/data-sources/images_image.md
@@ -76,24 +76,38 @@ data "flexibleengine_images_image" "bms_image" {
 * `flavor_id` - (Optional, String) Specifies the ECS flavor ID used to filter out available images.
   You can specify only one flavor ID and only ECS flavor ID is valid, BMS flavor is not supported.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - Specifies a resource ID in UUID format.
+
 * `checksum` - The checksum of the data associated with the image.
+
 * `container_format` - The format of the image's container.
+
 * `disk_format` - The format of the image's disk.
+
 * `file` - the trailing path after the glance endpoint that represent the location of the image or the path to retrieve
   it.
+
 * `metadata` - The metadata associated with the image. Image metadata allow for meaningfully define the image properties
   and tags.
+
 * `min_disk_gb` - The minimum amount of disk space required to use the image.
+
 * `min_ram_mb` - The minimum amount of ram required to use the image.
+
 * `protected` - Whether or not the image is protected.
+
 * `schema` - The path to the JSON-schema that represent the image or image.
+
 * `size_bytes` - The size of the image (in bytes).
+
 * `status` - The status of the image.
+
 * `backup_id` - The backup ID of the whole image in the CBR vault.
+
 * `created_at` - The date when the image was created.
+
 * `updated_at` - The date when the image was last updated.

--- a/docs/data-sources/images_image_v2.md
+++ b/docs/data-sources/images_image_v2.md
@@ -18,45 +18,56 @@ data "flexibleengine_images_image_v2" "ubuntu" {
 
 ## Argument Reference
 
-* `region` - (Optional) The region in which to obtain the image.
-    If omitted, the `region` argument of the provider is used.
+* `region` - (Optional, String) The region in which to obtain the image.
+  If omitted, the `region` argument of the provider is used.
 
-* `name` - (Optional) The name of the image. Exact matching is used.
+* `name` - (Optional, String) The name of the image. Exact matching is used.
 
-* `owner` - (Optional) The owner (UUID) of the image.
+* `owner` - (Optional, String) The owner (UUID) of the image.
 
-* `size_min` - (Optional) The minimum size (in bytes) of the image to return.
+* `size_min` - (Optional, Int) The minimum size (in bytes) of the image to return.
 
-* `size_max` - (Optional) The maximum size (in bytes) of the image to return.
+* `size_max` - (Optional, Int) The maximum size (in bytes) of the image to return.
 
-* `sort_direction` - (Optional) Order the results in either `asc` or `desc`.
+* `sort_direction` - (Optional, String) Order the results in either `asc` or `desc`.
 
-* `sort_key` - (Optional) Sort images based on a certain key. Defaults to `name`.
+* `sort_key` - (Optional, String) Sort images based on a certain key. Defaults to `name`.
 
-* `tag` - (Optional) Search for images with a specific tag.
+* `tag` - (Optional, String) Search for images with a specific tag.
 
-* `visibility` - (Optional) The visibility of the image. Must be one of
-   "public", "private", "community", or "shared".
+* `visibility` - (Optional, String) The visibility of the image. Must be one of
+ "public", "private", "community", or "shared".
 
-* `most_recent` - (Optional) If more than one result is returned, use the most
+* `most_recent` - (Optional, Bool) If more than one result is returned, use the most
   recent image.
 
-## Attributes Reference
+## Attribute Reference
 
 `id` is set to the ID of the found image. In addition, the following attributes
 are exported:
 
 * `checksum` - The checksum of the data associated with the image.
+
 * `container_format`: The format of the image's container.
+
 * `disk_format`: The format of the image's disk.
+
 * `file` - The URL for uploading and downloading the image file.
+
 * `metadata` - The metadata associated with the image.
    Image metadata allow for meaningfully define the image properties and tags.
+
 * `min_disk_gb`: The minimum amount of disk space required to use the image.
+
 * `min_ram_mb`: The minimum amount of ram required to use the image.
-* `protected` - Whether or not the image is protected.
+
+* `protected` - Whether the image is protected.
+
 * `schema` - The path to the JSON-schema that represent
    the image or image
+
 * `size_bytes` - The size of the image (in bytes).
+
 * `created_at` - The date the image was created.
+
 * `updated_at` - The date the image was last updated.

--- a/docs/resources/images_image.md
+++ b/docs/resources/images_image.md
@@ -126,7 +126,7 @@ The following arguments are supported:
 * `vault_id` - (Optional, String, ForceNew) The ID of the vault to which an ECS is to be added or has been added.
   This parameter is mandatory when you create a private whole image from an ECS.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 

--- a/docs/resources/images_image_copy.md
+++ b/docs/resources/images_image_copy.md
@@ -53,10 +53,9 @@ The following arguments are supported:
   allowed, but it cannot start or end with a space.
 
 * `target_region` - (Optional, String, ForceNew) Specifies the target region name.
-  If specified, it means cross-region replication.
+  If specified, it means cross-region replication. Changing this parameter will create a new resource.
 
-* `description` - (Optional, String, ForceNew) Specifies the description of the copy image.
-  Changing this parameter will create a new resource.
+* `description` - (Optional, String) Specifies the description of the copy image.
 
 * `kms_key_id` - (Optional, String, ForceNew) Specifies the master key used for encrypting an image.
   Only copying scene within a region is supported. Changing this parameter will create a new resource.
@@ -73,7 +72,7 @@ The following arguments are supported:
 
 * `tags` - (Optional, Map) Specifies the key/value pairs to associate with the copy image.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
@@ -96,3 +95,10 @@ In addition to all arguments above, the following attributes are exported:
 * `checksum` - Indicates the checksum of the data associated with the image.
 
 * `status` - Indicates the status of the image.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 60 minutes.
+* `delete` - Default is 3 minutes.

--- a/docs/resources/images_image_share_accepter.md
+++ b/docs/resources/images_image_share_accepter.md
@@ -32,8 +32,15 @@ The following arguments are supported:
 
   Changing this parameter will create a new resource.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 5 minutes.
+* `delete` - Default is 5 minutes.

--- a/docs/resources/images_image_v2.md
+++ b/docs/resources/images_image_v2.md
@@ -25,79 +25,79 @@ resource "flexibleengine_images_image_v2" "rancheros" {
 
 The following arguments are supported:
 
-* `container_format` - (Required) The container format. Must be one of
-   "ami", "ari", "aki", "bare", "ovf".
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
 
-* `disk_format` - (Required) The disk format. Must be one of
-   "ami", "ari", "aki", "vhd", "vmdk", "raw", "qcow2", "vdi", "iso".
+* `container_format` - (Required, String, ForceNew) The container format. Must be one of
+  "ami", "ari", "aki", "bare", "ovf". Changing this creates a new Image.
 
-* `local_file_path` - (Optional) This is the filepath of the raw image file
-   that will be uploaded to Glance. Conflicts with `image_source_url`.
+* `disk_format` - (Required, String, ForceNew) The disk format. Must be one of
+  "ami", "ari", "aki", "vhd", "vmdk", "raw", "qcow2", "vdi", "iso". Changing this creates a new Image.
 
-* `image_cache_path` - (Optional) This is the directory where the images will
-   be downloaded. Images will be stored with a filename corresponding to
-   the url's md5 hash. Defaults to "$HOME/.terraform/image_cache"
+* `local_file_path` - (Optional, String, ForceNew) This is the filepath of the raw image file
+  that will be uploaded to Glance. Conflicts with `image_source_url`. Changing this creates a new Image.
 
-* `image_source_url` - (Optional) This is the url of the raw image that will
-   be downloaded in the `image_cache_path` before being uploaded to Glance.
-   Glance is able to download image from internet but the `gophercloud` library
-   does not yet provide a way to do so.
-   Conflicts with `local_file_path`.
+* `image_cache_path` - (Optional, String) This is the directory where the images will
+  be downloaded. Images will be stored with a filename corresponding to
+  the url's md5 hash. Defaults to "$HOME/.terraform/image_cache"
 
-* `min_disk_gb` - (Optional) Amount of disk space (in GB) required to boot image.
-   Defaults to 0.
+* `image_source_url` - (Optional, String, ForceNew) This is the url of the raw image that will
+  be downloaded in the `image_cache_path` before being uploaded to Glance.
+  Glance is able to download image from internet but the `gophercloud` library does not yet provide a way to do so.
+  Conflicts with `local_file_path`. Changing this creates a new Image.
 
-* `min_ram_mb` - (Optional) Amount of ram (in MB) required to boot image.
-   Defauts to 0.
+* `min_disk_gb` - (Optional, Int, ForceNew) Amount of disk space (in GB) required to boot image.
+   Defaults to 0. Changing this creates a new Image.
 
-* `name` - (Required) The name of the image.
+* `min_ram_mb` - (Optional, Int, ForceNew) Amount of ram (in MB) required to boot image.
+  Defauts to 0. Changing this creates a new Image.
 
-* `protected` - (Optional) If true, image will not be deletable.
-   Defaults to false.
+* `name` - (Required, String) The name of the image.
 
-* `region` - (Optional) The region in which to obtain the V2 Glance client.
-    A Glance client is needed to create an Image that can be used with
-    a compute instance. If omitted, the `region` argument of the provider
-    is used. Changing this creates a new Image.
+* `protected` - (Optional, Bool, ForceNew) If true, image will not be deletable.
+  Defaults to **false**. Changing this creates a new Image.
 
-* `tags` - (Optional) The tags of the image. It must be a list of strings.
-    At this time, it is not possible to delete all tags of an image.
+* `tags` - (Optional, List) The tags of the image. It must be a list of strings.
+  At this time, it is not possible to delete all tags of an image.
 
-* `visibility` - (Optional) The visibility of the image. Must be one of
-   "public", "private", "community", or "shared". The ability to set the
-   visibility depends upon the configuration of the FlexibleEngine cloud.
+* `visibility` - (Optional, String) The visibility of the image. Must be one of
+  "public", "private", "community", or "shared". The ability to set the
+  visibility depends upon the configuration of the FlexibleEngine cloud.
 
 Note: The `properties` attribute handling in the gophercloud library is currently buggy
 and needs to be fixed before being implemented in this resource.
 
-## Attributes Reference
+## Attribute Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - A unique ID assigned by Glance.
 
 * `checksum` - The checksum of the data associated with the image.
-* `container_format` - See Argument Reference above.
-* `disk_format` - See Argument Reference above.
-* `file` - the trailing path after the glance
-   endpoint that represent the location of the image
-   or the path to retrieve it.
-* `id` - A unique ID assigned by Glance.
+
+* `file` - the trailing path after the glance endpoint that represent the location of the image or the path
+  to retrieve it.
+
 * `metadata` - The metadata associated with the image.
-   Image metadata allow for meaningfully define the image properties and tags.
-* `min_disk_gb` - See Argument Reference above.
-* `min_ram_mb` - See Argument Reference above.
-* `name` - See Argument Reference above.
+  Image metadata allow for meaningfully define the image properties and tags.
+
 * `owner` - The id of the flexibleengine user who owns the image.
-* `protected` - See Argument Reference above.
-* `region` - See Argument Reference above.
-* `schema` - The path to the JSON-schema that represent
-   the image or image
+
+* `schema` - The path to the JSON-schema that represent the image or image
+
 * `size_bytes` - The size in bytes of the data associated with the image.
-* `status` - The status of the image. It can be "queued", "active"
-   or "saving".
-* `tags` - See Argument Reference above.
-* `visibility` - See Argument Reference above.
+
+* `status` - The status of the image. It can be "queued", "active" or "saving".
+
 * `created_at` - The date the image was created.
+
 * `updated_at` - The date the image was last updated.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
 
 ## Import
 


### PR DESCRIPTION
### 1. images_image

**type: ​**data source
**field:** `size_max`, `size_min`
**reason:** The two fields are deprecated<br />
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/7da4d673-3c55-4e18-b0be-e4200a612301)
