### PR TITLE
feat(cce): support hibernate in cce cluster

### DIFF
--- a/docs/resources/cce_cluster_v3.md
+++ b/docs/resources/cce_cluster_v3.md
@@ -120,6 +120,10 @@ The following arguments are supported:
 * `masters` - (Optional, List, ForceNew) Advanced configuration of master nodes. Changing this creates a new cluster.
   The [masters](#cce_masters) object structure is documented below.
 
+* `hibernate` - (Optional, Bool) Specifies whether to hibernate the CCE cluster. Defaults to **false**. After a cluster is
+  hibernated, resources such as workloads cannot be created or managed in the cluster, and the cluster cannot be
+  deleted.
+
 <a name="cce_masters"></a>
 The `masters` block supports:
 

--- a/flexibleengine/utils.go
+++ b/flexibleengine/utils.go
@@ -200,3 +200,23 @@ func IsUUIDFormat(str string) bool {
 	}
 	return true
 }
+
+// isStrContainsSliceElement returns true if the string exists in given slice or contains in one of slice elements when
+// open exact flag. Also you can ignore case for this check.
+func isStrContainsSliceElement(str string, sl []string, ignoreCase, isExcat bool) bool {
+	if ignoreCase {
+		str = strings.ToLower(str)
+	}
+	for _, s := range sl {
+		if ignoreCase {
+			s = strings.ToLower(s)
+		}
+		if isExcat && s == str {
+			return true
+		}
+		if !isExcat && strings.Contains(str, s) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
fixes #976 

```
make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCCEClusterV3_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCCEClusterV3_basic -timeout 720m
=== RUN   TestAccCCEClusterV3_basic
--- PASS: TestAccCCEClusterV3_basic (457.11s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 457.159s

make testacc TEST='./flexibleengine' TESTARGS='-run TestAccCluster_hibernate'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccCluster_hibernate -timeout 720m
=== RUN   TestAccCluster_hibernate
=== PAUSE TestAccCluster_hibernate
=== CONT  TestAccCluster_hibernate
--- PASS: TestAccCluster_hibernate (708.70s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 708.747s
```