### PR TITLE
docs(waf): fix docs issues

### DIFF
--- a/docs/data-sources/waf_dedicated_instances.md
+++ b/docs/data-sources/waf_dedicated_instances.md
@@ -27,12 +27,18 @@ The following arguments are supported:
 
 * `name` - (Optional, String) The name of WAF dedicated instance.
 
-## Attributes Reference
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project id of the  WAF dedicated instance.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - The data source ID in UUID format.
 
-The following attributes are exported:
+* `instances` - An array of available WAF dedicated instances. The [instances](#waf_instances) object structure is
+  documented below.
 
+<a name="waf_instances"></a>
 The `instances` block supports:
 
 * `id` - The id of WAF dedicated instance.
@@ -40,11 +46,6 @@ The `instances` block supports:
 * `name` - The name of WAF dedicated instance.
 
 * `available_zone` - The available zone names for the WAF dedicated instances.
-
-* `specification_code` - The specification code of instance.
-  Different specifications have different throughput. Values are:
-  + `waf.instance.professional` - The professional edition, throughput: 100 Mbit/s; QPS: 2,000 (Reference only).
-  +`waf.instance.enterprise` - The enterprise edition, throughput: 500 Mbit/s; QPS: 10,000 (Reference only).
 
 * `cpu_architecture` - The ECS cpu architecture of WAF dedicated instance.
 

--- a/docs/resources/waf_certificate.md
+++ b/docs/resources/waf_certificate.md
@@ -37,6 +37,9 @@ EOT
 
 The following arguments are supported:
 
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the certificate resource.
+  If omitted, the provider-level region will be used. Changing this will create a new certificate resource.
+
 * `name` - (Required, String) Specifies the certificate name. The maximum length is 256 characters.
   Only digits, letters, underscores(`_`), and hyphens(`-`) are allowed.
 
@@ -44,13 +47,20 @@ The following arguments are supported:
 
 * `private_key` - (Required, String, ForceNew) Specifies the private key. Changing this creates a new certificate.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The certificate ID in UUID format.
 
 * `expiration` - Indicates the time when the certificate expires.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/waf_dedicated_certificate.md
+++ b/docs/resources/waf_dedicated_certificate.md
@@ -48,13 +48,20 @@ The following arguments are supported:
 
 * `private_key` - (Required, String, ForceNew) Specifies the private key. Changing this creates a new certificate.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The certificate ID in UUID format.
 
 * `expiration` - Indicates the time when the certificate expires.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/waf_dedicated_domain.md
+++ b/docs/resources/waf_dedicated_domain.md
@@ -60,14 +60,14 @@ resource "flexibleengine_waf_dedicated_domain" "domain_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the dedicated mode domain resource. If omitted,
-  the provider-level region will be used. Changing this setting will push a new domain.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the dedicated mode domain resource.
+  If omitted, the provider-level region will be used. Changing this will create a new dedicated mode domain resource.
 
 * `domain` - (Required, String, ForceNew) Specifies the domain name to be protected. For example, `www.example.com` or
   `*.example.com`. Changing this creates a new domain.
 
 * `server` - (Required, List, ForceNew) The server configuration list of the domain. A maximum of 80 can be configured.
-  The object structure is documented below.
+  The [server](#waf_server) object structure is documented below.
 
 * `certificate_id` - (Optional, String) Specifies the certificate ID. This parameter is mandatory when `client_protocol`
   is set to HTTPS.
@@ -87,6 +87,24 @@ The following arguments are supported:
 * `protect_status` - (Optional, Int) The protection status of domain, `0`: suspended, `1`: enabled.
   Default value is `1`.
 
+* `tls` - (Optional, String) Specifies the minimum required TLS version. The options include `TLS v1.0`, `TLS v1.1`,
+  `TLS v1.2`.
+
+* `cipher` - (Optional, String) Specifies the cipher suite of domain. The options include `cipher_1`, `cipher_2`,
+  `cipher_3`, `cipher_4`, `cipher_default`.
+
+* `pci_3ds` - (Optional, Bool) Specifies the status of the PCI 3DS compliance certification check. The options
+  include `true` and `false`. This parameter must be used together with tls and cipher.
+
+  -> **NOTE:** Tls must be set to TLS v1.2, and cipher must be set to cipher_2. The PCI 3DS compliance certification
+  check cannot be disabled after being enabled.
+
+* `pci_dss` - (Optional, Bool) Specifies the status of the PCI DSS compliance certification check. The options
+  include `true` and `false`. This parameter must be used together with tls and cipher.
+
+  -> **NOTE:** Tls must be set to TLS v1.2, and cipher must be set to cipher_2.
+
+<a name="waf_server"></a>
 The `server` block supports:
 
 * `client_protocol` - (Required, String, ForceNew) Protocol type of the client. The options include `HTTP` and `HTTPS`.
@@ -106,7 +124,7 @@ The `server` block supports:
 * `port` - (Required, Int, ForceNew) Port number used by the web server. The value ranges from 0 to 65535. Changing this
   creates a new service.
 
-## Attributes Reference
+## Attribute Reference
 
 The following attributes are exported:
 
@@ -119,10 +137,6 @@ The following attributes are exported:
   + `1` - The domain name is connected to WAF.
 
 * `protocol` - The protocol type of the client. The options are `HTTP` and `HTTPS`.
-
-* `tls` - The TLS configuration of domain.
-
-* `cihper` - The cipher suite of domain.
 
 * `compliance_certification` - The compliance certifications of the domain, values are:
   + `pci_dss` - The status of domain PCI DSS, `true`: enabled, `false`: disabled.

--- a/docs/resources/waf_dedicated_instance.md
+++ b/docs/resources/waf_dedicated_instance.md
@@ -49,8 +49,8 @@ resource "flexibleengine_waf_dedicated_instance" "instance_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the WAF dedicated instance. If omitted, the
-  provider-level region will be used. Changing this setting will create a new instance.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the WAF dedicated instance resource.
+  If omitted, the provider-level region will be used. Changing this will create a new WAF dedicated instance resource.
 
 * `name` - (Required, String) The name of WAF dedicated instance. Duplicate names are allowed, we suggest to keeping the
   name unique.
@@ -84,7 +84,7 @@ The following arguments are supported:
 * `group_id` - (Optional, String, ForceNew) The instance group ID used by the WAF dedicated instance in ELB mode.
   Changing this will create a new instance.
 
-## Attributes Reference
+## Attribute Reference
 
 The following attributes are exported:
 
@@ -109,8 +109,8 @@ The following attributes are exported:
 
 This resource provides the following timeouts configuration options:
 
-* `create` - Default is 30 minute.
-* `delete` - Default is 20 minute.
+* `create` - Default is 30 minutes.
+* `delete` - Default is 20 minutes.
 
 ## Import
 

--- a/docs/resources/waf_dedicated_policy.md
+++ b/docs/resources/waf_dedicated_policy.md
@@ -22,8 +22,8 @@ resource "flexibleengine_waf_dedicated_policy" "policy_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the WAF policy resource. If omitted, the
-  provider-level region will be used. Changing this setting will push a new certificate.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the WAF policy resource.
+  If omitted, the provider-level region will be used. Changing this will create a new WAF policy resource.
 
 * `name` - (Required, String) Specifies the policy name. The maximum length is 256 characters. Only digits, letters,
   underscores(_), and hyphens(-) are allowed.
@@ -38,7 +38,7 @@ The following arguments are supported:
   + `2`: medium
   + `3`: high
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
@@ -46,12 +46,13 @@ In addition to all arguments above, the following attributes are exported:
 
 * `full_detection` - The detection mode in Precise Protection.
   + `true`: full detection, Full detection finishes all threat detections before blocking requests that meet Precise
-      Protection specified conditions.
+    Protection specified conditions.
   + `false`: instant detection. Instant detection immediately ends threat detection after blocking a request that
-      meets Precise Protection specified conditions.
+    meets Precise Protection specified conditions.
 
-* `options` - The protection switches. The options object structure is documented below.
+* `options` - The protection switches. The [options](#waf_options) object structure is documented below.
 
+<a name="waf_options"></a>
 The `options` block supports:
 
 * `basic_web_protection` - Indicates whether Basic Web Protection is enabled.
@@ -81,6 +82,13 @@ The `options` block supports:
 * `false_alarm_masking` - Indicates whether False Alarm Masking is enabled.
 
 * `web_tamper_protection` - Indicates whether Web Tamper Protection is enabled.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/waf_domain.md
+++ b/docs/resources/waf_domain.md
@@ -52,10 +52,14 @@ resource "flexibleengine_waf_domain" "domain_1" {
 
 The following arguments are supported:
 
-* `domain` - (Required, String, ForceNew) Specifies the domain name to be protected. For example, `www.example.com` or `*.example.com`.
-  Changing this creates a new domain.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the domain resource.
+  If omitted, the provider-level region will be used. Changing this will create a new domain resource.
 
-* `server` - (Required, List) Specifies an array of origin web servers. The object structure is documented below.
+* `domain` - (Required, String, ForceNew) Specifies the domain name to be protected. For example, `www.example.com`
+  or `*.example.com`. Changing this creates a new domain.
+
+* `server` - (Required, List) Specifies an array of origin web servers. The [server](#waf_server) object structure is
+  documented below.
 
 * `certificate_id` - (Optional, String) Specifies the certificate ID.
   This parameter is mandatory when `client_protocol` is set to HTTPS.
@@ -63,7 +67,7 @@ The following arguments are supported:
 * `policy_id` - (Optional, String, ForceNew) Specifies the policy ID associated with the domain.
   If not specified, a new policy will be created automatically. Changing this create a new domain.
 
-* `keep_proxy` - (Optional, Bool) Specifies whether to retain the policy when deleting a domain name. Defaults to true.
+* `keep_policy` - (Optional, Bool) Specifies whether to retain the policy when deleting a domain name. Defaults to true.
 
 * `proxy` - (Optional, Bool) Specifies whether a proxy is configured.
 
@@ -78,6 +82,7 @@ The following arguments are supported:
   + If `sip_header_name` is *akamai*, the value is ["True-Client-IP"].
   + If `sip_header_name` is *custom*, you can customize a value.
 
+<a name="waf_server"></a>
 The `server` block supports:
 
 * `client_protocol` - (Required, String) Protocol type of the client. The options are *HTTP* and *HTTPS*.
@@ -90,7 +95,7 @@ The `server` block supports:
 
 * `port` - (Required, Int) Port number used by the web server. The value ranges from 0 to 65535, for example, 8080.
 
-## Attributes Reference
+## Attribute Reference
 
 The following attributes are exported:
 
@@ -109,6 +114,13 @@ The following attributes are exported:
   + 1: The domain name is connected to WAF.
 
 * `protocol` - The protocol type of the client. The options are HTTP, HTTPS, and HTTP&HTTPS.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/waf_policy.md
+++ b/docs/resources/waf_policy.md
@@ -20,6 +20,9 @@ resource "flexibleengine_waf_policy" "policy_1" {
 
 The following arguments are supported:
 
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the WAF policy resource.
+  If omitted, the provider-level region will be used. Changing this will create a new WAF policy resource.
+
 * `name` - (Required, String) Specifies the policy name. The maximum length is 256 characters.
   Only digits, letters, underscores(_), and hyphens(-) are allowed.
 
@@ -40,41 +43,50 @@ The following arguments are supported:
 
 * `domains` - (Optional, List) An array of domain IDs.
 
-* `protection_status` - (Optional, Object) Specifies the protection switches. The object structure is documented below.
+* `protection_status` - (Optional, List) Specifies the protection switches. The [protection_status](#waf_protection_status)
+  object structure is documented below.
 
+<a name="waf_protection_status"></a>
 The `protection_status` block supports:
 
-* `basic_web_protection` - Specifies whether Basic Web Protection is enabled.
+* `basic_web_protection` - (Optional, Bool) Specifies whether Basic Web Protection is enabled.
 
-* `general_check` - Specifies whether General Check in Basic Web Protection is enabled.
+* `general_check` - (Optional, Bool) Specifies whether General Check in Basic Web Protection is enabled.
 
-* `crawler_engine` - Specifies whether the Search Engine switch in Basic Web Protection is enabled.
+* `crawler_engine` - (Optional, Bool) Specifies whether the Search Engine switch in Basic Web Protection is enabled.
 
-* `crawler_scanner` - Specifies whether the Scanner switch in Basic Web Protection is enabled.
+* `crawler_scanner` - (Optional, Bool) Specifies whether the Scanner switch in Basic Web Protection is enabled.
 
-* `crawler_script` - Specifies whether the Script Tool switch in Basic Web Protection is enabled.
+* `crawler_script` - (Optional, Bool) Specifies whether the Script Tool switch in Basic Web Protection is enabled.
 
-* `crawler_other` - Specifies whether detection of other crawlers in Basic Web Protection is enabled.
+* `crawler_other` - (Optional, Bool) Specifies whether detection of other crawlers in Basic Web Protection is enabled.
 
-* `webshell` - Specifies whether webshell detection in Basic Web Protection is enabled.
+* `webshell` - (Optional, Bool) Specifies whether webshell detection in Basic Web Protection is enabled.
 
-* `cc_protection` - Specifies whether CC Attack Protection is enabled.
+* `cc_protection` - (Optional, Bool) Specifies whether CC Attack Protection is enabled.
 
-* `precise_protection` - Specifies whether Precise Protection is enabled.
+* `precise_protection` - (Optional, Bool) Specifies whether Precise Protection is enabled.
 
-* `blacklist` - Specifies whether Blacklist and Whitelist is enabled.
+* `blacklist` - (Optional, Bool) Specifies whether Blacklist and Whitelist is enabled.
 
-* `data_masking` - Specifies whether Data Masking is enabled.
+* `data_masking` - (Optional, Bool) Specifies whether Data Masking is enabled.
 
-* `false_alarm_masking` - Specifies whether False Alarm Masking is enabled.
+* `false_alarm_masking` - (Optional, Bool) Specifies whether False Alarm Masking is enabled.
 
-* `web_tamper_protection` - Specifies whether Web Tamper Protection is enabled.
+* `web_tamper_protection` - (Optional, Bool) Specifies whether Web Tamper Protection is enabled.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The policy ID in UUID format.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/waf_rule_cc_protection.md
+++ b/docs/resources/waf_rule_cc_protection.md
@@ -64,12 +64,13 @@ The following arguments are supported:
 
 * `block_time` - (Optional, Int) Specifies the lock duration. The value ranges from 0 seconds to 2^32 seconds.
 
-* `block_page_type` - (Optional, String) Specifies the type of the returned page.
-  The options are `application/json`, `text/html`, and `text/xml`.
+* `block_page_type` - (Optional, String, ForceNew) Specifies the type of the returned page.
+  The options are `application/json`, `text/html`, and `text/xml`. Changing this will create a new resource.
 
-* `block_page_content` - (Optional, String) Specifies the content of the returned page.
+* `block_page_content` - (Optional, String, ForceNew) Specifies the content of the returned page. Changing this will
+  create a new resource.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 


### PR DESCRIPTION
### 1. waf_dedicated_domain

**type: ​**resource
**field:** `tls`, `cihper`, `pci_dss`,`pci_3ds`
**reason:** The unit test was already have the fields
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/2cdd7061-d3fd-4144-8d5e-e4a5df75ab3e)

### 2. waf_dedicated_instances

**type: ​**data source
**field:** `enterprise_project_id`
**reason:** The Terraform script is passed
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/83dc5f61-6984-4759-9aa4-59ae036017c8)
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/0eadf288-93bc-4823-a729-438c598cb2f1)

