### PR TITLE
chore: mark MRS v1 resources as deprecated

### DIFF
--- a/docs/resources/mrs_cluster_v1.md
+++ b/docs/resources/mrs_cluster_v1.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "MapReduce Service (MRS)"
+subcategory: "Deprecated"
 description: ""
 page_title: "flexibleengine_mrs_cluster_v1"
 ---
@@ -8,7 +8,7 @@ page_title: "flexibleengine_mrs_cluster_v1"
 
 Manages a MRS cluster resource within FlexibleEngine.
 
-!> **Warning:** It will be deprecated, using `flexibleengine_mrs_cluster_v2` instead.
+!> **Warning:** It has been deprecated, please use `flexibleengine_mrs_cluster_v2` instead.
 
 ## Example Usage:  Creating a MRS cluster
 

--- a/docs/resources/mrs_hybrid_cluster_v1.md
+++ b/docs/resources/mrs_hybrid_cluster_v1.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "MapReduce Service (MRS)"
+subcategory: "Deprecated"
 description: ""
 page_title: "flexibleengine_mrs_hybrid_cluster_v1"
 ---
@@ -8,7 +8,7 @@ page_title: "flexibleengine_mrs_hybrid_cluster_v1"
 
 Manages a MRS hybrid cluster resource cluster within FlexibleEngine.
 
-!> **Warning:** It will be deprecated, using `flexibleengine_mrs_cluster_v2` instead.
+!> **Warning:** It has been deprecated, please use `flexibleengine_mrs_cluster_v2` instead.
 
 ## Example Usage
 

--- a/docs/resources/mrs_job_v1.md
+++ b/docs/resources/mrs_job_v1.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "MapReduce Service (MRS)"
+subcategory: "Deprecated"
 description: ""
 page_title: "flexibleengine_mrs_job_v1"
 ---
@@ -8,7 +8,7 @@ page_title: "flexibleengine_mrs_job_v1"
 
 Manages resource job within FlexibleEngine MRS.
 
-!> **Warning:** It will be deprecated, using `flexibleengine_mrs_job_v2` instead.
+!> **Warning:** It has been deprecated, please use `flexibleengine_mrs_job_v2` instead.
 
 ## Example Usage
 

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -366,10 +366,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_lb_whitelist_v2":                    resourceWhitelistV2(),
 			"flexibleengine_lb_l7policy_v2":                     resourceL7PolicyV2(),
 			"flexibleengine_lb_l7rule_v2":                       resourceL7RuleV2(),
-			"flexibleengine_mrs_hybrid_cluster_v1":              resourceMRSHybridClusterV1(),
-			"flexibleengine_mrs_cluster_v1":                     resourceMRSClusterV1(),
 			"flexibleengine_mrs_cluster_v2":                     resourceMRSClusterV2(),
-			"flexibleengine_mrs_job_v1":                         resourceMRSJobV1(),
 			"flexibleengine_mrs_job_v2":                         resourceMRSJobV2(),
 			"flexibleengine_mls_instance_v1":                    resourceMlsInstanceV1(),
 			"flexibleengine_network_acl":                        resourceNetworkACL(),
@@ -577,6 +574,10 @@ func Provider() *schema.Provider {
 			"flexibleengine_rds_instance_v1":   resourceRdsInstance(),
 			"flexibleengine_vpc_eip_v1":        resourceVpcEIPV1(),
 			"flexibleengine_vpc_route_v2":      resourceVPCRouteV2(),
+
+			"flexibleengine_mrs_hybrid_cluster_v1": resourceMRSHybridClusterV1(),
+			"flexibleengine_mrs_cluster_v1":        resourceMRSClusterV1(),
+			"flexibleengine_mrs_job_v1":            resourceMRSJobV1(),
 
 			"flexibleengine_networking_floatingip_v2":           resourceNetworkingFloatingIPV2(),
 			"flexibleengine_networking_floatingip_associate_v2": resourceNetworkingFloatingIPAssociateV2(),

--- a/flexibleengine/resource_flexibleengine_mrs_cluster_v1.go
+++ b/flexibleengine/resource_flexibleengine_mrs_cluster_v1.go
@@ -28,6 +28,7 @@ func resourceMRSClusterV1() *schema.Resource {
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
+		DeprecationMessage: "It has been deprecated, please use `flexibleengine_mrs_cluster_v2` instead",
 		Schema: map[string]*schema.Schema{
 			"region": {
 				Type:     schema.TypeString,

--- a/flexibleengine/resource_flexibleengine_mrs_cluster_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_mrs_cluster_v1_test.go
@@ -15,7 +15,10 @@ func TestAccMRSV1Cluster_basic(t *testing.T) {
 	var clusterGet cluster.Cluster
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckMrs(t) },
+		PreCheck: func() {
+			testAccPreCheckDeprecated(t)
+			testAccPreCheckMrs(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMRSV1ClusterDestroy,
 		Steps: []resource.TestStep{

--- a/flexibleengine/resource_flexibleengine_mrs_hybrid_cluster_v1.go
+++ b/flexibleengine/resource_flexibleengine_mrs_hybrid_cluster_v1.go
@@ -23,6 +23,7 @@ func resourceMRSHybridClusterV1() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		DeprecationMessage: "It has been deprecated, please use `flexibleengine_mrs_cluster_v2` instead",
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(60 * time.Minute),
 			Delete: schema.DefaultTimeout(20 * time.Minute),

--- a/flexibleengine/resource_flexibleengine_mrs_hybrid_cluster_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_mrs_hybrid_cluster_v1_test.go
@@ -12,7 +12,10 @@ func TestAccMRSV1HybridCluster_basic(t *testing.T) {
 	var mrsCluster cluster.Cluster
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckMrs(t) },
+		PreCheck: func() {
+			testAccPreCheckDeprecated(t)
+			testAccPreCheckMrs(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMRSV1ClusterDestroy,
 		Steps: []resource.TestStep{

--- a/flexibleengine/resource_flexibleengine_mrs_job_v1.go
+++ b/flexibleengine/resource_flexibleengine_mrs_job_v1.go
@@ -20,6 +20,7 @@ func resourceMRSJobV1() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		DeprecationMessage: "It has been deprecated, please use `flexibleengine_mrs_job_v2` instead",
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(10 * time.Minute),
 			Update: schema.DefaultTimeout(10 * time.Minute),

--- a/flexibleengine/resource_flexibleengine_mrs_job_v1_test.go
+++ b/flexibleengine/resource_flexibleengine_mrs_job_v1_test.go
@@ -16,7 +16,10 @@ func TestAccMRSV1Job_basic(t *testing.T) {
 	var jobGet job.Job
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheckMrs(t) },
+		PreCheck: func() {
+			testAccPreCheckDeprecated(t)
+			testAccPreCheckMrs(t)
+		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMRSV1JobDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
the following resources will be deprecated:

+ flexibleengine_mrs_cluster_v1
+ flexibleengine_mrs_hybrid_cluster_v1
+ flexibleengine_mrs_job_v1