### PR TITLE
docs(sdrs): fix docs issues.

### DIFF
--- a/docs/data-sources/sdrs_domain_v1.md
+++ b/docs/data-sources/sdrs_domain_v1.md
@@ -18,12 +18,11 @@ data "flexibleengine_sdrs_domain_v1" "dom_1" {
 
 ## Argument Reference
 
-* `name` - (Optional) Specifies the name of an active-active domain. Currently only support SDRS_HypeDomain01.
+* `name` - (Optional, String) Specifies the name of an active-active domain. Currently only support SDRS_HypeDomain01.
 
-## Attributes Reference
+## Attribute Reference
 
 `id` is set to the ID of the active-active domain. In addition, the following attributes
 are exported:
 
-* `name` - See Argument Reference above.
 * `description` - Specifies the description of an active-active domain.

--- a/docs/resources/sdrs_drill_v1.md
+++ b/docs/resources/sdrs_drill_v1.md
@@ -46,24 +46,29 @@ resource "flexibleengine_sdrs_drill_v1" "drill_1" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of a DR drill. The name can contain a maximum of 64 bytes.
+* `name` - (Required, String) The name of a DR drill. The name can contain a maximum of 64 bytes.
   The value can contain only letters (a to z and A to Z), digits (0 to 9), decimal points (.),
   underscores (_), and hyphens (-).
 
-* `group_id` - (Required) Specifies the ID of a protection group. Changing this creates a new drill.
+* `group_id` - (Required, String, ForceNew) Specifies the ID of a protection group. Changing this creates a new drill.
 
-* `drill_vpc_id` - (Required) Specifies the ID used for a DR drill. Changing this creates a new drill.
+* `drill_vpc_id` - (Required, String, ForceNew) Specifies the ID used for a DR drill. Changing this creates a new drill.
 
-## Attributes Reference
+## Attribute Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
 * `id` -  ID of a DR drill.
-* `name` - See Argument Reference above.
-* `group_id` - See Argument Reference above.
-* `drill_vpc_id` - See Argument Reference above.
+
 * `status` - The status of a DR drill.
   For details, see [DR Drill Status](https://docs.prod-cloud-ocb.orange-business.com/en-us/api/sdrs/en-us_topic_0126152933.html).
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/sdrs_protectedinstance_v1.md
+++ b/docs/resources/sdrs_protectedinstance_v1.md
@@ -43,32 +43,41 @@ resource "flexibleengine_sdrs_protectedinstance_v1" "instance_1" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of a protected instance.
+* `name` - (Required, String) The name of a protected instance.
 
-* `description` - (Optional) The description of a protected instance. Changing this creates a new instance.
+* `description` - (Optional, String, ForceNew) The description of a protected instance. Changing this creates a new
+  instance.
 
-* `group_id` - (Required) Specifies the ID of the protection group where a protected instance is added.
-  Changing this creates a new instance.
+* `group_id` - (Required, String, ForceNew) Specifies the ID of the protection group where a protected instance is
+  added. Changing this creates a new instance.
 
-* `server_id` - (Required) Specifies the ID of the source server. Changing this creates a new instance.
+* `server_id` - (Required, String, ForceNew) Specifies the ID of the source server. Changing this creates a new instance.
 
-* `cluster_id` - (Optional) Specifies the ID of a storage pool. Changing this creates a new instance.
+* `cluster_id` - (Optional, String, ForceNew) Specifies the ID of a storage pool. Changing this creates a new instance.
 
-* `primary_subnet_id` - (Optional) Specifies the `ipv4_subnet_id` or `ipv6_subnet_id` of the
+* `primary_subnet_id` - (Optional, String, ForceNew) Specifies the `ipv4_subnet_id` or `ipv6_subnet_id` of the
   VPC Subnet of the primary NIC on the target server. Changing this creates a new instance.
 
-* `primary_ip_address` - (Optional) Specifies the IP address of the primary NIC on the target server.
+* `primary_ip_address` - (Optional, String, ForceNew) Specifies the IP address of the primary NIC on the target server.
   Changing this creates a new instance.
 
-* `delete_target_server` - (Optional) Specifies whether to delete the target server. The default value is false.
-  Changing this creates a new instance.
+* `delete_target_server` - (Optional, Bool, ForceNew) Specifies whether to delete the target server. The default
+  value is false. Changing this creates a new instance.
 
-* `delete_target_eip` - (Optional) Specifies whether to delete the EIP of the target server. The default value is false.
-  Changing this creates a new instance.
+* `delete_target_eip` - (Optional, Bool, ForceNew) Specifies whether to delete the EIP of the target server.
+  The default value is false. Changing this creates a new instance.
 
-## Attributes Reference
+## Attribute Reference
 
 The following attributes are exported:
 
 * `id` -  ID of the protected instance.
+
 * `target_server` -  ID of the target server.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.

--- a/docs/resources/sdrs_protectiongroup_v1.md
+++ b/docs/resources/sdrs_protectiongroup_v1.md
@@ -36,29 +36,40 @@ resource "flexibleengine_sdrs_protectiongroup_v1" "group_1" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of a protection group.
+* `name` - (Required, String) The name of a protection group.
 
-* `description` - (Optional) The description of a protection group. Changing this creates a new group.
+* `description` - (Optional, String, ForceNew) The description of a protection group. Changing this creates a new group.
 
-* `source_availability_zone` - (Required) Specifies the source AZ of a protection group. Changing this creates a new group.
-
-* `target_availability_zone` - (Required) Specifies the target AZ of a protection group. Changing this creates a new group.
-
-* `domain_id` - (Required) Specifies the ID of an active-active domain. Changing this creates a new group.
-
-* `source_vpc_id` - (Required) Specifies the ID of the source VPC. Changing this creates a new group.
-
-* `dr_type` - (Optional) Specifies the deployment model. The default value is migration indicating migration within a VPC.
+* `source_availability_zone` - (Required, String, ForceNew) Specifies the source AZ of a protection group.
   Changing this creates a new group.
 
-* `enable` - (Optional) Enable protection or not. It can only be set to true when there's replication pairs within
+* `target_availability_zone` - (Required, String, ForceNew) Specifies the target AZ of a protection group.
+  Changing this creates a new group.
+
+* `domain_id` - (Required, String, ForceNew) Specifies the ID of an active-active domain.
+  Changing this creates a new group.
+
+* `source_vpc_id` - (Required, String, ForceNew) Specifies the ID of the source VPC.
+  Changing this creates a new group.
+
+* `dr_type` - (Optional, String, ForceNew) Specifies the deployment model. The default value is migration indicating
+  migration within a VPC. Changing this creates a new group.
+
+* `enable` - (Optional, Bool) Enable protection or not. It can only be set to true when there's replication pairs within
   the protection group.
 
-## Attributes Reference
+## Attribute Reference
 
 The following attributes are exported:
 
 * `id` -  ID of the protection group.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/sdrs_replication_attach_v1.md
+++ b/docs/resources/sdrs_replication_attach_v1.md
@@ -55,16 +55,26 @@ resource "flexibleengine_sdrs_replication_attach_v1" "attach_1" {
 
 The following arguments are supported:
 
-* `instance_id` - (Required) Specifies the ID of a protected instance. Changing this creates a new replication attach.
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of a protected instance.
+  Changing this creates a new replication attach.
 
-* `replication_id` - (Required) Specifies the ID of a replication pair. Changing this creates a new replication attach.
+* `replication_id` - (Required, String, ForceNew) Specifies the ID of a replication pair.
+  Changing this creates a new replication attach.
 
-* `device` - (Required) Specifies the device name, eg. /dev/vdb. Changing this creates a new replication attach.
+* `device` - (Required, String, ForceNew) Specifies the device name, eg. /dev/vdb.
+  Changing this creates a new replication attach.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID in format of <instance_id>:<replication_id>.
 
-* `status` - The status of the SDRS replication attch resource.
+* `status` - The status of the SDRS replication attach resource.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.

--- a/docs/resources/sdrs_replication_pair_v1.md
+++ b/docs/resources/sdrs_replication_pair_v1.md
@@ -41,20 +41,20 @@ resource "flexibleengine_sdrs_replication_pair_v1" "replication_1" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of a replication pair. The name can contain a maximum of 64 bytes.
+* `name` - (Required, String) The name of a replication pair. The name can contain a maximum of 64 bytes.
   The value can contain only letters (a to z and A to Z), digits (0 to 9), decimal points (.),
   underscores (_), and hyphens (-).
 
-* `description` - (Optional) The description of a replication pair. Changing this creates a new pair.
+* `description` - (Optional, String, ForceNew) The description of a replication pair. Changing this creates a new pair.
 
-* `group_id` - (Required) Specifies the ID of a protection group. Changing this creates a new pair.
+* `group_id` - (Required, String, ForceNew) Specifies the ID of a protection group. Changing this creates a new pair.
 
-* `volume_id` - (Required) Specifies the ID of a source disk. Changing this creates a new pair.
+* `volume_id` - (Required, String, ForceNew) Specifies the ID of a source disk. Changing this creates a new pair.
 
-* `delete_target_volume` - (Optional) Specifies whether to delete the target disk.
+* `delete_target_volume` - (Optional, Bool) Specifies whether to delete the target disk.
   The default value is `false`.
 
-## Attributes Reference
+## Attribute Reference
 
 The following attributes are exported:
 
@@ -67,6 +67,13 @@ The following attributes are exported:
 * `status` - Specifies the status of a replication pair.
 
 * `target_volume_id` - Specifies the ID of the disk in the protection availability zone.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/flexibleengine/resource_flexibleengine_sdrs_drill.go
+++ b/flexibleengine/resource_flexibleengine_sdrs_drill.go
@@ -43,7 +43,6 @@ func resourceSdrsDrillV1() *schema.Resource {
 			},
 			"status": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 		},

--- a/flexibleengine/resource_flexibleengine_sdrs_replication_pair_v1.go
+++ b/flexibleengine/resource_flexibleengine_sdrs_replication_pair_v1.go
@@ -57,22 +57,18 @@ func resourceSdrsReplicationPairV1() *schema.Resource {
 			// the following attributes are computed
 			"replication_model": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"fault_level": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"status": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 			"target_volume_id": {
 				Type:     schema.TypeString,
-				Optional: true,
 				Computed: true,
 			},
 		},


### PR DESCRIPTION
### 1. flexibleengine_sdrs_replication_pair_v1
`replication_model`,`fault_level`,`status`,`target_volume_id` are computed in schema

