### PR TITLE
docs(rds): fix docs issues.

### DIFF
--- a/docs/data-sources/rds_flavors_v3.md
+++ b/docs/data-sources/rds_flavors_v3.md
@@ -19,6 +19,9 @@ data "flexibleengine_rds_flavors_v3" "flavor" {
 
 ## Argument Reference
 
+* `region` - (Optional, String) The region in which to query the data source. If omitted, the provider-level region
+  will be used.
+
 * `db_type` - (Required, String) Specifies the DB engine. Value: MySQL, PostgreSQL, SQLServer.
 
 * `db_version` - (Required, String) Specifies the database version. MySQL databases support MySQL 5.6
@@ -42,21 +45,29 @@ data "flexibleengine_rds_flavors_v3" "flavor" {
 
 * `availability_zone` - (Optional, String) Specifies the availability zone which the RDS flavor belongs to.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The data source ID.
 
-* `flavors` - Indicates the flavors information. Structure is documented below.
+* `flavors` - Indicates the flavors information. The [flavors](#rds_flavors) object structure is documented below.
 
+<a name="rds_flavors"></a>
 The `flavors` block contains:
 
 * `id` - The ID of the rds flavor.
+
 * `name` - The name of the rds flavor.
+
 * `vcpus` - The CPU size.
+
 * `memory` - The memory size in GB.
+
 * `group_type` - The performance specification.
+
 * `instance_mode` - The mode of instance.
+
 * `availability_zones` - The availability zones which the RDS flavor belongs to.
+
 * `db_versions` - The Available versions of the database.

--- a/docs/resources/rds_account.md
+++ b/docs/resources/rds_account.md
@@ -24,8 +24,8 @@ resource "flexibleengine_rds_account" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the rds account resource. If omitted, the
-  provider-level region will be used. Changing this creates a new resource.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the RDS account resource.
+  If omitted, the provider-level region will be used. Changing this will create a new RDS account resource.
 
 * `instance_id` - (Required, String, ForceNew) Specifies the rds instance id. Changing this will create a new resource.
 
@@ -38,11 +38,19 @@ The following arguments are supported:
   long and contain only letters(case-sensitive), digits, and special characters(~!@#$%^*-_=+?,()&). The value must be
   different from name or name spelled backwards.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID of account which is formatted `<instance_id>/<account_name>`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/rds_database.md
+++ b/docs/resources/rds_database.md
@@ -24,8 +24,8 @@ resource "flexibleengine_rds_database" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the RDS database resource. If omitted, the
-  provider-level region will be used. Changing this creates a new resource.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the RDS database resource.
+  If omitted, the provider-level region will be used. Changing this will create a new RDS database resource.
 
 * `instance_id` - (Required, String, ForceNew) Specifies the RDS instance ID. Changing this will create a new resource.
 
@@ -37,11 +37,23 @@ The following arguments are supported:
 * `character_set` - (Required, String, ForceNew) Specifies the character set used by the database, For example **utf8**,
   **gbk**, **ascii**, etc. Changing this will create a new resource.
 
-## Attributes Reference
+* `description` - (Optional, String) Specifies the database description. The value can contain **0** to **512**
+  characters. This parameter takes effect only for DB instances whose kernel versions are at least **5.6.51.3**,
+  **5.7.33.1**, or **8.0.21.4**.
+
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID of database which is formatted `<instance_id>/<database_name>`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/rds_database_privilege.md
+++ b/docs/resources/rds_database_privilege.md
@@ -36,31 +36,41 @@ resource "flexibleengine_rds_database_privilege" "test" {
 
 The following arguments are supported:
 
-* `region` - (Optional, String, ForceNew) The region in which to create the RDS database privilege resource. If omitted,
-  the provider-level region will be used. Changing this creates a new resource.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the RDS database privilege resource.
+  If omitted, the provider-level region will be used. Changing this will create a new RDS database privilege resource.
 
 * `instance_id` - (Required, String, ForceNew) Specifies the RDS instance ID. Changing this will create a new resource.
 
 * `db_name` - (Required, String, ForceNew) Specifies the database name. Changing this creates a new resource.
 
-* `users` - (Required, String, ForceNew) Specifies the account that associated with the database. This parameter supports
-  a maximum of 50 elements. Structure is documented below. Changing this creates a new resource.
+* `users` - (Required, List, ForceNew) Specifies the account that associated with the database. This parameter supports
+  a maximum of 50 elements. The [users](#rds_users) object structure is documented below.
+  Changing this creates a new resource.
 
+<a name="rds_users"></a>
 The `users` block supports:
 
-* `name` - (Required, String, ForceNew) Specifies the username of the database account. Changing this creates a new resource.
+* `name` - (Required, String) Specifies the username of the database account.
 
-* `readonly` - (Optional, Bool, ForceNew) Specifies the read-only permission. The value can be:
+* `readonly` - (Optional, Bool) Specifies the read-only permission. The value can be:
   + **true**: indicates the read-only permission.
   + **false**: indicates the read and write permission.
 
-  The default value is **false**. Changing this creates a new resource.
+  The default value is **false**.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID of database privilege which is formatted `<instance_id>/<database_name>`.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+* `update` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.
 
 ## Import
 

--- a/docs/resources/rds_instance_v3.md
+++ b/docs/resources/rds_instance_v3.md
@@ -156,6 +156,9 @@ resource "flexibleengine_rds_instance_v3" "instance" {
 
 The following arguments are supported:
 
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the RDS instance resource.
+  If omitted, the provider-level region will be used. Changing this will create a new RDS instance resource.
+
 * `name` - (Required, String) Specifies the DB instance name. The DB instance name of the same type must be unique for
   the same tenant. The value must be 4 to 64 characters in length and start with a letter. It is case-sensitive and can
   contain only letters, digits, hyphens (-), and underscores (_).
@@ -167,8 +170,8 @@ The following arguments are supported:
 * `availability_zone` - (Required, List, ForceNew) Specifies the list of AZ name.
   Changing this parameter will create a new resource.
 
-* `db` - (Required, String, ForceNew) Specifies the database information. Structure is documented below.
-  Changing this parameter will create a new resource.
+* `db` - (Required, List, ForceNew) Specifies the database information. The [db](#rds_db) object structure is
+  documented below. Changing this parameter will create a new resource.
 
 * `vpc_id` - (Required, String, ForceNew) Specifies the VPC ID. Changing this parameter will create a new resource.
 
@@ -177,12 +180,13 @@ The following arguments are supported:
 
 * `security_group_id` - (Required, String) Specifies the security group which the RDS DB instance belongs to.
 
-* `volume` - (Required, List) Specifies the volume information. Structure is documented below.
+* `volume` - (Required, List) Specifies the volume information. The [volume](#rds_volume) object structure is
+  documented below.
 
-* `fixed_ip` - (Optional, String, ForceNew) Specifies an intranet IP address of RDS DB instance.
-  Changing this parameter will create a new resource.
+* `fixed_ip` - (Optional, String) Specifies an intranet IP address of RDS DB instance.
 
-* `backup_strategy` - (Optional, List) Specifies the advanced backup policy. Structure is documented below.
+* `backup_strategy` - (Optional, List) Specifies the advanced backup policy. The [backup_strategy](#rds_backup_strategy)
+  object structure is documented below.
 
 * `ha_replication_mode` - (Optional, String, ForceNew) Specifies the replication mode for the standby DB instance.
   Changing this parameter will create a new resource.
@@ -204,6 +208,11 @@ The following arguments are supported:
 * `tags` - (Optional, Map) A mapping of tags to assign to the RDS instance.
   Each tag is represented by one key-value pair.
 
+* `parameters` - (Optional, List) Specify an array of one or more parameters to be set to the RDS instance after
+  launched. You can check on console to see which parameters supported. The [parameters](#rds_parameters) object
+  structure is documented below.
+
+<a name="rds_db"></a>
 The `db` block supports:
 
 * `type` - (Required, String, ForceNew) Specifies the DB engine. Available value are *MySQL*, *PostgreSQL* and
@@ -215,20 +224,19 @@ The `db` block supports:
   databases support 2014 SE and 2014 EE, example values: "2014_SE", "2014_EE".
   Changing this parameter will create a new resource.
 
-* `password` - (Required, String, ForceNew) Specifies the database password. The value cannot be
-  empty and should contain 8 to 32 characters, including uppercase
-  and lowercase letters, digits, and the following special
-  characters: ~!@#%^*-_=+? You are advised to enter a strong
-  password to improve security, preventing security risks such as
-  brute force cracking.  Changing this parameter will create a new resource.
+* `password` - (Required, String) Specifies the database password. The value cannot be
+  empty and should contain 8 to 32 characters, including uppercase and lowercase letters, digits, and the following
+  special characters: ~!@#%^*-_=+? You are advised to enter a strong password to improve security, preventing security
+  risks such as brute force cracking.
 
 * `port` - (Optional, Int) Specifies the database port.
   + The MySQL database port ranges from 1024 to 65535 (excluding 12017 and 33071, which are occupied by the RDS system
       and cannot be used). The default value is 3306.
   + The PostgreSQL database port ranges from 2100 to 9500. The default value is 5432.
   + The Microsoft SQL Server database port can be 1433 or ranges from 2100 to 9500, excluding 5355 and 5985.
-      The default value is 1433.
+    The default value is 1433.
 
+<a name="rds_volume"></a>
 The `volume` block supports:
 
 * `size` - (Required, Int) Specifies the volume size. Its value range is from 40 GB to 4000 GB.
@@ -241,9 +249,10 @@ The `volume` block supports:
 
   Changing this parameter will create a new resource.
 
-* `disk_encryption_id` - (Optional, String) Specifies the key ID for disk encryption.
+* `disk_encryption_id` - (Optional, String, ForceNew) Specifies the key ID for disk encryption.
   Changing this parameter will create a new resource.
 
+<a name="rds_backup_strategy"></a>
 The `backup_strategy` block supports:
 
 * `keep_days` - (Optional, Int) Specifies the retention days for specific backup files. The value range is from 0 to
@@ -253,12 +262,19 @@ The `backup_strategy` block supports:
   policy.
 
 * `start_time` - (Required, String) Specifies the backup time window. Automated backups will be triggered during the
-  backup time window. It must be a valid value in the **hh:mm-HH:MM**
-  format. The current time is in the UTC format. The HH value must be 1 greater than the hh value. The values of mm and
-  MM must be the same and must be set to any of the following: 00, 15, 30, or 45. Example value: 08:15-09:15 23:00-00:
-  00.
+  backup time window. It must be a valid value in the **hh:mm-HH:MM** format. The current time is in the UTC format.
+  The HH value must be 1 greater than the hh value. The values of mm and MM must be the same and must be set to any
+  of the following: 00, 15, 30, or 45. Example value: 08:15-09:15 23:00-00:00.
 
-## Attributes Reference
+<a name="rds_parameters"></a>
+The `parameters` block supports:
+
+* `name` - (Required, String) Specifies the parameter name. Some of them needs the instance to be restarted
+  to take effect.
+
+* `value` - (Required, String) Specifies the parameter value.
+
+## Attribute Reference
 
 In addition to the arguments listed above, the following computed attributes are exported:
 
@@ -268,18 +284,17 @@ In addition to the arguments listed above, the following computed attributes are
 
 * `created` - Indicates the creation time.
 
-* `nodes` - Indicates the instance nodes information. Structure is documented below.
+* `nodes` - Indicates the instance nodes information. The [nodes](#rds_attr_nodes) object structure is documented below.
 
 * `private_ips` - Indicates the private IP address list.
   It is a blank string until an ECS is created.
 
 * `public_ips` - Indicates the public IP address list.
 
-* `db` - See Argument Reference above. The `db` block also contains:
+* `db` - See Argument Reference above. The [db](#rds_attr_db) object structure is documented below.
 
-  + `user_name` - Indicates the default user name of database.
-
-The `nodes` block contains:
+<a name="rds_attr_nodes"></a>
+The `nodes` block supports:
 
 * `availability_zone` - Indicates the AZ.
 
@@ -292,12 +307,18 @@ The `nodes` block contains:
 
 * `status` - Indicates the node status.
 
+<a name="rds_attr_db"></a>
+The `db` block supports:
+
+* `user_name` - Indicates the default username of database.
+
 ## Timeouts
 
 This resource provides the following timeouts configuration options:
 
-* `create` - Default is 30 minute.
-* `update` - Default is 30 minute.
+* `create` - Default is 30 minutes.
+* `update` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.
 
 ## Import
 
@@ -307,7 +328,7 @@ RDS instance can be imported using the `id`, e.g.
 terraform import flexibleengine_rds_instance_v3.instance_1 7117d38e-4c8f-4624-a505-bd96b97d024c
 ```
 
-But due to some attrubutes missing from the API response, it's required to ignore changes as below.
+But due to some attributes missing from the API response, it's required to ignore changes as below.
 
 ```hcl
 resource "flexibleengine_rds_instance_v3" "instance_1" {

--- a/docs/resources/rds_parametergroup_v3.md
+++ b/docs/resources/rds_parametergroup_v3.md
@@ -32,42 +32,61 @@ resource "flexibleengine_rds_parametergroup_v3" "pg_1" {
 
 The following arguments are supported:
 
-* `name` - (Required) The parameter group name. It contains a maximum of 64 characters.
+* `name` - (Required, String) The parameter group name. It contains a maximum of 64 characters.
 
-* `description` - (Optional) The parameter group description. It contains a maximum of 256 characters and
+* `description` - (Optional, String) The parameter group description. It contains a maximum of 256 characters and
   cannot contain the following special characters:>!<"&'= the value is left blank by default.
 
-* `values` - (Optional) Parameter group values key/value pairs defined by users based on the default parameter groups.
+* `values` - (Optional, Map) Parameter group values key/value pairs defined by users based on the default
+  parameter groups.
 
-* `datastore` - (Required) Database object. The database object structure is documented below.
-  Changing this creates a new parameter group.
+* `datastore` - (Required, List, ForceNew) Database object. The [datastore](#rds_datastore) object structure is
+  documented below. Changing this creates a new parameter group.
 
+<a name="rds_datastore"></a>
 The `datastore` block supports:
 
-* `type` - (Required) The DB engine. Currently, MySQL, PostgreSQL, and Microsoft SQL Server are supported.
+* `type` - (Required, String) The DB engine. Currently, MySQL, PostgreSQL, and Microsoft SQL Server are supported.
   The value is case-insensitive and can be mysql, postgresql, or sqlserver.
 
-* `version` - (Required) Specifies the database version.
+* `version` - (Required, String) Specifies the database version.
 
   + MySQL databases support MySQL 5.6 and 5.7. Example value: 5.7.
   + PostgreSQL databases support PostgreSQL 9.5 and 9.6. Example value: 9.5.
   + Microsoft SQL Server databases support 2014 SE, 2016 SE, and 2016 EE. Example value: 2014_SE.
 
-## Attributes Reference
+## Attribute Reference
 
 The following attributes are exported:
 
 * `id` -  ID of the parameter group.
 
-* `configuration_parameters` - Indicates the parameter configuration defined by users based on the default parameters groups.
+* `configuration_parameters` - Indicates the parameter configuration defined by users based on the default
+  parameters groups. The [configuration_parameters](#rds_configuration_parameters) object structure is documented below.
 
-  + `name` - Indicates the parameter name.
-  + `value` - Indicates the parameter value.
-  + `restart_required` - Indicates whether a restart is required.
-  + `readonly` - Indicates whether the parameter is read-only.
-  + `value_range` - Indicates the parameter value range.
-  + `type` - Indicates the parameter type.
-  + `description` - Indicates the parameter description.
+<a name="rds_configuration_parameters"></a>
+The `configuration_parameters` block supports:
+
+* `name` - Indicates the parameter name.
+
+* `value` - Indicates the parameter value.
+
+* `restart_required` - Indicates whether a restart is required.
+
+* `readonly` - Indicates whether the parameter is read-only.
+
+* `value_range` - Indicates the parameter value range.
+
+* `type` - Indicates the parameter type.
+
+* `description` - Indicates the parameter description.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/rds_read_replica_v3.md
+++ b/docs/resources/rds_read_replica_v3.md
@@ -68,45 +68,46 @@ resource "flexibleengine_rds_read_replica_v3" "instance_2" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the DB instance name.
-    The DB instance name of the same type must be unique for the
-    same tenant. The value must be 4 to 64 characters in length
-    and start with a letter. It is case-sensitive and can contain
-    only letters, digits, hyphens (-), and underscores (_).
-    Changing this parameter will create a new resource.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the RDS read replica resource.
+  If omitted, the provider-level region will be used. Changing this will create a new RDS read replica resource.
+  Currently, read replicas can be created only in the same region as that of the primary DB instance.
 
-* `flavor` - (Required) Specifies the specification code.
+* `name` - (Required, String, ForceNew) Specifies the DB instance name. The DB instance name of the same type must be
+  unique for the same tenant. The value must be 4 to 64 characters in length and start with a letter. It is
+  case-sensitive and can contain only letters, digits, hyphens (-), and underscores (_).
+  Changing this parameter will create a new resource.
 
-* `replica_of_id` - (Required) Specifies the DB instance ID, which is used to
-    create a read replica. Changing this parameter will create a new resource.
+* `flavor` - (Required, String) Specifies the specification code.
 
-* `volume` - (Required) Specifies the volume information. Structure is documented below.
-    Changing this parameter will create a new resource.
+* `replica_of_id` - (Required, String, ForceNew) Specifies the DB instance ID, which is used to create a read replica.
+  Changing this parameter will create a new resource.
 
-* `availability_zone` - (Required) Specifies the AZ name.
-    Changing this parameter will create a new resource.
+* `volume` - (Required, List, ForceNew) Specifies the volume information. The [volume](#rds_volume) object structure is
+  documented below. Changing this parameter will create a new resource.
 
-* `tags` - (Optional) A mapping of tags to assign to the RDS read replica instance.
-    Each tag is represented by one key-value pair.
+* `availability_zone` - (Required, String, ForceNew) Specifies the AZ name.
+  Changing this parameter will create a new resource.
 
-* `region` - (Optional) The region in which to create the instance. If omitted,
-    the `region` argument of the provider is used. Currently, read replicas can
-    be created only in the same region as that of the promary DB instance.
-    Changing this parameter will create a new resource.
+* `tags` - (Optional, Map) A mapping of tags to assign to the RDS read replica instance.
+  Each tag is represented by one key-value pair.
 
+<a name="rds_volume"></a>
 The `volume` block supports:
 
-* `type` - (Required) Specifies the volume type. Its value can be any of the following
-    and is case-sensitive:
-    - ULTRAHIGH: indicates the SSD type.
-    - ULTRAHIGHPRO: indicates the ultra-high I/O.
+* `type` - (Required, String, ForceNew) Specifies the volume type. Its value can be any of the following
+  and is case-sensitive:
+  - ULTRAHIGH: indicates the SSD type.
+  - ULTRAHIGHPRO: indicates the ultra-high I/O.
 
-    Changing this parameter will create a new resource.
+  Changing this parameter will create a new resource.
 
-* `disk_encryption_id` -  (Optional) Specifies the key ID for disk encryption.
-    Changing this parameter will create a new resource.
+* `disk_encryption_id` -  (Optional, String, ForceNew) Specifies the key ID for disk encryption.
+  Changing this parameter will create a new resource.
 
-## Attributes Reference
+* `size` - (Optional, Int) Specifies the volume size. Its value range is from **40** GB to **4000** GB. The value must
+  be a multiple of 10 and greater than the original size.
+
+## Attribute Reference
 
 In addition to the arguments listed above, the following computed attributes are exported:
 
@@ -114,7 +115,9 @@ In addition to the arguments listed above, the following computed attributes are
 
 * `status` - Indicates the instance status.
 
-* `db` - Indicates the database information. Structure is documented below.
+* `type` -  Indicates the type of the read replica instance.
+
+* `db` - Indicates the database information. The [db](#rds_db) object structure is documented below.
 
 * `private_ips` - Indicates the private IP address list.
 
@@ -126,15 +129,23 @@ In addition to the arguments listed above, the following computed attributes are
 
 * `vpc_id` - Indicates the VPC ID.
 
+<a name="rds_db"></a>
 The `db` block supports:
 
 * `port` - Indicates the database port information.
 
 * `type` - Indicates the DB engine. Value: MySQL, PostgreSQL, SQLServer.
 
-* `user_name` - Indicates the default user name of database.
+* `user_name` - Indicates the default username of database.
 
 * `version` - Indicates the database version.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.
 
 ## Import
 

--- a/flexibleengine/acceptance/resource_flexibleengine_rds_account_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_rds_account_test.go
@@ -176,36 +176,31 @@ resource "flexibleengine_networking_secgroup_v2" "test" {
   name = "%[1]s"
 }
 
-data "flexibleengine_rds_flavors_v3" "test" {
-  db_type       = "MySQL"
-  db_version    = "5.7"
-  instance_mode = "single"
-  vcpus         = 2
-  memory        = 4
-}
-
 resource "flexibleengine_rds_instance_v3" "test" {
-  name               = "%[1]s"
-  flavor             = data.flexibleengine_rds_flavors_v3.test.flavors[0].name
-  security_group_id  = flexibleengine_networking_secgroup_v2.test.id
-  subnet_id          = flexibleengine_vpc_subnet_v1.test.id
-  vpc_id             = flexibleengine_vpc_v1.test.id
+  name                = "%[1]s"
+  flavor              = "rds.mysql.c6.large.2.ha"
+  security_group_id   = flexibleengine_networking_secgroup_v2.test.id
+  subnet_id           = flexibleengine_vpc_subnet_v1.test.id
+  vpc_id              = flexibleengine_vpc_v1.test.id
+  fixed_ip            = "192.168.0.58"
+  ha_replication_mode = "semisync"
 
- availability_zone = [
-   data.flexibleengine_availability_zones.test.names[0]
- ]
+  availability_zone = [
+    data.flexibleengine_availability_zones.test.names[0],
+    data.flexibleengine_availability_zones.test.names[1],
+  ]
 
- db {
-   password = "Huangwei!120521"
-   type     = "MySQL"
-   version  = "5.7"
-   port     = 3306
- }
+  db {
+    password = "Huangwei!120521"
+    type     = "MySQL"
+    version  = "5.7"
+    port     = 3306
+  }
 
- volume {
-   type = "ULTRAHIGH"
-   size = 40
- }
+  volume {
+    type = "ULTRAHIGH"
+    size = 50
+  }
 }
 `, rName)
 }

--- a/flexibleengine/acceptance/resource_flexibleengine_rds_database_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_rds_database_test.go
@@ -105,6 +105,7 @@ resource "flexibleengine_rds_database" "test" {
   instance_id   = flexibleengine_rds_instance_v3.test.id
   name          = "%s"
   character_set = "utf8"
+  description   = "terraform script description"
 }
 `, testRdsAccount_base(rName), rName)
 }

--- a/flexibleengine/acceptance/resource_flexibleengine_rds_instance_v3_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_rds_instance_v3_test.go
@@ -36,6 +36,8 @@ func TestAccRdsInstanceV3_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "60"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "div_precision_increment"),
+					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "12"),
 					resource.TestCheckResourceAttrSet(resourceName, "fixed_ip"),
 				),
 			},
@@ -169,6 +171,11 @@ resource "flexibleengine_rds_instance_v3" "instance" {
   backup_strategy {
     start_time = "08:00-09:00"
     keep_days  = 1
+  }
+
+  parameters {
+    name  = "div_precision_increment"
+    value = "12"
   }
 
   tags = {


### PR DESCRIPTION
### 1.flexibleengine_rds_database

**field:** `description`
**reason:** unit test was passed<br />
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/b8d6feb1-c810-45b6-8a2f-fe135ddd80e5)
```hcl
=== RUN   TestAccRdsDatabase_basic
=== PAUSE TestAccRdsDatabase_basic
=== CONT  TestAccRdsDatabase_basic
--- PASS: TestAccRdsDatabase_basic (633.11s)
PASS


Process finished with the exit code 0
```


### 2.flexibleengine_rds_instance_v3

**field:** `enterprise_project_id`
**reason:** The service does not support the field.<br />
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/4f157387-fad4-4647-8529-13fedfa077bc)

**field:** `volume.limit_size`,`vloume.trigger_threshold`
**reason:** The service does not support the field.
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/6fff0804-5a5d-47b4-871e-12bd8c0f7794)

**field:** `parameters.name`,`parameters.value`
**reason:** The service does not support the field.
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/c35e96f8-f61a-453d-83e4-be31b92da74a)


### 3.flexibleengine_rds_read_replica_v3

**field:** `volume.size`
**reason: ​**The unit test has but docs is missed the field
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/05debd29-58b7-4ab3-a8fe-14af0c98db7d)

**field:** `type`
**reason: ​**The docs is missed the field
![image](https://github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/assets/65212374/b63f6adc-75e4-4961-9b7d-493efd983a0e)

