### PR TITLE
docs(FireWall): fix docs issues

### DIFF
--- a/docs/resources/fw_firewall_group_v2.md
+++ b/docs/resources/fw_firewall_group_v2.md
@@ -47,48 +47,37 @@ resource "flexibleengine_fw_firewall_group_v2" "firewall_group_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to obtain the v2 networking client.
-    A networking client is needed to create a firewall group. If omitted, the
-    `region` argument of the provider is used. Changing this creates a new
-    firewall group.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
 
-* `ingress_policy_id` - The ingress policy resource id for the firewall group. Changing
-    this updates the `ingress_policy_id` of an existing firewall group.
+* `ingress_policy_id` - (Optional, String) The ingress policy resource id for the firewall group. Changing
+  this updates the `ingress_policy_id` of an existing firewall group.
 
-* `egress_policy_id` - The egress policy resource id for the firewall group. Changing
-    this updates the `egress_policy_id` of an existing firewall group.
+* `egress_policy_id` - (Optional, String) The egress policy resource id for the firewall group. Changing
+  this updates the `egress_policy_id` of an existing firewall group.
 
-* `name` - (Optional) A name for the firewall group. Changing this
-    updates the `name` of an existing firewall group.
+* `name` - (Optional, String) A name for the firewall group. Changing this
+  updates the `name` of an existing firewall group.
 
-* `description` - (Required) A description for the firewall group. Changing this
-    updates the `description` of an existing firewall group.
+* `description` - (Optional, String) A description for the firewall group. Changing this
+  updates the `description` of an existing firewall group.
 
-* `admin_state_up` - (Optional) Administrative up/down status for the firewall group
-    (must be "true" or "false" if provided - defaults to "true").
-    Changing this updates the `admin_state_up` of an existing firewall group.
+* `ports` - (Optional, List) The ports associated with this firewall group instance.
+  Must be a list of strings. Changing this updates the associated routers of an existing firewall group.
 
-* `tenant_id` - (Optional) The owner of the floating IP. Required if admin wants
-    to create a firewall group for another tenant. Changing this creates a new
-    firewall group.
+## Attribute Reference
 
-* `ports` - (Optional) Port(s) to associate this firewall group instance
-    with. Must be a list of strings. Changing this updates the associated routers
-    of an existing firewall group.
+In addition to all arguments above, the following attributes are exported:
 
-* `value_specs` - (Optional) Map of additional options.
+* `id` - The ID of the firewall group.
 
-## Attributes Reference
+## Timeouts
 
-The following attributes are exported:
+This resource provides the following timeouts configuration options:
 
-* `region` - See Argument Reference above.
-* `policy_id` - See Argument Reference above.
-* `name` - See Argument Reference above.
-* `description` - See Argument Reference above.
-* `admin_state_up` - See Argument Reference above.
-* `tenant_id` - See Argument Reference above.
-* `ports` - See Argument Reference above.
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/fw_policy_v2.md
+++ b/docs/resources/fw_policy_v2.md
@@ -43,44 +43,42 @@ resource "flexibleengine_fw_policy_v2" "policy_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to obtain the v2 networking client.
-    A networking client is needed to create a firewall policy. If omitted, the
-    `region` argument of the provider is used. Changing this creates a new
-    firewall policy.
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this creates a new resource.
 
-* `name` - (Optional) A name for the firewall policy. Changing this
-    updates the `name` of an existing firewall policy.
+* `name` - (Optional, String) A name for the firewall policy. Changing this
+  updates the `name` of an existing firewall policy.
 
-* `description` - (Optional) A description for the firewall policy. Changing
-    this updates the `description` of an existing firewall policy.
+* `description` - (Optional, String) A description for the firewall policy. Changing
+  this updates the `description` of an existing firewall policy.
 
-* `rules` - (Optional) An array of one or more firewall rules that comprise
-    the policy. Changing this results in adding/removing rules from the
-    existing firewall policy.
+* `rules` - (Optional, List) An array of one or more firewall rules that comprise
+  the policy. Changing this results in adding/removing rules from the
+  existing firewall policy.
 
-* `audited` - (Optional) Audit status of the firewall policy
-    (must be "true" or "false" if provided - defaults to "false").
-    This status is set to "false" whenever the firewall policy or any of its
-    rules are changed. Changing this updates the `audited` status of an existing
-    firewall policy.
+* `audited` - (Optional, Bool) Audit status of the firewall policy
+  (must be "true" or "false" if provided - defaults to "false").
+  This status is set to "false" whenever the firewall policy or any of its
+  rules are changed. Changing this updates the `audited` status of an existing
+  firewall policy.
 
-* `shared` - (Optional) Sharing status of the firewall policy (must be "true"
-    or "false" if provided). If this is "true" the policy is visible to, and
-    can be used in, firewalls in other tenants. Changing this updates the
-    `shared` status of an existing firewall policy. Only administrative users
-    can specify if the policy should be shared.
+* `shared` - (Optional, Bool) Sharing status of the firewall policy (must be "true"
+  or "false" if provided). If this is "true" the policy is visible to, and
+  can be used in, firewalls in other tenants. Changing this updates the
+  `shared` status of an existing firewall policy. Only administrative users
+  can specify if the policy should be shared.
 
-* `value_specs` - (Optional) Map of additional options.
+## Attribute Reference
 
-## Attributes Reference
+In addition to all arguments above, the following attributes are exported:
 
-The following attributes are exported:
+* `id` - The ID of the policy.
 
-* `region` - See Argument Reference above.
-* `name` - See Argument Reference above.
-* `description` - See Argument Reference above.
-* `audited` - See Argument Reference above.
-* `shared` - See Argument Reference above.
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
 
 ## Import
 

--- a/docs/resources/fw_rule_v2.md
+++ b/docs/resources/fw_rule_v2.md
@@ -25,70 +25,53 @@ resource "flexibleengine_fw_rule_v2" "rule_1" {
 
 The following arguments are supported:
 
-* `region` - (Optional) The region in which to obtain the v2 networking client.
-    A Compute client is needed to create a firewall rule. If omitted, the
-    `region` argument of the provider is used. Changing this creates a new
-    firewall rule.
+* `region` - (Optional, String, ForceNew) The region in which to obtain the v2 networking client.
+  A Compute client is needed to create a firewall rule. If omitted, the
+  `region` argument of the provider is used. Changing this creates a new
+  firewall rule.
 
-* `name` - (Optional) A unique name for the firewall rule. Changing this
-    updates the `name` of an existing firewall rule.
+* `name` - (Optional, String) A unique name for the firewall rule. Changing this
+  updates the `name` of an existing firewall rule.
 
-* `description` - (Optional) A description for the firewall rule. Changing this
-    updates the `description` of an existing firewall rule.
+* `description` - (Optional, String) A description for the firewall rule. Changing this
+  updates the `description` of an existing firewall rule.
 
-* `protocol` - (Required) The protocol type on which the firewall rule operates.
-    Valid values are: `tcp`, `udp`, `icmp`, and `any`. Changing this updates the
-    `protocol` of an existing firewall rule.
+* `protocol` - (Required, String) The protocol type on which the firewall rule operates.
+  Valid values are: `tcp`, `udp`, `icmp`, and `any`. Changing this updates the
+  `protocol` of an existing firewall rule.
 
-* `action` - (Required) Action to be taken ( must be "allow" or "deny") when the
-    firewall rule matches. Changing this updates the `action` of an existing
-    firewall rule.
+* `action` - (Required, String) Action to be taken ( must be "allow" or "deny") when the
+  firewall rule matches. Changing this updates the `action` of an existing
+  firewall rule.
 
-* `ip_version` - (Optional) IP version, either 4 (default) or 6. Changing this
-    updates the `ip_version` of an existing firewall rule.
+* `ip_version` - (Optional, Int) IP version, either 4 (default) or 6. Changing this
+  updates the `ip_version` of an existing firewall rule.
 
-* `source_ip_address` - (Optional) The source IP address on which the firewall
-    rule operates. Changing this updates the `source_ip_address` of an existing
-    firewall rule.
+* `source_ip_address` - (Optional, String) The source IP address on which the firewall
+  rule operates. Changing this updates the `source_ip_address` of an existing
+  firewall rule.
 
-* `destination_ip_address` - (Optional) The destination IP address on which the
-    firewall rule operates. Changing this updates the `destination_ip_address`
-    of an existing firewall rule.
+* `destination_ip_address` - (Optional, String) The destination IP address on which the
+  firewall rule operates. Changing this updates the `destination_ip_address`
+  of an existing firewall rule.
 
-* `source_port` - (Optional) The source port on which the firewall
-    rule operates. Changing this updates the `source_port` of an existing
-    firewall rule.
+* `source_port` - (Optional, String) The source port on which the firewall
+  rule operates. Changing this updates the `source_port` of an existing
+  firewall rule.
 
-* `destination_port` - (Optional) The destination port on which the firewall
-    rule operates. Changing this updates the `destination_port` of an existing
-    firewall rule.
+* `destination_port` - (Optional, String) The destination port on which the firewall
+  rule operates. Changing this updates the `destination_port` of an existing
+  firewall rule.
 
-* `enabled` - (Optional) Enabled status for the firewall rule (must be "true"
-    or "false" if provided - defaults to "true"). Changing this updates the
-    `enabled` status of an existing firewall rule.
+* `enabled` - (Optional, Bool) Enabled status for the firewall rule (must be "true"
+  or "false" if provided - defaults to "true"). Changing this updates the
+  `enabled` status of an existing firewall rule.
 
-* `tenant_id` - (Optional) The owner of the firewall rule. Required if admin
-    wants to create a firewall rule for another tenant. Changing this creates a
-    new firewall rule.
+## Attribute Reference
 
-* `value_specs` - (Optional) Map of additional options.
+In addition to all arguments above, the following attributes are exported:
 
-## Attributes Reference
-
-The following attributes are exported:
-
-* `region` - See Argument Reference above.
-* `name` - See Argument Reference above.
-* `description` - See Argument Reference above.
-* `protocol` - See Argument Reference above.
-* `action` - See Argument Reference above.
-* `ip_version` - See Argument Reference above.
-* `source_ip_address` - See Argument Reference above.
-* `destination_ip_address` - See Argument Reference above.
-* `source_port` - See Argument Reference above.
-* `destination_port` - See Argument Reference above.
-* `enabled` - See Argument Reference above.
-* `tenant_id` - See Argument Reference above.
+* `id` - The ID of the rule.
 
 ## Import
 

--- a/docs/resources/network_acl.md
+++ b/docs/resources/network_acl.md
@@ -45,24 +45,36 @@ resource "flexibleengine_network_acl" "fw_acl" {
 
 The following arguments are supported:
 
-* `name` - (Required) Specifies the network ACL name. This parameter can contain a maximum of 64 characters,
-    which may consist of letters, digits, underscores (_), and hyphens (-).
+* `name` - (Required, String) Specifies the network ACL name. This parameter can contain a maximum of 64 characters,
+  which may consist of letters, digits, underscores (_), and hyphens (-).
 
-* `description` - (Optional) Specifies the supplementary information about the network ACL.
-    This parameter can contain a maximum of 255 characters and cannot contain angle brackets (< or >).
+* `description` - (Optional, String) Specifies the supplementary information about the network ACL.
+  This parameter can contain a maximum of 255 characters and cannot contain angle brackets (< or >).
 
-* `inbound_rules` - (Optional)  A list of the IDs of ingress rules associated with the network ACL.
+* `inbound_rules` - (Optional, List)  A list of the IDs of ingress rules associated with the network ACL.
 
-* `outbound_rules` - (Optional) A list of the IDs of egress rules associated with the network ACL.
+* `outbound_rules` - (Optional, List) A list of the IDs of egress rules associated with the network ACL.
 
-* `subnets` - (Optional) A list of the IDs of networks associated with the network ACL.
+* `subnets` - (Optional, List) A list of the IDs of networks associated with the network ACL.
 
-## Attributes Reference
+## Attribute Reference
 
-All of the argument attributes are also exported as result attributes:
+In addition to part of arguments above, the following attributes are exported:
 
 * `id` - The ID of the network ACL.
+
 * `inbound_policy_id` - The ID of the ingress firewall policy for the network ACL.
+
 * `outbound_policy_id` - The ID of the egress firewall policy for the network ACL.
+
 * `ports` - A list of the port IDs of the subnet gateway.
+
 * `status` - The status of the network ACL.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 10 minutes.
+* `update` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.

--- a/docs/resources/network_acl_rule.md
+++ b/docs/resources/network_acl_rule.md
@@ -26,47 +26,38 @@ resource "flexibleengine_network_acl_rule" "rule_1" {
 
 The following arguments are supported:
 
-* `name` - (Optional) Specifies a unique name for the network ACL rule.
+* `name` - (Optional, String) Specifies a unique name for the network ACL rule.
 
-* `description` - (Optional) Specifies the description for the network ACL rule.
+* `description` - (Optional, String) Specifies the description for the network ACL rule.
 
-* `protocol` - (Required) Specifies the protocol supported by the network ACL rule.
-     Valid values are: *tcp*, *udp*, *icmp* and *any*.
+* `protocol` - (Required, String) Specifies the protocol supported by the network ACL rule.
+   Valid values are: *tcp*, *udp*, *icmp* and *any*.
 
-* `action` - (Required) Specifies the action in the network ACL rule. Currently, the value can be *allow* or *deny*.
+* `action` - (Required, String) Specifies the action in the network ACL rule. Currently, the value can be *allow* or *deny*.
 
-* `ip_version` - (Optional) Specifies the IP version, either 4 (default) or 6. This parameter is
-    available after the IPv6 function is enabled.
+* `ip_version` - (Optional, Int) Specifies the IP version, either 4 (default) or 6. This parameter is
+  available after the IPv6 function is enabled.
 
-* `source_ip_address` - (Optional) Specifies the source IP address that the traffic is allowed from.
-    The default value is *0.0.0.0/0*. For example: xxx.xxx.xxx.xxx (IP address), xxx.xxx.xxx.0/24 (CIDR block).
+* `source_ip_address` - (Optional, String) Specifies the source IP address that the traffic is allowed from.
+  The default value is *0.0.0.0/0*. For example: xxx.xxx.xxx.xxx (IP address), xxx.xxx.xxx.0/24 (CIDR block).
 
-* `destination_ip_address` - (Optional) Specifies the destination IP address to which the traffic is allowed.
-    The default value is *0.0.0.0/0*. For example: xxx.xxx.xxx.xxx (IP address), xxx.xxx.xxx.0/24 (CIDR block).
+* `destination_ip_address` - (Optional, String) Specifies the destination IP address to which the traffic is allowed.
+  The default value is *0.0.0.0/0*. For example: xxx.xxx.xxx.xxx (IP address), xxx.xxx.xxx.0/24 (CIDR block).
 
-* `source_port` - (Optional) Specifies the source port number or port number range. The value ranges from 1 to 65535.
-    For a port number range, enter two port numbers connected by a hyphen (-). For example, 1-100.
+* `source_port` - (Optional, String) Specifies the source port number or port number range. The value ranges from 1 to
+  65535. For a port number range, enter two port numbers connected by a hyphen (-). For example, 1-100.
 
-* `destination_port` - (Optional) Specifies the destination port number or port number range.
-    The value ranges from 1 to 65535. For a port number range, enter two port numbers connected by a hyphen (-).
-    For example, 1-100.
+* `destination_port` - (Optional, String) Specifies the destination port number or port number range.
+  The value ranges from 1 to 65535. For a port number range, enter two port numbers connected by a hyphen (-).
+  For example, 1-100.
 
-* `enabled` - (Optional) Enabled status for the network ACL rule. Defaults to true.
+* `enabled` - (Optional, Bool) Enabled status for the network ACL rule. Defaults to true.
 
-## Attributes Reference
+## Attribute Reference
 
-The following attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
-* `name` - See Argument Reference above.
-* `description` - See Argument Reference above.
-* `protocol` - See Argument Reference above.
-* `action` - See Argument Reference above.
-* `ip_version` - See Argument Reference above.
-* `source_ip_address` - See Argument Reference above.
-* `destination_ip_address` - See Argument Reference above.
-* `source_port` - See Argument Reference above.
-* `destination_port` - See Argument Reference above.
-* `enabled` - See Argument Reference above.
+* `id` - The ID of the acl rule.
 
 ## Import
 

--- a/flexibleengine/resource_flexibleengine_fw_firewall_group_v2.go
+++ b/flexibleengine/resource_flexibleengine_fw_firewall_group_v2.go
@@ -51,17 +51,6 @@ func resourceFWFirewallGroupV2() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"admin_state_up": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
-			},
-			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
-			},
 			"ports": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -69,10 +58,24 @@ func resourceFWFirewallGroupV2() *schema.Resource {
 				Set:      schema.HashString,
 				Computed: true,
 			},
+			"admin_state_up": {
+				Type:       schema.TypeBool,
+				Optional:   true,
+				Default:    true,
+				Deprecated: "admin_state_up is deprecated",
+			},
+			"tenant_id": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "tenant_id is deprecated",
+			},
 			"value_specs": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				ForceNew: true,
+				Type:       schema.TypeMap,
+				Optional:   true,
+				ForceNew:   true,
+				Deprecated: "value_specs is deprecated",
 			},
 		},
 	}

--- a/flexibleengine/resource_flexibleengine_fw_policy_v2.go
+++ b/flexibleengine/resource_flexibleengine_fw_policy_v2.go
@@ -49,21 +49,23 @@ func resourceFWPolicyV2() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
-			},
 			"rules": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"tenant_id": {
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "tenant_id is deprecated",
+			},
 			"value_specs": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				ForceNew: true,
+				Type:       schema.TypeMap,
+				Optional:   true,
+				ForceNew:   true,
+				Deprecated: "value_specs is deprecated",
 			},
 		},
 	}

--- a/flexibleengine/resource_flexibleengine_fw_rule_v2.go
+++ b/flexibleengine/resource_flexibleengine_fw_rule_v2.go
@@ -70,14 +70,16 @@ func resourceFWRuleV2() *schema.Resource {
 				Default:  true,
 			},
 			"tenant_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Deprecated: "tenant_id is deprecated",
 			},
 			"value_specs": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				ForceNew: true,
+				Type:       schema.TypeMap,
+				Optional:   true,
+				ForceNew:   true,
+				Deprecated: "value_specs is deprecated",
 			},
 		},
 	}


### PR DESCRIPTION
`tenant_id,` `admin_state_up`, `value_specs` are deprecated