### PR TITLE
feat(RDS): import RDS resource, unit test and document.

### DIFF
--- a/docs/data-sources/rds_backups.md
+++ b/docs/data-sources/rds_backups.md
@@ -1,0 +1,96 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# flexibleengine_rds_backups
+
+Use this data source to get the list of RDS backups.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "flexibleengine_rds_backups" "test" {
+  instance_id = var.instance_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `instance_id` - (Required, String) Specifies the DB instance ID.
+
+* `name` - (Optional, String) Specifies the backup name.
+
+* `backup_id` - (Optional, String) Specifies the backup ID.
+
+* `backup_type` - (Optional, String) Specifies the backup type. The options are as follows:
+  - **auto**: Automated full backup.
+  - **manual**: Manual full backup.
+  - **fragment**: Differential full backup.
+  - **incremental**: Automated incremental backup.
+
+* `begin_time` - (Optional, String) Specifies the start time for obtaining the backup list.
+  The format of the start time is "yyyy-mm-ddThh:mm:ssZ".
+
+* `end_time` - (Optional, String) Specifies the end time for obtaining the backup list.
+  The format of the end time is "yyyy-mm-ddThh:mm:ssZ" and the end time must be later than the start time.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `backups` - Backup list. For details, see Data structure of the Backup field.
+  The [backups](#rds_backups) structure is documented below.
+
+<a name="rds_backups"></a>
+The `backups` block supports:
+
+* `id` - Backup ID.
+
+* `instance_id` - RDS instance ID.
+
+* `name` - Backup name.
+
+* `type` - Backup type. The options are as follows:
+  - **auto**: Automated full backup.
+  - **manual**: Manual full backup.
+  - **fragment**: Differential full backup.
+  - **incremental**: Automated incremental backup.
+
+* `size` - Backup size in KB.
+
+* `status` - Backup status. The options are as follows:
+  - **BUILDING**: Backup in progress.
+  - **COMPLETED**: Backup completed.
+  - **FAILED**: Backup failed.
+  - **DELETING**: Backup being deleted.
+
+* `begin_time` - Backup start time in the "yyyy-mm-ddThh:mm:ssZ" format.
+
+* `end_time` - Backup end time in the "yyyy-mm-ddThh:mm:ssZ" format.
+
+* `associated_with_ddm` - Whether a DDM instance has been associated.
+
+* `datastore` - The database information. The [datastore](#rds_datastore) structure is documented below.
+
+* `databases` - Database been backed up. The [databases](#rds_databases) structure is documented below.
+
+<a name="rds_datastore"></a>
+The `datastore` block supports:
+
+* `type` - DB engine. The value can be: **MySQL**, **PostgreSQL**, **SQL Server**, **MariaDB**.
+
+* `version` - DB engine version.
+
+<a name="rds_databases"></a>
+The `rds_databases` block supports:
+
+* `name` - Database to be backed up for Microsoft SQL Server.

--- a/docs/data-sources/rds_engine_versions.md
+++ b/docs/data-sources/rds_engine_versions.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# flexibleengine_rds_engine_versions
+
+Use this data source to obtain all version information of the specified engine type of FlexibleEngine.
+
+## Example Usage
+
+```hcl
+data "flexibleengine_rds_engine_versions" "test" {
+  type = "SQLServer"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which to obtain the RDS engine versions.
+  If omitted, the provider-level region will be used.
+
+* `type` - (Optional, String) Specifies the RDS engine type.
+  The valid values are **MySQL**, **PostgreSQL**, **SQLServer** and **MariaDB**, default to **MySQL**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - Data source ID in hashcode format.
+
+* `versions` - Indicates the list of database versions. The [versions](#rds_versions) object structure is
+  documented below.
+
+<a name="rds_versions"></a>
+The `versions` block supports:
+
+* `id` - Indicates the database version ID. Its value is unique.
+
+* `name` - Indicates the database version number. Only the major version number (two digits) is returned.
+  For example, if the version number is MySQL 5.6.X, only 5.6 is returned.

--- a/docs/data-sources/rds_flavors_v3.md
+++ b/docs/data-sources/rds_flavors_v3.md
@@ -22,7 +22,7 @@ data "flexibleengine_rds_flavors_v3" "flavor" {
 * `region` - (Optional, String) The region in which to query the data source. If omitted, the provider-level region
   will be used.
 
-* `db_type` - (Required, String) Specifies the DB engine. Value: **MySQL**, **PostgreSQL**, **MariaDB**.
+* `db_type` - (Required, String) Specifies the DB engine. Value: **MySQL**, **PostgreSQL**, **SQLServer** and **MariaDB**.
 
 * `db_version` - (Required, String) Specifies the database version. The supported versions of each database
   are as follows:

--- a/docs/data-sources/rds_flavors_v3.md
+++ b/docs/data-sources/rds_flavors_v3.md
@@ -22,11 +22,15 @@ data "flexibleengine_rds_flavors_v3" "flavor" {
 * `region` - (Optional, String) The region in which to query the data source. If omitted, the provider-level region
   will be used.
 
-* `db_type` - (Required, String) Specifies the DB engine. Value: MySQL, PostgreSQL, SQLServer.
+* `db_type` - (Required, String) Specifies the DB engine. Value: **MySQL**, **PostgreSQL**, **MariaDB**.
 
-* `db_version` - (Required, String) Specifies the database version. MySQL databases support MySQL 5.6
-  and 5.7. PostgreSQL databases support PostgreSQL 9.5 and 9.6. Microsoft SQL Server databases support
-  2014_SE, 2016_SE, and 2016_EE.
+* `db_version` - (Required, String) Specifies the database version. The supported versions of each database
+  are as follows:
+  - **MySQL**: MySQL databases support **5.6**, **5.7** and **8.0**.
+  - **PostgreSQL**: PostgreSQL databases support **9.5**, **9.6**, **10**, **11**, **12**, **13**, **14** and
+    **1.0 (Enhanced Edition)**.
+  - **SQLServer**: Microsoft SQL Server databases support **2014_SE**, **2016_SE** and **2016_EE**.
+  - **MariaDB**: MariaDB databases support **10.5**.
 
 * `instance_mode` - (Optional, String) The mode of instance. Value: *ha*(indicates primary/standby instance),
   *single*(indicates single instance) and *replica*(indicates read replicas).
@@ -36,12 +40,12 @@ data "flexibleengine_rds_flavors_v3" "flavor" {
 * `memory` - (Optional, Int) Specifies the memory size(GB) in the RDS flavor.
 
 * `group_type` - (Optional, String) Specifies the performance specification, the valid values are as follows:
-  + **normal**: General enhanced.
-  + **normal2**: General enhanced type II.
-  + **dedicatedNormal**: (dedicatedNormalLocalssd): Dedicated for x86.
-  + **normalLocalssd**: x86 general type.
-  + **general**: General type.
-  + **bigmem**: Large memory type.
+  - **normal**: General enhanced.
+  - **normal2**: General enhanced type II.
+  - **dedicatedNormal**: (dedicatedNormalLocalssd): Dedicated for x86.
+  - **normalLocalssd**: x86 general type.
+  - **general**: General type.
+  - **bigmem**: Large memory type.
 
 * `availability_zone` - (Optional, String) Specifies the availability zone which the RDS flavor belongs to.
 

--- a/docs/data-sources/rds_instances.md
+++ b/docs/data-sources/rds_instances.md
@@ -1,0 +1,132 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# flexibleengine_rds_instances
+
+Use this data source to list all available RDS instances.
+
+## Example Usage
+
+```hcl
+data "flexibleengine_rds_instances" "test" {
+  name = "rds-instance"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional, String) The region in which query obtain the instances. If omitted, the provider-level region
+  will be used.
+
+* `name` - (Optional, String) Specifies the name of the instance.
+
+* `type` - (Optional, String) Specifies the type of the instance. Valid values are:
+  **Single**, **Ha**, **Replica**, and **Enterprise**.
+
+* `datastore_type` - (Optional, String) Specifies the type of the database. Valid values are:
+  **MySQL**, **PostgreSQL**, **SQLServer** and **MariaDB**.
+
+* `vpc_id` - (Optional, String) Specifies the VPC ID.
+
+* `subnet_id` - (Optional, String) Specifies the network ID of a subnet.
+
+* `enterprise_project_id` - (Optional, String) Specifies the enterprise project id.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The ID of the data source.
+
+* `instances` - An array of available instances. The [instances](#rds_instances) object structure is documented below.
+
+<a name="rds_instances"></a>
+The `instances` block supports:
+
+* `region` - The region of the instance.
+
+* `name` - Indicates the name of the instance.
+
+* `availability_zone` - Indicates the availability zone name.
+
+* `flavor` - Indicates the instance specifications.
+
+* `vpc_id` - Indicates the VPC ID.
+
+* `subnet_id` - Indicates the network ID of a subnet.
+
+* `id` - Indicates the ID of the instance.
+
+* `security_group_id` - Indicates the security group ID.
+
+* `param_group_id` - Indicates the configuration ID.
+
+* `enterprise_project_id` - Indicates the enterprise project id.
+
+* `fixed_ip` - Indicates the intranet floating IP address of the instance.
+
+* `ssl_enable` - Indicates whether to enable SSL.
+
+* `tags` - Indicates the tags of the instance.
+
+* `ha_replication_mode` - Indicates the replication mode for the standby DB instance.
+
+* `time_zone` - Indicates the time zone.
+
+* `private_ips` - Indicates the private ips in list.
+
+* `public_ips` - Indicates the public ips in list.
+
+* `status` - Indicates the DB instance status.
+
+* `created` - Indicates the creation time.
+
+* `db` - Indicates the database information. The [db](#rds_db) object structure is documented below.
+
+* `volume` - Indicates the volume information. The [volume](#rds_volume) object structure is documented below.
+
+* `backup_strategy` - Indicates the advanced backup policy. The [backup_strategy](#rds_backup_strategy) object structure
+  is documented below.
+
+* `nodes` - Indicates the instance nodes information. The [nodes](#rds_nodes) object structure is documented below.
+
+<a name="rds_db"></a>
+The `db` block supports:
+
+* `type` - Indicates the database engine.
+
+* `version` - Indicates the database version.
+
+* `port` - Indicates the database port.
+
+* `user_name` - Indicates the database username.
+
+<a name="rds_volume"></a>
+The `volume` block supports:
+
+* `size` - Indicates the volume size.
+
+* `type` - Indicates the volume type.
+
+* `disk_encryption_id` - Indicates the kms key id.
+
+<a name="rds_backup_strategy"></a>
+The `backup_strategy` block supports:
+
+* `start_time` - Indicates the backup time window.
+
+* `keep_days` - Indicates the number of days to retain the generated.
+
+<a name="rds_nodes"></a>
+The `nodes` block supports:
+
+* `id` - Indicates the node ID.
+
+* `name` - Indicates the node name.
+
+* `status` - Indicates the node status.
+
+* `role` - Indicates the node type.
+
+* `availability_zone` - Indicates the availability zone where the node resides.

--- a/docs/data-sources/rds_storage_types.md
+++ b/docs/data-sources/rds_storage_types.md
@@ -1,0 +1,70 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# flexibleengine_rds_storage_types
+
+Use this data source to get the list of RDS storage types.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+data "flexibleengine_rds_storage_types" "test" {
+  db_type    = "MySQL"
+  db_version = "8.0"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String) Specifies the region in which to query the data source.
+  If omitted, the provider-level region will be used.
+
+* `db_type` - (Required, String) Specifies the DB engine type. Its value can be any of the following and
+  is case-insensitive: **MySQL**, **PostgreSQL**, **SQLServer** and **MariaDB**.
+
+* `db_version` - (Required, String) Specifies the database version. For details about how to obtain the database
+  version, see section [Querying Version Information About a DB Engine](https://docs.prod-cloud-ocb.orange-business.com/en-us/api/rds/rds_06_0001.html).
+
+* `instance_mode` - (Optional, String) Specifies the HA mode. The value options are as
+  follows: **single**, **ha**, **replica**.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `storage_types` - Indicates the DB instance specifications information list. For details, see Data structure of
+  the storage_type field. The [storage_types](#Storagetype_storageType) structure is documented below.
+
+<a name="Storagetype_storageType"></a>
+The `storage_types` block supports:
+
+* `name` - Indicates the storage type. Its value can be any of the following:
+  - **COMMON**: Indicates the SATA type.
+  - **ULTRAHIGH**: Indicates the SSD type.
+
+* `az_status` - The status details of the AZs to which the specification belongs.
+  Key indicates the AZ ID, and value indicates the specification status in the AZ.
+  The options of value are as follows:
+    - **normal**: The specifications in the AZ are available.
+    - **unsupported**: The specifications are not supported by the AZ.
+    - **sellout**: The specifications in the AZ are sold out.
+
+* `support_compute_group_type` - Performance specifications.
+  The options are as follows:
+    - **normal**: General-enhanced.
+    - **normal2**: General-enhanced II.
+    - **armFlavors**: Kunpeng general-enhanced.
+    - **dedicicatenormal**: Exclusive x86.
+    - **armlocalssd**: Standard Kunpeng.
+    - **normallocalssd**: Standard x86.
+    - **general**: General-purpose.
+    - **dedicated**: Dedicated, which is only supported for cloud SSDs.
+    - **rapid**: Dedicated, which is only supported for extreme SSDs.
+    - **bigmen**: Large-memory.

--- a/docs/resources/rds_backup.md
+++ b/docs/resources/rds_backup.md
@@ -1,0 +1,83 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# flexibleengine_rds_backup
+
+Manages a RDS manual backup resource within FlexibleEngine.  
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "backup_name" {}
+
+resource "flexibleengine_rds_backup" "test" {
+  instance_id = var.instance_id
+  name        = var.backup_name
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `name` - (Required, String, ForceNew) Specifies the name of the resource backup.
+  The valid length is limited from can contain 4 to 64 characters long, start with a letter, and contain only
+  letters (case-sensitive),digits, hyphens (-), and underscores (_).
+  Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the instance id.
+  Changing this parameter will create a new resource.
+
+* `description` - (Optional, String, ForceNew) The description about the backup.  
+  It contains a maximum of 256 characters and cannot contain the following special characters: **> ! < " & ' =**.
+  Changing this parameter will create a new resource.
+
+* `databases` - (Optional, List, ForceNew) List of self-built Microsoft SQL Server databases that are partially
+  backed up. (Only Microsoft SQL Server supports partial backups). The [databases](#rds_databases) structure is
+  documented below. Changing this parameter will create a new resource.
+
+<a name="rds_databases"></a>
+The `databases` block supports:
+
+* `name` - (Required, String, ForceNew) Database to be backed up for Microsoft SQL Server.
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+* `begin_time` - Backup start time in the "yyyy-mm-ddThh:mm:ssZ" format.
+
+* `end_time` - Backup end time in the "yyyy-mm-ddThh:mm:ssZ" format.
+
+* `status` - Backup status. The options are as follows:
+  + **BUILDING**: Backup in progress.
+  + **COMPLETED**: Backup completed.
+  + **FAILED**: Backup failed.
+  + **DELETING**: Backup being deleted.
+
+* `size` - Backup size in KB.
+
+* `associated_with_ddm` - Whether a DDM instance has been associated.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.
+
+## Import
+
+The rds manual backup can be imported using the instance ID and the backup ID separated by a slash, e.g.:
+
+```shell
+terraform import flexibleengine_rds_backup.test 1ce123456a00f2591fabc00385ff1235/0ce123456a00f2591fabc00385ff1234
+```

--- a/docs/resources/rds_cross_region_backup_strategy.md
+++ b/docs/resources/rds_cross_region_backup_strategy.md
@@ -1,0 +1,74 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# flexibleengine_rds_cross_region_backup_strategy
+
+Manages RDS cross-region backup strategy resource within FlexibleEngine.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+variable "destination_region" {}
+variable "destination_project_id" {}
+
+resource "flexibleengine_rds_cross_region_backup_strategy" "test" {
+  instance_id            = var.instance_id
+  backup_type            = "all"
+  keep_days              = 5
+  destination_region     = var.destination_region
+  destination_project_id = var.destination_project_id
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the RDS instance.
+
+  Changing this parameter will create a new resource.
+
+* `backup_type` - (Required, String) Specifies the backup type. Value options:
+    + **auto**: open automated full backup.
+    + **all**: open both automated full backup and automated incremental backup.
+
+  Only **all** is supported for SQL server.
+
+* `keep_days` - (Required, Int) Specifies the number of days to retain the generated backup files.
+  Value ranges from `1` to `1825`.
+
+* `destination_region` - (Required, String, ForceNew) Specifies the target region ID for the cross-region backup policy.
+
+  Changing this parameter will create a new resource.
+
+* `destination_project_id` - (Required, String, ForceNew) Specifies the target project ID for the cross-region backup
+  policy.
+
+  Changing this parameter will create a new resource.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+* `update` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.
+
+## Import
+
+The RDS cross-region backup strategy can be imported using the `id`, e.g.
+
+```shell
+terraform import flexibleengine_rds_cross_region_backup_strategy.test <id>
+```

--- a/docs/resources/rds_instance_v3.md
+++ b/docs/resources/rds_instance_v3.md
@@ -349,10 +349,10 @@ But due to some attributes missing from the API response, it's required to ignor
 resource "flexibleengine_rds_instance_v3" "instance_1" {
   ...
 
-lifecycle {
-  ignore_changes = [
-    "db",
-  ]
-}
+  lifecycle {
+    ignore_changes = [
+      "db",
+    ]
+  }
 }
 ```

--- a/docs/resources/rds_instance_v3.md
+++ b/docs/resources/rds_instance_v3.md
@@ -183,7 +183,8 @@ The following arguments are supported:
 * `volume` - (Required, List) Specifies the volume information. The [volume](#rds_volume) object structure is
   documented below.
 
-* `fixed_ip` - (Optional, String) Specifies an intranet IP address of RDS DB instance.
+* `fixed_ip` - (Optional, String, ForceNew) Specifies an intranet IP address of RDS DB instance.
+  Changing this parameter will create a new resource.
 
 * `backup_strategy` - (Optional, List) Specifies the advanced backup policy. The [backup_strategy](#rds_backup_strategy)
   object structure is documented below.
@@ -192,7 +193,8 @@ The following arguments are supported:
   Changing this parameter will create a new resource.
   + For MySQL, the value is *async* or *semisync*.
   + For PostgreSQL, the value is *async* or *sync*.
-  + For Microsoft SQL Server, the value is *sync*.
+  + For SQLServer, the value is *sync*.
+  + For MariaDB, the value is *async* or *semisync*.
 
   -> **NOTE:** async indicates the asynchronous replication mode. semisync indicates the semi-synchronous replication
   mode. sync indicates the synchronous replication mode.
@@ -202,8 +204,12 @@ The following arguments are supported:
 
 * `time_zone` - (Optional, String, ForceNew) Specifies the UTC time zone. The value ranges from
   UTC-12:00 to UTC+12:00 at the full hour, and defaults to *UTC*.
+  Changing this parameter will create a new resource.
 
 * `ssl_enable` - (Optional, Bool) Specifies whether to enable the SSL for **MySQL** database.
+
+* `description` - (Optional, String) Specifies the description of the instance. The value consists of 0 to 64
+  characters, including letters, digits, periods (.), underscores (_), and hyphens (-).
 
 * `tags` - (Optional, Map) A mapping of tags to assign to the RDS instance.
   Each tag is represented by one key-value pair.
@@ -216,25 +222,33 @@ The following arguments are supported:
 The `db` block supports:
 
 * `type` - (Required, String, ForceNew) Specifies the DB engine. Available value are *MySQL*, *PostgreSQL* and
-  *SQLServer*. Changing this parameter will create a new resource.
+  *MariaDB*. Changing this parameter will create a new resource.
 
-* `version` - (Required, String, ForceNew) Specifies the database version. MySQL databases support MySQL 5.6
-  and 5.7, example values: "5.6", "5.7". PostgreSQL databases support
-  PostgreSQL 9.5, 9.6, 10 and 11, example values: "9.5", "9.6", "10", "11". Microsoft SQL Server
-  databases support 2014 SE and 2014 EE, example values: "2014_SE", "2014_EE".
+* `version` - (Required, String, ForceNew) Specifies the database version. The supported versions of each database
+  are as follows:
+  + **MySQL**: MySQL databases support **5.6**, **5.7** and **8.0**.
+  + **PostgreSQL**: PostgreSQL databases support **9.5**, **9.6**, **10**, **11**, **12**, **13**, **14** and
+    **1.0 (Enhanced Edition)**.
+  + **SQLServer**: SQLServer databases support **2014 SE** and **2014 EE**.
+  + **MariaDB**: MariaDB databases support **10.5**.
+
   Changing this parameter will create a new resource.
 
-* `password` - (Required, String) Specifies the database password. The value cannot be
-  empty and should contain 8 to 32 characters, including uppercase and lowercase letters, digits, and the following
-  special characters: ~!@#%^*-_=+? You are advised to enter a strong password to improve security, preventing security
-  risks such as brute force cracking.
+* `password` - (Required, String, ForceNew) Specifies the database password. The value cannot be
+  empty and should contain 8 to 32 characters, including uppercase
+  and lowercase letters, digits, and the following special
+  characters: ~!@#%^*-_=+? You are advised to enter a strong
+  password to improve security, preventing security risks such as
+  brute force cracking. Changing this parameter will create a new resource.
 
 * `port` - (Optional, Int) Specifies the database port.
   + The MySQL database port ranges from 1024 to 65535 (excluding 12017 and 33071, which are occupied by the RDS system
-      and cannot be used). The default value is 3306.
+    and cannot be used). The default value is 3306.
   + The PostgreSQL database port ranges from 2100 to 9500. The default value is 5432.
   + The Microsoft SQL Server database port can be 1433 or ranges from 2100 to 9500, excluding 5355 and 5985.
     The default value is 1433.
+  + The MariaDB database port ranges from 1024 to 65535 (excluding 12017 and 33071, which are occupied by the RDS system
+    and cannot be used). The default value is 3306.
 
 <a name="rds_volume"></a>
 The `volume` block supports:
@@ -246,6 +260,8 @@ The `volume` block supports:
   and is case-sensitive:
   + *COMMON*: indicates the SATA type.
   + *ULTRAHIGH*: indicates the SSD type.
+  + *CLOUDSSD*: cloud SSD storage. This storage type is supported only with general-purpose and dedicated DB
+    instances.
 
   Changing this parameter will create a new resource.
 
@@ -262,9 +278,9 @@ The `backup_strategy` block supports:
   policy.
 
 * `start_time` - (Required, String) Specifies the backup time window. Automated backups will be triggered during the
-  backup time window. It must be a valid value in the **hh:mm-HH:MM** format. The current time is in the UTC format.
-  The HH value must be 1 greater than the hh value. The values of mm and MM must be the same and must be set to any
-  of the following: 00, 15, 30, or 45. Example value: 08:15-09:15 23:00-00:00.
+  backup time window. It must be a valid value in the **hh:mm-HH:MM** format.
+  The current time is in the UTC format. The HH value must be 1 greater than the hh value. The values of mm and MM must
+  be the same and must be set to any of the following: 00, 15, 30, or 45. Example value: 08:15-09:15 23:00-00:00.
 
 <a name="rds_parameters"></a>
 The `parameters` block supports:
@@ -276,7 +292,7 @@ The `parameters` block supports:
 
 ## Attribute Reference
 
-In addition to the arguments listed above, the following computed attributes are exported:
+In addition to all arguments above, the following attributes are exported:
 
 * `id` - The resource ID in UUID format.
 
@@ -284,7 +300,7 @@ In addition to the arguments listed above, the following computed attributes are
 
 * `created` - Indicates the creation time.
 
-* `nodes` - Indicates the instance nodes information. The [nodes](#rds_attr_nodes) object structure is documented below.
+* `nodes` - Indicates the instance nodes information. The [nodes](#rds_nodes) object structure is documented below.
 
 * `private_ips` - Indicates the private IP address list.
   It is a blank string until an ECS is created.
@@ -293,7 +309,7 @@ In addition to the arguments listed above, the following computed attributes are
 
 * `db` - See Argument Reference above. The [db](#rds_attr_db) object structure is documented below.
 
-<a name="rds_attr_nodes"></a>
+<a name="rds_nodes"></a>
 The `nodes` block supports:
 
 * `availability_zone` - Indicates the AZ.
@@ -318,7 +334,6 @@ This resource provides the following timeouts configuration options:
 
 * `create` - Default is 30 minutes.
 * `update` - Default is 30 minutes.
-* `delete` - Default is 30 minutes.
 
 ## Import
 
@@ -334,10 +349,10 @@ But due to some attributes missing from the API response, it's required to ignor
 resource "flexibleengine_rds_instance_v3" "instance_1" {
   ...
 
-  lifecycle {
-    ignore_changes = [
-      "db",
-    ]
-  }
+lifecycle {
+  ignore_changes = [
+    "db",
+  ]
+}
 }
 ```

--- a/docs/resources/rds_parametergroup_v3.md
+++ b/docs/resources/rds_parametergroup_v3.md
@@ -47,13 +47,13 @@ The following arguments are supported:
 The `datastore` block supports:
 
 * `type` - (Required, String) The DB engine. Currently, MySQL, PostgreSQL, and Microsoft SQL Server are supported.
-  The value is case-insensitive and can be mysql, postgresql, or sqlserver.
+  The value is case-insensitive and can be **mysql**, **postgresql**, **sqlserver**or **mariadb**.
 
 * `version` - (Required, String) Specifies the database version.
 
   + MySQL databases support MySQL 5.6 and 5.7. Example value: 5.7.
   + PostgreSQL databases support PostgreSQL 9.5 and 9.6. Example value: 9.5.
-  + Microsoft SQL Server databases support 2014 SE, 2016 SE, and 2016 EE. Example value: 2014_SE.
+  + MariaDB databases support MariaDB 10.5. Example value: 10.5.
 
 ## Attribute Reference
 

--- a/docs/resources/rds_read_replica_v3.md
+++ b/docs/resources/rds_read_replica_v3.md
@@ -134,7 +134,7 @@ The `db` block supports:
 
 * `port` - Indicates the database port information.
 
-* `type` - Indicates the DB engine. Value: MySQL, PostgreSQL, SQLServer.
+* `type` - Indicates the DB engine. Value: **MySQL**, **PostgreSQL**, **SQLServer**, **MariaDB**.
 
 * `user_name` - Indicates the default username of database.
 

--- a/docs/resources/rds_sql_audit.md
+++ b/docs/resources/rds_sql_audit.md
@@ -1,0 +1,57 @@
+---
+subcategory: "Relational Database Service (RDS)"
+---
+
+# flexibleengine_rds_sql_audit
+
+Manages RDS SQL audit resource within FlexibleEngine.
+
+-> **NOTE:** Only MySQL and PostgreSQL engines are supported.
+
+## Example Usage
+
+```hcl
+variable "instance_id" {}
+
+resource "flexibleengine_rds_sql_audit" "test" {
+  instance_id = var.instance_id
+  keep_days   = 5
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Optional, String, ForceNew) Specifies the region in which to create the resource.
+  If omitted, the provider-level region will be used. Changing this parameter will create a new resource.
+
+* `instance_id` - (Required, String, ForceNew) Specifies the ID of the RDS instance.
+  Changing this parameter will create a new resource.
+
+* `keep_days` - (Required, Int) Specifies the number of days for storing audit logs. Value ranges from `1` to `732`.
+
+* `reserve_auditlogs` - (Optional, Bool) Specifies whether the historical audit logs will be reserved for some time
+  when SQL audit is disabled. It is valid only when SQL audit is disabled.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - The resource ID.
+
+## Timeouts
+
+This resource provides the following timeouts configuration options:
+
+* `create` - Default is 30 minutes.
+* `update` - Default is 30 minutes.
+* `delete` - Default is 30 minutes.
+
+## Import
+
+The RDS SQL audit can be imported using the `id`, e.g.
+
+```shell
+terraform import flexibleengine_rds_sql_audit.test <id>
+```

--- a/flexibleengine/acceptance/data_source_flexibleengine_rds_backups_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_rds_backups_test.go
@@ -1,0 +1,205 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceBackup_basic(t *testing.T) {
+	rName := "data.flexibleengine_rds_backups.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+	name := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceBackup_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "backups.0.id", "flexibleengine_rds_backup.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "backups.0.name", "flexibleengine_rds_backup.test", "name"),
+					resource.TestCheckResourceAttrPair(rName, "backups.0.instance_id",
+						"flexibleengine_rds_instance_v3.test", "id"),
+					resource.TestCheckResourceAttr(rName, "backups.0.type", "manual"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.size"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.status"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.begin_time"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.end_time"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.associated_with_ddm"),
+					resource.TestCheckResourceAttr(rName, "backups.0.datastore.#", "1"),
+					resource.TestCheckResourceAttr(rName, "backups.0.databases.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceBackup_auto_basic(t *testing.T) {
+	rName := "data.flexibleengine_rds_backups.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+	name := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceBackup_auto_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "backups.0.id", "flexibleengine_rds_backup.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "backups.0.name", "flexibleengine_rds_backup.test", "name"),
+					resource.TestCheckResourceAttrPair(rName, "backups.0.instance_id",
+						"flexibleengine_rds_instance_v3.test", "id"),
+					resource.TestCheckResourceAttr(rName, "backups.0.type", "auto"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.size"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.status"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.begin_time"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.end_time"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.associated_with_ddm"),
+					resource.TestCheckResourceAttr(rName, "backups.0.datastore.#", "1"),
+					resource.TestCheckResourceAttr(rName, "backups.0.databases.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceBackup_incremental_basic(t *testing.T) {
+	rName := "data.flexibleengine_rds_backups.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+	name := acceptance.RandomAccResourceName()
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceBackup_incremental_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "backups.0.id", "flexibleengine_rds_backup.test", "id"),
+					resource.TestCheckResourceAttrPair(rName, "backups.0.name", "flexibleengine_rds_backup.test", "name"),
+					resource.TestCheckResourceAttrPair(rName, "backups.0.instance_id",
+						"flexibleengine_rds_instance_v3.test", "id"),
+					resource.TestCheckResourceAttr(rName, "backups.0.type", "incremental"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.size"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.status"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.begin_time"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.end_time"),
+					resource.TestCheckResourceAttrSet(rName, "backups.0.associated_with_ddm"),
+					resource.TestCheckResourceAttr(rName, "backups.0.datastore.#", "1"),
+					resource.TestCheckResourceAttr(rName, "backups.0.databases.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceBackup_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_networking_secgroup_v2" "test" {
+  name = "default"
+}
+
+data "flexibleengine_rds_flavors_v3" "test" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  instance_mode = "single"
+}
+
+resource "flexibleengine_rds_instance_v3" "test" {
+  name              = "%[2]s"
+  flavor            = data.flexibleengine_rds_flavors_v3.test.flavors[2].name
+  availability_zone = [data.flexibleengine_availability_zones.test.names[0]]
+  security_group_id = data.flexibleengine_networking_secgroup_v2.test.id
+  subnet_id         = flexibleengine_vpc_subnet_v1.test.id
+  vpc_id            = flexibleengine_vpc_v1.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    password = "FlexibleEngine!120521"
+    type     = "MySQL"
+    version  = "8.0"
+    port     = 8630
+  }
+
+  volume {
+    type = "COMMON"
+    size = 60
+  }
+
+  backup_strategy {
+    start_time = "08:00-09:00"
+    keep_days  = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      backup_strategy,
+    ]
+  }
+}
+
+resource "flexibleengine_rds_backup" "test" {
+  name        = "%[2]s"
+  instance_id = flexibleengine_rds_instance_v3.test.id
+}
+
+`, testVpc(name), name)
+}
+
+func testAccDatasourceBackup_basic(name string) string {
+	return fmt.Sprintf(`
+%s 
+
+data "flexibleengine_rds_backups" "test" {
+  instance_id = flexibleengine_rds_instance_v3.test.id
+  backup_type = "manual"
+
+  depends_on = [
+    flexibleengine_rds_backup.test
+  ]
+}
+`, testAccDatasourceBackup_base(name))
+}
+
+func testAccDatasourceBackup_auto_basic(name string) string {
+	return fmt.Sprintf(`
+%s 
+
+data "flexibleengine_rds_backups" "test" {
+  instance_id = flexibleengine_rds_instance_v3.test.id
+  backup_type = "auto"
+
+  depends_on = [
+    flexibleengine_rds_backup.test
+  ]
+}
+`, testAccDatasourceBackup_base(name))
+}
+
+func testAccDatasourceBackup_incremental_basic(name string) string {
+	return fmt.Sprintf(`
+%s 
+
+data "flexibleengine_rds_backups" "test" {
+  instance_id = flexibleengine_rds_instance_v3.test.id
+  backup_type = "incremental"
+
+  depends_on = [
+    flexibleengine_rds_backup.test
+  ]
+}
+`, testAccDatasourceBackup_base(name))
+}

--- a/flexibleengine/acceptance/data_source_flexibleengine_rds_engine_versions_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_rds_engine_versions_test.go
@@ -1,0 +1,96 @@
+package acceptance
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccRdsEngineVersionsV3DataSource_basic(t *testing.T) {
+	dataSourceName := "data.flexibleengine_rds_engine_versions.test"
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsEngineVersionsV3DataSource_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "type", "MySQL"),
+					resource.TestMatchResourceAttr(dataSourceName, "versions.#", regexp.MustCompile("\\d+")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRdsEngineVersionsV3DataSource_PostgreSQL_basic(t *testing.T) {
+	dataSourceName := "data.flexibleengine_rds_engine_versions.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsEngineVersionsV3DataSource_PostgreSQL_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "type", "PostgreSQL"),
+					resource.TestMatchResourceAttr(dataSourceName, "versions.#", regexp.MustCompile("\\d+")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRdsEngineVersionsV3DataSource_SQLServer_basic(t *testing.T) {
+	dataSourceName := "data.flexibleengine_rds_engine_versions.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsEngineVersionsV3DataSource_SQLServer_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(dataSourceName, "type", "SQLServer"),
+					resource.TestMatchResourceAttr(dataSourceName, "versions.#", regexp.MustCompile("\\d+")),
+				),
+			},
+		},
+	})
+}
+
+func testAccRdsEngineVersionsV3DataSource_basic() string {
+	return fmt.Sprint(`
+data "flexibleengine_rds_engine_versions" "test" {
+  type = "MySQL"
+}
+`)
+}
+
+func testAccRdsEngineVersionsV3DataSource_PostgreSQL_basic() string {
+	return fmt.Sprint(`
+data "flexibleengine_rds_engine_versions" "test" {
+  type = "PostgreSQL"
+}
+`)
+}
+
+func testAccRdsEngineVersionsV3DataSource_SQLServer_basic() string {
+	return fmt.Sprint(`
+data "flexibleengine_rds_engine_versions" "test" {
+  type = "SQLServer"
+}
+`)
+}

--- a/flexibleengine/acceptance/data_source_flexibleengine_rds_instances_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_rds_instances_test.go
@@ -1,0 +1,176 @@
+package acceptance
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccRdsInstanceDataSource_basic(t *testing.T) {
+	dataSourceName := "data.flexibleengine_rds_instances.test"
+	rName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsInstanceDataSource_basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "instances.#", regexp.MustCompile("\\d+")),
+					resource.TestCheckResourceAttrSet(dataSourceName, "instances.0.name"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRdsInstanceDataSource_ha_basic(t *testing.T) {
+	dataSourceName := "data.flexibleengine_rds_instances.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsInstanceDataSource_ha_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "instances.#", regexp.MustCompile("\\d+")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRdsInstanceDataSource_replica_basic(t *testing.T) {
+	dataSourceName := "data.flexibleengine_rds_instances.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsInstanceDataSource_replica_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "instances.#", regexp.MustCompile("\\d+")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRdsInstanceDataSource_enterprise_basic(t *testing.T) {
+	dataSourceName := "data.flexibleengine_rds_instances.test"
+	dc := acceptance.InitDataSourceCheck(dataSourceName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsInstanceDataSource_enterprise_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestMatchResourceAttr(dataSourceName, "instances.#", regexp.MustCompile("\\d+")),
+				),
+			},
+		},
+	})
+}
+
+func testAccRdsInstanceDataSource_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_networking_secgroup_v2" "test" {
+  name = "default"
+}
+
+data "flexibleengine_rds_flavors_v3" "test" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  instance_mode = "single"
+}
+
+resource "flexibleengine_rds_instance_v3" "test" {
+  name              = "%s"
+  flavor            = data.flexibleengine_rds_flavors_v3.test.flavors[2].name
+  availability_zone = [data.flexibleengine_availability_zones.test.names[0]]
+  security_group_id = data.flexibleengine_networking_secgroup_v2.test.id
+  subnet_id         = flexibleengine_vpc_subnet_v1.test.id
+  vpc_id            = flexibleengine_vpc_v1.test.id
+  time_zone         = "UTC+08:00"
+  fixed_ip          = "192.168.0.58"
+
+  db {
+    password = "FlexibleEngine!120521"
+    type     = "MySQL"
+    version  = "8.0"
+    port     = 8630
+  }
+
+  volume {
+    type = "COMMON"
+    size = 50
+  }
+
+  backup_strategy {
+    start_time = "08:00-09:00"
+    keep_days  = 1
+  }
+
+  tags = {
+    key = "value"
+    foo = "bar"
+  }
+}
+
+data "flexibleengine_rds_instances" "test" {
+  depends_on = [
+    flexibleengine_rds_instance_v3.test,
+  ]
+}
+`, testVpc(rName), rName)
+}
+
+func testAccRdsInstanceDataSource_ha_basic() string {
+	return fmt.Sprintf(`
+data "flexibleengine_rds_instances" "test" {
+  type           = "Ha"
+  datastore_type = "PostgreSQL"
+}
+`)
+}
+
+func testAccRdsInstanceDataSource_replica_basic() string {
+	return fmt.Sprintf(`
+data "flexibleengine_rds_instances" "test" {
+  type           = "Replica"
+  datastore_type = "PostgreSQL"
+}
+`)
+}
+
+func testAccRdsInstanceDataSource_enterprise_basic() string {
+	return fmt.Sprintf(`
+data "flexibleengine_rds_instances" "test" {
+  type                  = "Enterprise"
+  datastore_type        = "SQLServer"
+  enterprise_project_id = "0"
+}
+`)
+}

--- a/flexibleengine/acceptance/data_source_flexibleengine_rds_storage_types_test.go
+++ b/flexibleengine/acceptance/data_source_flexibleengine_rds_storage_types_test.go
@@ -1,0 +1,105 @@
+package acceptance
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccDatasourceStoragetype_basic(t *testing.T) {
+	rName := "data.flexibleengine_rds_storage_types.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceStoragetype_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "db_type", "MySQL"),
+					resource.TestCheckResourceAttr(rName, "db_version", "8.0"),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.az_status.%"),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.support_compute_group_type.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceStoragetype_PostgreSQL_basic(t *testing.T) {
+	rName := "data.flexibleengine_rds_storage_types.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceStoragetype_PostgreSQL_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "db_type", "PostgreSQL"),
+					resource.TestCheckResourceAttr(rName, "db_version", "14"),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.az_status.%"),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.support_compute_group_type.#"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDatasourceStoragetype_SQLServer_basic(t *testing.T) {
+	rName := "data.flexibleengine_rds_storage_types.test"
+	dc := acceptance.InitDataSourceCheck(rName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDatasourceStoragetype_SQLServer_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					dc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "db_type", "SQLServer"),
+					resource.TestCheckResourceAttr(rName, "db_version", "2019_SE"),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.name"),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.az_status.%"),
+					resource.TestCheckResourceAttrSet(rName, "storage_types.0.support_compute_group_type.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDatasourceStoragetype_basic() string {
+	return `
+data "flexibleengine_rds_storage_types" "test" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  instance_mode = "replica"
+}`
+}
+
+func testAccDatasourceStoragetype_PostgreSQL_basic() string {
+	return `
+data "flexibleengine_rds_storage_types" "test" {
+  db_type       = "PostgreSQL"
+  db_version    = "14"
+  instance_mode = "ha"
+}`
+}
+
+func testAccDatasourceStoragetype_SQLServer_basic() string {
+	return `
+data "flexibleengine_rds_storage_types" "test" {
+  db_type       = "SQLServer"
+  db_version    = "2019_SE"
+  instance_mode = "single"
+}`
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_rds_backup_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_rds_backup_test.go
@@ -1,0 +1,356 @@
+package acceptance
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getBackupResourceFunc(config *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := OS_REGION_NAME
+	// getBackup: Query the RDS manual backup
+	var (
+		getBackupHttpUrl = "v3/{project_id}/backups"
+		getBackupProduct = "rds"
+	)
+	getBackupClient, err := config.NewServiceClient(getBackupProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating Backup Client: %s", err)
+	}
+
+	getBackupPath := getBackupClient.Endpoint + getBackupHttpUrl
+	getBackupPath = strings.Replace(getBackupPath, "{project_id}", getBackupClient.ProjectID, -1)
+
+	getBackupqueryParams := fmt.Sprintf("?instance_id=%s&backup_id=%s",
+		state.Primary.Attributes["instance_id"], state.Primary.ID)
+	getBackupPath = getBackupPath + getBackupqueryParams
+	getBackupOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		OkCodes: []int{
+			200,
+		},
+	}
+	getBackupResp, err := getBackupClient.Request("GET", getBackupPath, &getBackupOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Backup: %s", err)
+	}
+
+	getBackupRespBody, err := utils.FlattenResponse(getBackupResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving Backup: %s", err)
+	}
+
+	count := utils.PathSearch("total_count", getBackupRespBody, 0)
+	if fmt.Sprintf("%v", count) == "0" {
+		return nil, fmt.Errorf("error retrieving Backup: %s", err)
+	}
+
+	return getBackupRespBody, nil
+}
+
+func TestAccBackup_mysql_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "flexibleengine_rds_backup.test"
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getBackupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testBackup_mysql_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"flexibleengine_rds_instance_v3.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "begin_time"),
+					resource.TestCheckResourceAttrSet(rName, "end_time"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "size"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccBackupImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func TestAccBackup_sqlserver_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "flexibleengine_rds_backup.test"
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getBackupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testBackup_sqlserver_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"flexibleengine_rds_instance_v3.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "begin_time"),
+					resource.TestCheckResourceAttrSet(rName, "end_time"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "size"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccBackupImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+func TestAccBackup_pg_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "flexibleengine_rds_backup.test"
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getBackupResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testBackup_pg_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(rName, "name", name),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"flexibleengine_rds_instance_v3.test", "id"),
+					resource.TestCheckResourceAttrSet(rName, "begin_time"),
+					resource.TestCheckResourceAttrSet(rName, "end_time"),
+					resource.TestCheckResourceAttrSet(rName, "status"),
+					resource.TestCheckResourceAttrSet(rName, "size"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: testAccBackupImportStateFunc(rName),
+			},
+		},
+	})
+}
+
+// disable auto_backup to prevent the instance status from changing to "BACKING UP" before manual backup creation.
+func testBackup_mysql_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_networking_secgroup_v2" "test" {
+  name = "default"
+}
+
+data "flexibleengine_rds_flavors_v3" "test" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  instance_mode = "single"
+}
+
+resource "flexibleengine_rds_instance_v3" "test" {
+  name              = "%[2]s"
+  flavor            = data.flexibleengine_rds_flavors_v3.test.flavors[2].name
+  availability_zone = [data.flexibleengine_availability_zones.test.names[0]]
+  security_group_id = data.flexibleengine_networking_secgroup_v2.test.id
+  subnet_id         = flexibleengine_vpc_subnet_v1.test.id
+  vpc_id            = flexibleengine_vpc_v1.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    password = "FlexibleEngine!120521"
+    type     = "MySQL"
+    version  = "8.0"
+    port     = 8630
+  }
+
+  volume {
+    type = "COMMON"
+    size = 60
+  }
+
+  backup_strategy {
+    start_time = "08:00-09:00"
+    keep_days  = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      backup_strategy,
+    ]
+  }
+}
+
+resource "flexibleengine_rds_backup" "test" {
+  name        = "%[2]s"
+  instance_id = flexibleengine_rds_instance_v3.test.id
+}
+`, testVpc(name), name)
+}
+
+// disable auto_backup to prevent the instance status from changing to "BACKING UP" before manual backup creation.
+func testBackup_sqlserver_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_networking_secgroup_v2" "test" {
+  name = "default"
+}
+
+data "flexibleengine_rds_flavors_v3" "test" {
+  db_type       = "SQLServer"
+  db_version    = "2019_SE"
+  instance_mode = "single"
+}
+
+resource "flexibleengine_rds_instance_v3" "test" {
+  name              = "%[2]s"
+  flavor            = data.flexibleengine_rds_flavors_v3.test.flavors[0].name
+  availability_zone = [data.flexibleengine_availability_zones.test.names[0]]
+  security_group_id = data.flexibleengine_networking_secgroup_v2.test.id
+  subnet_id         = flexibleengine_vpc_subnet_v1.test.id
+  vpc_id            = flexibleengine_vpc_v1.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    password = "FlexibleEngine!120521"
+    type     = "SQLServer"
+    version  = "2019_SE"
+    port     = 8631
+  }
+  volume {
+    type = "COMMON"
+    size = 50
+  }
+  backup_strategy {
+    start_time = "08:00-09:00"
+    keep_days  = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      backup_strategy,
+    ]
+  }
+}
+
+resource "flexibleengine_rds_backup" "test" {
+  name        = "%[2]s"
+  instance_id = flexibleengine_rds_instance_v3.test.id
+}
+`, testVpc(name), name)
+}
+
+// disable auto_backup to prevent the instance status from changing to "BACKING UP" before manual backup creation.
+func testBackup_pg_basic(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_networking_secgroup_v2" "test" {
+  name = "default"
+}
+
+data "flexibleengine_rds_flavors_v3" "test" {
+  db_type       = "PostgreSQL"
+  db_version    = "14"
+  instance_mode = "single"
+  vcpus         = 8
+}
+
+resource "flexibleengine_rds_instance_v3" "test" {
+  name              = "%[2]s"
+  flavor            = data.flexibleengine_rds_flavors_v3.test.flavors[0].name
+  availability_zone = [data.flexibleengine_availability_zones.test.names[0]]
+  security_group_id = data.flexibleengine_networking_secgroup_v2.test.id
+  subnet_id         = flexibleengine_vpc_subnet_v1.test.id
+  vpc_id            = flexibleengine_vpc_v1.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    password = "FlexibleEngine!120521"
+    type     = "PostgreSQL"
+    version  = "14"
+    port     = 8632
+  }
+  volume {
+    type = "COMMON"
+    size = 50
+  }
+  backup_strategy {
+    start_time = "08:00-09:00"
+    keep_days  = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      backup_strategy,
+    ]
+  }
+}
+
+resource "flexibleengine_rds_backup" "test" {
+  name        = "%[2]s"
+  instance_id = flexibleengine_rds_instance_v3.test.id
+}
+`, testVpc(name), name)
+}
+
+func testAccBackupImportStateFunc(name string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return "", fmt.Errorf("Resource (%s) not found: %s", name, rs)
+		}
+		if rs.Primary.ID == "" || rs.Primary.Attributes["instance_id"] == "" {
+			return "", fmt.Errorf("resource (%s) not found: %s", name, rs)
+		}
+		return fmt.Sprintf("%s/%s", rs.Primary.Attributes["instance_id"], rs.Primary.ID), nil
+	}
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_rds_cross_region_backup_strategy_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_rds_cross_region_backup_strategy_test.go
@@ -1,0 +1,217 @@
+package acceptance
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getBackupStrategyResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := OS_REGION_NAME
+	// getBackupStrategy: Query the RDS cross region backup strategy
+	var (
+		getBackupStrategyHttpUrl = "v3/{project_id}/instances/{instance_id}/backups/offsite-policy"
+		getBackupStrategyProduct = "rds"
+	)
+	getBackupStrategyClient, err := cfg.NewServiceClient(getBackupStrategyProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating RDS client: %s", err)
+	}
+
+	getBackupStrategyPath := getBackupStrategyClient.Endpoint + getBackupStrategyHttpUrl
+	getBackupStrategyPath = strings.ReplaceAll(getBackupStrategyPath, "{project_id}", getBackupStrategyClient.ProjectID)
+	getBackupStrategyPath = strings.ReplaceAll(getBackupStrategyPath, "{instance_id}", state.Primary.ID)
+
+	getBackupStrategyOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+	}
+
+	getBackupStrategyResp, err := getBackupStrategyClient.Request("GET", getBackupStrategyPath, &getBackupStrategyOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving RDS cross region backup strategy: %s", err)
+	}
+
+	getBackupStrategyRespBody, err := utils.FlattenResponse(getBackupStrategyResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving RDS cross region backup strategy: %s", err)
+	}
+
+	policyPara := utils.PathSearch("policy_para", getBackupStrategyRespBody, nil)
+	if policyPara == nil {
+		return nil, fmt.Errorf("error retrieving RDS cross region backup strategy: %s", err)
+	}
+
+	backupStrategies := policyPara.([]interface{})
+	if len(backupStrategies) == 0 || utils.PathSearch("keep_days", backupStrategies[0], 0).(float64) == 0 {
+		return nil, fmt.Errorf("error retrieving RDS cross region backup strategy: %s", err)
+	}
+
+	return getBackupStrategyRespBody, nil
+}
+
+func TestAccBackupStrategy_basic(t *testing.T) {
+	var obj interface{}
+
+	name := acceptance.RandomAccResourceName()
+	rName := "flexibleengine_rds_cross_region_backup_strategy.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getBackupStrategyResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			acceptance.TestAccPreCheckReplication(t)
+		},
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testBackupStrategy_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"flexibleengine_rds_instance_v3.test", "id"),
+					resource.TestCheckResourceAttr(rName, "backup_type", "auto"),
+					resource.TestCheckResourceAttr(rName, "keep_days", "5"),
+					resource.TestCheckResourceAttr(rName, "destination_region", OS_DEST_REGION),
+					resource.TestCheckResourceAttr(rName, "destination_project_id", OS_DEST_PROJECT_ID),
+				),
+			},
+			{
+				Config: testBackupStrategy_basic_update1(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"flexibleengine_rds_instance_v3.test", "id"),
+					resource.TestCheckResourceAttr(rName, "backup_type", "all"),
+					resource.TestCheckResourceAttr(rName, "keep_days", "8"),
+					resource.TestCheckResourceAttr(rName, "destination_region", OS_DEST_REGION),
+					resource.TestCheckResourceAttr(rName, "destination_project_id", OS_DEST_PROJECT_ID),
+				),
+			},
+			{
+				Config: testBackupStrategy_basic_update2(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"flexibleengine_rds_instance_v3.test", "id"),
+					resource.TestCheckResourceAttr(rName, "backup_type", "auto"),
+					resource.TestCheckResourceAttr(rName, "keep_days", "10"),
+					resource.TestCheckResourceAttr(rName, "destination_region", OS_DEST_REGION),
+					resource.TestCheckResourceAttr(rName, "destination_project_id", OS_DEST_PROJECT_ID),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccRdsCrossRegionBackupStrategy(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_networking_secgroup_v2" "test" {
+  name = "default"
+}
+
+data "flexibleengine_rds_flavors_v3" "test" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  instance_mode = "single"
+}
+
+resource "flexibleengine_rds_instance_v3" "test" {
+  name              = "%[2]s"
+  flavor            = data.flexibleengine_rds_flavors_v3.test.flavors[2].name
+  availability_zone = [data.flexibleengine_availability_zones.test.names[0]]
+  security_group_id = data.flexibleengine_networking_secgroup_v2.test.id
+  subnet_id         = flexibleengine_vpc_subnet_v1.test.id
+  vpc_id            = flexibleengine_vpc_v1.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    password = "FlexibleEngine!120521"
+    type     = "MySQL"
+    version  = "8.0"
+    port     = 8630
+  }
+
+  volume {
+    type = "COMMON"
+    size = 50
+  }
+
+  backup_strategy {
+    start_time = "08:00-09:00"
+    keep_days  = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      backup_strategy,
+    ]
+  }
+}
+`, testVpc(name), name)
+}
+
+func testBackupStrategy_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_rds_cross_region_backup_strategy" "test" {
+  instance_id            = flexibleengine_rds_instance_v3.test.id
+  backup_type            = "auto"
+  keep_days              = "5"
+  destination_region     = "%s"
+  destination_project_id = "%s"
+}
+`, testAccRdsCrossRegionBackupStrategy(name), OS_DEST_REGION, OS_DEST_PROJECT_ID)
+}
+
+func testBackupStrategy_basic_update1(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_rds_cross_region_backup_strategy" "test" {
+  instance_id            = flexibleengine_rds_instance_v3.test.id
+  backup_type            = "all"
+  keep_days              = "8"
+  destination_region     = "%s"
+  destination_project_id = "%s"
+}
+`, testAccRdsCrossRegionBackupStrategy(name), OS_DEST_REGION, OS_DEST_PROJECT_ID)
+}
+
+func testBackupStrategy_basic_update2(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_rds_cross_region_backup_strategy" "test" {
+  instance_id            = flexibleengine_rds_instance_v3.test.id
+  backup_type            = "auto"
+  keep_days              = "10"
+  destination_region     = "%s"
+  destination_project_id = "%s"
+}
+`, testAccRdsCrossRegionBackupStrategy(name), OS_DEST_REGION, OS_DEST_PROJECT_ID)
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_rds_instance_v3_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_rds_instance_v3_test.go
@@ -36,8 +36,6 @@ func TestAccRdsInstanceV3_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "60"),
 					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
 					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
-					resource.TestCheckResourceAttr(resourceName, "parameters.0.name", "div_precision_increment"),
-					resource.TestCheckResourceAttr(resourceName, "parameters.0.value", "12"),
 					resource.TestCheckResourceAttrSet(resourceName, "fixed_ip"),
 				),
 			},
@@ -62,6 +60,36 @@ func TestAccRdsInstanceV3_basic(t *testing.T) {
 					"db",
 					"status",
 				},
+			},
+		},
+	})
+}
+
+func TestAccRdsInstanceV3_mariadb_basic(t *testing.T) {
+	var instance instances.RdsInstanceResponse
+	name := acctest.RandString(4)
+	resourceType := "flexibleengine_rds_instance_v3"
+	resourceName := "flexibleengine_rds_instance_v3.instance"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      testAccCheckRdsInstanceV3Destroy(resourceType),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRdsInstanceV3_mariadb_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRdsInstanceV3Exists(resourceName, &instance),
+					resource.TestCheckResourceAttr(resourceName, "name", fmt.Sprintf("rds_acc_instance-%s", name)),
+					resource.TestCheckResourceAttr(resourceName, "flavor", "rds.mariadb.n1.large.2"),
+					resource.TestCheckResourceAttr(resourceName, "time_zone", "UTC+01:00"),
+					resource.TestCheckResourceAttr(resourceName, "db.0.port", "3306"),
+					resource.TestCheckResourceAttr(resourceName, "backup_strategy.0.keep_days", "1"),
+					resource.TestCheckResourceAttr(resourceName, "volume.0.size", "60"),
+					resource.TestCheckResourceAttr(resourceName, "tags.key", "value"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+					resource.TestCheckResourceAttrSet(resourceName, "fixed_ip"),
+				),
 			},
 		},
 	})
@@ -173,11 +201,6 @@ resource "flexibleengine_rds_instance_v3" "instance" {
     keep_days  = 1
   }
 
-  parameters {
-    name  = "div_precision_increment"
-    value = "12"
-  }
-
   tags = {
     key = "value"
     foo = "bar"
@@ -218,6 +241,41 @@ resource "flexibleengine_rds_instance_v3" "instance" {
   tags = {
     key   = "value1"
     owner = "terraform"
+  }
+}
+`, testAccRdsInstanceV3_network(rName), rName, OS_AVAILABILITY_ZONE)
+}
+
+func testAccRdsInstanceV3_mariadb_basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_rds_instance_v3" "instance" {
+  name              = "rds_acc_instance-%s"
+  flavor            = "rds.mariadb.n1.large.2"
+  availability_zone = ["%s"]
+  security_group_id = flexibleengine_networking_secgroup_v2.secgroup.id
+  vpc_id            = flexibleengine_vpc_v1.vpc_1.id
+  subnet_id         = flexibleengine_vpc_subnet_v1.subnet_1.id
+  time_zone         = "UTC+01:00"
+
+  db {
+    password = "FlexibleEngine!120521"
+    type     = "MariaDB"
+    version  = "10.5"
+  }
+  volume {
+    type = "CLOUDSSD"
+    size = 60
+  }
+  backup_strategy {
+    start_time = "08:00-09:00"
+    keep_days  = 1
+  }
+
+  tags = {
+    key = "value"
+    foo = "bar"
   }
 }
 `, testAccRdsInstanceV3_network(rName), rName, OS_AVAILABILITY_ZONE)

--- a/flexibleengine/acceptance/resource_flexibleengine_rds_sql_audit_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_rds_sql_audit_test.go
@@ -1,0 +1,171 @@
+package acceptance
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
+)
+
+func getSQLAuditResourceFunc(cfg *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	region := OS_REGION_NAME
+	// getSQLAudit: Query the RDS SQL audit
+	var (
+		getSQLAuditHttpUrl = "v3/{project_id}/instances/{instance_id}/auditlog-policy"
+		getSQLAuditProduct = "rds"
+	)
+	getSQLAuditClient, err := cfg.NewServiceClient(getSQLAuditProduct, region)
+	if err != nil {
+		return nil, fmt.Errorf("error creating RDS client: %s", err)
+	}
+
+	getSQLAuditPath := getSQLAuditClient.Endpoint + getSQLAuditHttpUrl
+	getSQLAuditPath = strings.ReplaceAll(getSQLAuditPath, "{project_id}", getSQLAuditClient.ProjectID)
+	getSQLAuditPath = strings.ReplaceAll(getSQLAuditPath, "{instance_id}", state.Primary.ID)
+
+	getSQLAuditOpt := golangsdk.RequestOpts{
+		KeepResponseBody: true,
+		MoreHeaders:      map[string]string{"Content-Type": "application/json"},
+	}
+
+	getSQLAuditResp, err := getSQLAuditClient.Request("GET", getSQLAuditPath, &getSQLAuditOpt)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving RDS SQL audit: %s", err)
+	}
+
+	getSQLAuditRespBody, err := utils.FlattenResponse(getSQLAuditResp)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving RDS SQL audit: %s", err)
+	}
+
+	keepDays := utils.PathSearch("keep_days", getSQLAuditRespBody, 0).(float64)
+	if keepDays == 0 {
+		return nil, fmt.Errorf("error retrieving RDS SQL audit: %s", err)
+	}
+
+	return getSQLAuditRespBody, nil
+}
+
+func TestAccSQLAudit_basic(t *testing.T) {
+	var obj interface{}
+	name := acceptance.RandomAccResourceName()
+	rName := "flexibleengine_rds_sql_audit.test"
+
+	rc := acceptance.InitResourceCheck(
+		rName,
+		&obj,
+		getSQLAuditResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testSQLAudit_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"flexibleengine_rds_instance_v3.test", "id"),
+					resource.TestCheckResourceAttr(rName, "keep_days", "5"),
+				),
+			},
+			{
+				Config: testSQLAudit_basic_update(name),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(rName, "instance_id",
+						"flexibleengine_rds_instance_v3.test", "id"),
+					resource.TestCheckResourceAttr(rName, "keep_days", "9"),
+				),
+			},
+			{
+				ResourceName:      rName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccRdsSqlAudit_base(name string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_networking_secgroup_v2" "test" {
+  name = "default"
+}
+
+data "flexibleengine_rds_flavors_v3" "test" {
+  db_type       = "MySQL"
+  db_version    = "8.0"
+  instance_mode = "single"
+}
+
+resource "flexibleengine_rds_instance_v3" "test" {
+  name              = "%[2]s"
+  flavor            = data.flexibleengine_rds_flavors_v3.test.flavors[2].name
+  availability_zone = [data.flexibleengine_availability_zones.test.names[0]]
+  security_group_id = data.flexibleengine_networking_secgroup_v2.test.id
+  subnet_id         = flexibleengine_vpc_subnet_v1.test.id
+  vpc_id            = flexibleengine_vpc_v1.test.id
+  time_zone         = "UTC+08:00"
+
+  db {
+    password = "FlexibleEngine!120521"
+    type     = "MySQL"
+    version  = "8.0"
+    port     = 8630
+  }
+
+  volume {
+    type = "COMMON"
+    size = 50
+  }
+
+  backup_strategy {
+    start_time = "08:00-09:00"
+    keep_days  = 1
+  }
+
+  lifecycle {
+    ignore_changes = [
+      backup_strategy,
+    ]
+  }
+}
+`, testVpc(name), name)
+}
+
+func testSQLAudit_basic(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_rds_sql_audit" "test" {
+  instance_id = flexibleengine_rds_instance_v3.test.id
+  keep_days   = "5"
+}
+`, testAccRdsSqlAudit_base(name))
+}
+
+func testSQLAudit_basic_update(name string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_rds_sql_audit" "test" {
+  instance_id = flexibleengine_rds_instance_v3.test.id
+  keep_days   = "9"
+}
+`, testAccRdsSqlAudit_base(name))
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -316,9 +316,15 @@ func Provider() *schema.Provider {
 			"flexibleengine_images_image":  ims.DataSourceImagesImageV2(),
 			"flexibleengine_images_images": ims.DataSourceImagesImages(),
 
-			"flexibleengine_networking_port":    vpc.DataSourceNetworkingPortV2(),
-			"flexibleengine_identity_group":     iam.DataSourceIdentityGroup(),
-			"flexibleengine_identity_users":     iam.DataSourceIdentityUsers(),
+			"flexibleengine_networking_port": vpc.DataSourceNetworkingPortV2(),
+			"flexibleengine_identity_group":  iam.DataSourceIdentityGroup(),
+			"flexibleengine_identity_users":  iam.DataSourceIdentityUsers(),
+
+			"flexibleengine_rds_backups":         rds.DataSourceBackup(),
+			"flexibleengine_rds_engine_versions": rds.DataSourceRdsEngineVersionsV3(),
+			"flexibleengine_rds_instances":       rds.DataSourceRdsInstances(),
+			"flexibleengine_rds_storage_types":   rds.DataSourceStoragetype(),
+
 			"flexibleengine_sfs_turbos":         sfs.DataSourceTurbos(),
 			"flexibleengine_smn_topics":         smn.DataSourceTopics(),
 			"flexibleengine_sms_source_servers": sms.DataSourceServers(),
@@ -535,9 +541,13 @@ func Provider() *schema.Provider {
 
 			"flexibleengine_obs_bucket_acl": obs.ResourceOBSBucketAcl(),
 
-			"flexibleengine_rds_account":            rds.ResourceMysqlAccount(),
-			"flexibleengine_rds_database":           rds.ResourceMysqlDatabase(),
-			"flexibleengine_rds_database_privilege": rds.ResourceMysqlDatabasePrivilege(),
+			"flexibleengine_rds_account":                      rds.ResourceMysqlAccount(),
+			"flexibleengine_rds_backup":                       rds.ResourceBackup(),
+			"flexibleengine_rds_cross_region_backup_strategy": rds.ResourceBackupStrategy(),
+			"flexibleengine_rds_database":                     rds.ResourceMysqlDatabase(),
+			"flexibleengine_rds_database_privilege":           rds.ResourceMysqlDatabasePrivilege(),
+			"flexibleengine_rds_sql_audit":                    rds.ResourceSQLAudit(),
+
 			"flexibleengine_sms_server_template":    sms.ResourceServerTemplate(),
 			"flexibleengine_sms_task":               sms.ResourceMigrateTask(),
 			"flexibleengine_swr_organization":       swr.ResourceSWROrganization(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
import RDSresource, unit test and document.

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [ ] Schema updated.

## Acceptance Steps Performed

```
### resource_flexibleengine_rds_backup

=== RUN   TestAccBackup_mysql_basic
=== PAUSE TestAccBackup_mysql_basic
=== CONT  TestAccBackup_mysql_basic
--- PASS: TestAccBackup_mysql_basic (1185.01s)
PASS

coverage: 2.1% of statements in ../../../terraform-provider-flexibleengine/...


=== RUN   TestAccBackup_sqlserver_basic
=== PAUSE TestAccBackup_sqlserver_basic
=== CONT  TestAccBackup_sqlserver_basic
--- PASS: TestAccBackup_sqlserver_basic (1931.04s)
PASS

coverage: 1.9% of statements in ../../../terraform-provider-flexibleengine/...


=== RUN   TestAccBackup_pg_basic
=== PAUSE TestAccBackup_pg_basic
=== CONT  TestAccBackup_pg_basic
--- PASS: TestAccBackup_pg_basic (1034.23s)
PASS

coverage: 1.9% of statements in ../../../terraform-provider-flexibleengine/...
```

```
### data_source_flexibleengine_rds_backup

=== RUN   TestAccDatasourceBackup_basic
=== PAUSE TestAccDatasourceBackup_basic
=== CONT  TestAccDatasourceBackup_basic
--- PASS: TestAccDatasourceBackup_basic (1108.51s)
PASS

coverage: 1.9% of statements in ../../../terraform-provider-flexibleengine/...


=== RUN   TestAccDatasourceBackup_auto_basic
=== PAUSE TestAccDatasourceBackup_auto_basic
=== CONT  TestAccDatasourceBackup_auto_basic
--- PASS: TestAccDatasourceBackup_auto_basic (412.16s)
PASS

coverage: 1.9% of statements in ../../../terraform-provider-flexibleengine/...

=== RUN   TestAccDatasourceBackup_incremental_basic
=== PAUSE TestAccDatasourceBackup_incremental_basic
=== CONT  TestAccDatasourceBackup_incremental_basic
--- PASS: TestAccDatasourceBackup_incremental_basic (432.17s)
PASS

coverage: 1.7% of statements in ../../../terraform-provider-flexibleengine/...
```

```
### data_source_flexibleengine_engine_versions

=== RUN   TestAccRdsEngineVersionsV3DataSource_basic
=== PAUSE TestAccRdsEngineVersionsV3DataSource_basic
=== CONT  TestAccRdsEngineVersionsV3DataSource_basic
--- PASS: TestAccRdsEngineVersionsV3DataSource_basic (44.08s)
PASS

coverage: 1.7% of statements in ../../../terraform-provider-flexibleengine/...

=== RUN   TestAccRdsEngineVersionsV3DataSource_PostgreSQL_basic
=== PAUSE TestAccRdsEngineVersionsV3DataSource_PostgreSQL_basic
=== CONT  TestAccRdsEngineVersionsV3DataSource_PostgreSQL_basic
--- PASS: TestAccRdsEngineVersionsV3DataSource_PostgreSQL_basic (38.72s)
PASS
coverage: 1.7% of statements in ../../../terraform-provider-flexibleengine/...

=== RUN   TestAccRdsEngineVersionsV3DataSource_SQLServer_basic
=== PAUSE TestAccRdsEngineVersionsV3DataSource_SQLServer_basic
=== CONT  TestAccRdsEngineVersionsV3DataSource_SQLServer_basic
--- PASS: TestAccRdsEngineVersionsV3DataSource_SQLServer_basic (43.08s)
PASS

coverage: 1.7% of statements in ../../../terraform-provider-flexibleengine/...
```

```
### data_source_flexibleengine_storage_types

=== RUN   TestAccDatasourceStoragetype_basic
=== PAUSE TestAccDatasourceStoragetype_basic
=== CONT  TestAccDatasourceStoragetype_basic
--- PASS: TestAccDatasourceStoragetype_basic (41.38s)
PASS

coverage: 1.7% of statements in ../../../terraform-provider-flexibleengine/...

=== RUN   TestAccDatasourceStoragetype_PostgreSQL_basic
=== PAUSE TestAccDatasourceStoragetype_PostgreSQL_basic
=== CONT  TestAccDatasourceStoragetype_PostgreSQL_basic
--- PASS: TestAccDatasourceStoragetype_PostgreSQL_basic (35.54s)
PASS

coverage: 1.7% of statements in ../../../terraform-provider-flexibleengine/...

=== RUN   TestAccDatasourceStoragetype_SQLServer_basic
=== PAUSE TestAccDatasourceStoragetype_SQLServer_basic
=== CONT  TestAccDatasourceStoragetype_SQLServer_basic
--- PASS: TestAccDatasourceStoragetype_SQLServer_basic (36.72s)
PASS
coverage: 1.7% of statements in ../../../terraform-provider-flexibleengine/...
```


```
### data_source_flexibleengine_rds_instances
=== RUN   TestAccRdsInstanceDataSource_basic
=== PAUSE TestAccRdsInstanceDataSource_basic
=== CONT  TestAccRdsInstanceDataSource_basic
--- PASS: TestAccRdsInstanceDataSource_basic (1086.39s)
PASS

coverage: 1.9% of statements in ../../../terraform-provider-flexibleengine/...


=== RUN   TestAccRdsInstanceDataSource_ha_basic
=== PAUSE TestAccRdsInstanceDataSource_ha_basic
=== CONT  TestAccRdsInstanceDataSource_ha_basic
--- PASS: TestAccRdsInstanceDataSource_ha_basic (165.64s)
PASS

=== RUN   TestAccRdsInstanceDataSource_replica_basic
=== PAUSE TestAccRdsInstanceDataSource_replica_basic
=== CONT  TestAccRdsInstanceDataSource_replica_basic
--- PASS: TestAccRdsInstanceDataSource_replica_basic (294.93s)
PASS

=== RUN   TestAccRdsInstanceDataSource_enterprise_basic
=== PAUSE TestAccRdsInstanceDataSource_enterprise_basic
=== CONT  TestAccRdsInstanceDataSource_enterprise_basic
--- PASS: TestAccRdsInstanceDataSource_enterprise_basic (33.76s)
PASS

```

```
### resource_flexibleengine_rds_sql_audit
=== RUN   TestAccSQLAudit_basic
=== PAUSE TestAccSQLAudit_basic
=== CONT  TestAccSQLAudit_basic
--- PASS: TestAccSQLAudit_basic (1077.14s)
PASS

coverage: 1.9% of statements in ../../../terraform-provider-flexibleengine/...
```

```
### resource_flexibleengine_rds_cross_region_backup_strategy
=== RUN   TestAccBackupStrategy_basic
=== PAUSE TestAccBackupStrategy_basic
=== CONT  TestAccBackupStrategy_basic
--- PASS: TestAccBackupStrategy_basic (1027.76s)
PASS

coverage: 1.9% of statements in ../../../terraform-provider-flexibleengine/...
```

