### PR TITLE
feat(VPCEP): Synchronized two VPCEP resources.

### DIFF
--- a/docs/resources/vpcep_approval.md
+++ b/docs/resources/vpcep_approval.md
@@ -69,21 +69,30 @@ The following arguments are supported:
 * `endpoints` - (Required, List) Specifies the list of VPC endpoint IDs which accepted to connect to VPC endpoint service.
     The VPC endpoints will be rejected when the resource was destroyed.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
 * `id` - The unique ID in UUID format which equals to the ID of the VPC endpoint service.
 
 * `connections` - An array of VPC endpoints connect to the VPC endpoint service. Structure is documented below.
-    - `endpoint_id` - The unique ID of the VPC endpoint.
-    - `packet_id` - The packet ID of the VPC endpoint.
-    - `domain_id` - The user's domain ID.
-    - `status` - The connection status of the VPC endpoint.
+  - `endpoint_id` - The unique ID of the VPC endpoint.
+  - `packet_id` - The packet ID of the VPC endpoint.
+  - `domain_id` - The user's domain ID.
+  - `status` - The connection status of the VPC endpoint.
+  - `description` - The description of the VPC endpoint service connection.
 
 ## Timeouts
 
 This resource provides the following timeouts configuration options:
 
-* `create` - Default is 10 minute.
-* `delete` - Default is 10 minute.
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
+
+## Import
+
+VPC endpoint approval can be imported using the `id`, e.g.
+
+```shell
+terraform import flexibleengine_vpcep_approval.test <id>
+```

--- a/docs/resources/vpcep_endpoint.md
+++ b/docs/resources/vpcep_endpoint.md
@@ -82,32 +82,33 @@ resource "flexibleengine_vpcep_endpoint" "demo" {
 The following arguments are supported:
 
 * `region` - (Optional, String, ForceNew) The region in which to create the VPC endpoint.
-    If omitted, the provider-level region will be used. Changing this creates a new VPC endpoint.
+  If omitted, the provider-level region will be used. Changing this creates a new VPC endpoint.
 
 * `service_id` - (Required, String, ForceNew) Specifies the ID of the VPC endpoint service.
-    Changing this creates a new VPC endpoint.
+  Changing this creates a new VPC endpoint.
 
 * `vpc_id` - (Required, String, ForceNew) Specifies the ID of the VPC where the VPC endpoint is to be created.
-    Changing this creates a new VPC endpoint.
+  Changing this creates a new VPC endpoint.
 
 * `network_id` - (Required, String, ForceNew) Specifies the network ID of the subnet in the VPC specified by `vpc_id`.
-    Changing this creates a new VPC endpoint.
+  Changing this creates a new VPC endpoint.
 
 * `ip_address` - (Optional, String, ForceNew) Specifies the IP address for accessing the associated VPC endpoint service.
-    Only IPv4 addresses are supported. Changing this creates a new VPC endpoint.
+  Only IPv4 addresses are supported. Changing this creates a new VPC endpoint.
 
-* `enable_dns` - (Optional, Bool, ForceNew) Specifies whether to create a private domain name. The default value is true.
-    Changing this creates a new VPC endpoint.
+* `enable_dns` - (Optional, Bool) Specifies whether to create a private domain name. The default value is true.
 
-* `enable_whitelist` (Optional, Bool, ForceNew) - Specifies whether to enable access control. The default value is false.
-    Changing this creates a new VPC endpoint.
+* `enable_whitelist` (Optional, Bool) - Specifies whether to enable access control. The default value is false.
 
 * `whitelist` (Optional, List, ForceNew) - Specifies the list of IP address or CIDR block,
-    which can be accessed to the VPC endpoint. Changing this creates a new VPC endpoint.
+  which can be accessed to the VPC endpoint. Changing this creates a new VPC endpoint.
+
+* `description` - (Optional, String, ForceNew) Specifies the description of the VPC endpoint.
+  Changing this creates a new VPC endpoint.
 
 * `tags` - (Optional, Map) The key/value pairs to associate with the VPC endpoint.
 
-## Attributes Reference
+## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
@@ -128,8 +129,8 @@ In addition to all arguments above, the following attributes are exported:
 
 This resource provides the following timeouts configuration options:
 
-* `create` - Default is 10 minute.
-* `delete` - Default is 10 minute.
+* `create` - Default is 10 minutes.
+* `delete` - Default is 10 minutes.
 
 ## Import
 

--- a/flexibleengine/acceptance/resource_flexibleengine_vpcep_approval_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_vpcep_approval_test.go
@@ -1,0 +1,98 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccVPCEndpointApproval_Basic(t *testing.T) {
+	var endpoint endpoints.Endpoint
+
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "flexibleengine_vpcep_approval.approval"
+
+	rc := acceptance.InitResourceCheck(
+		"flexibleengine_vpcep_endpoint.test",
+		&endpoint,
+		getVpcepEndpointResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCEndpointApproval_Basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttrPair(resourceName, "id", "flexibleengine_vpcep_service.test", "id"),
+					resource.TestCheckResourceAttrPair(resourceName, "connections.0.endpoint_id",
+						"flexibleengine_vpcep_endpoint.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "connections.0.status", "accepted"),
+				),
+			},
+			{
+				Config: testAccVPCEndpointApproval_Update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(resourceName, "connections.0.endpoint_id",
+						"flexibleengine_vpcep_endpoint.test", "id"),
+					resource.TestCheckResourceAttr(resourceName, "connections.0.status", "rejected"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccVPCEndpointApproval_Base(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpcep_endpoint" "test" {
+  service_id = flexibleengine_vpcep_service.test.id
+  vpc_id     = flexibleengine_vpc_v1.test.id
+  network_id = flexibleengine_vpc_subnet_v1.test.id
+  enable_dns = true
+
+  tags = {
+    owner = "tf-acc"
+  }
+  lifecycle {
+    ignore_changes = [enable_dns]
+  }
+}
+`, testAccVPCEndpoint_Precondition(rName))
+}
+
+func testAccVPCEndpointApproval_Basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpcep_approval" "approval" {
+  service_id = flexibleengine_vpcep_service.test.id
+  endpoints  = [flexibleengine_vpcep_endpoint.test.id]
+}
+`, testAccVPCEndpointApproval_Base(rName))
+}
+
+func testAccVPCEndpointApproval_Update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpcep_approval" "approval" {
+  service_id = flexibleengine_vpcep_service.test.id
+  endpoints  = []
+}
+`, testAccVPCEndpointApproval_Base(rName))
+}

--- a/flexibleengine/acceptance/resource_flexibleengine_vpcep_endpoint_test.go
+++ b/flexibleengine/acceptance/resource_flexibleengine_vpcep_endpoint_test.go
@@ -1,0 +1,177 @@
+package acceptance
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/chnsz/golangsdk/openstack/vpcep/v1/endpoints"
+
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance"
+)
+
+func TestAccVPCEndpoint_Basic(t *testing.T) {
+	var endpoint endpoints.Endpoint
+
+	rName := acceptance.RandomAccResourceNameWithDash()
+	resourceName := "flexibleengine_vpcep_endpoint.test"
+	rc := acceptance.InitResourceCheck(
+		resourceName,
+		&endpoint,
+		getVpcepEndpointResourceFunc,
+	)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { acceptance.TestAccPreCheck(t) },
+		ProviderFactories: TestAccProviderFactories,
+		CheckDestroy:      rc.CheckResourceDestroy(),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCEndpoint_Basic(rName),
+				Check: resource.ComposeTestCheckFunc(
+					rc.CheckResourceExists(),
+					resource.TestCheckResourceAttr(resourceName, "status", "accepted"),
+					resource.TestCheckResourceAttr(resourceName, "enable_dns", "true"),
+					resource.TestCheckResourceAttr(resourceName, "service_type", "interface"),
+					resource.TestCheckResourceAttr(resourceName, "description", "test description"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "tf-acc"),
+					resource.TestCheckResourceAttrSet(resourceName, "service_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "private_domain_name"),
+				),
+			},
+			{
+				Config: testAccVPCEndpoint_Update(rName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "status", "accepted"),
+					resource.TestCheckResourceAttr(resourceName, "tags.owner", "tf-acc-update"),
+					resource.TestCheckResourceAttr(resourceName, "tags.foo", "bar"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func getVpcepEndpointResourceFunc(conf *config.Config, state *terraform.ResourceState) (interface{}, error) {
+	vpcepClient, err := conf.VPCEPClient(OS_REGION_NAME)
+	if err != nil {
+		return nil, fmt.Errorf("error creating VPCEP client: %s", err)
+	}
+
+	return endpoints.Get(vpcepClient, state.Primary.ID).Extract()
+}
+
+const testAccCompute_data = `
+data "flexibleengine_availability_zones" "test" {}
+
+data "flexibleengine_compute_flavors_v2" "test" {
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+  performance_type  = "normal"
+  cpu_core          = 2
+  memory_size       = 4
+}
+
+data "flexibleengine_images_image_v2" "test" {
+  name = "OBS Ubuntu 20.04"
+}
+
+data "flexibleengine_networking_secgroup_v2" "test" {
+  name = "default"
+}
+`
+
+func testAccVPCEndpoint_Precondition(rName string) string {
+	return fmt.Sprintf(`
+%[1]s
+
+resource "flexibleengine_vpc_v1" "test" {
+  name = "%[2]s"
+  cidr = "192.168.0.0/16"
+}
+
+resource "flexibleengine_vpc_subnet_v1" "test" {
+  name       = "%[2]s"
+  cidr       = "192.168.0.0/24"
+  gateway_ip = "192.168.0.1"
+  vpc_id     = flexibleengine_vpc_v1.test.id
+}
+
+resource "flexibleengine_compute_instance_v2" "ecs" {
+  name              = "%[2]s"
+  image_id          = data.flexibleengine_images_image_v2.test.id
+  flavor_id         = data.flexibleengine_compute_flavors_v2.test.flavors[0]
+  security_groups   = [data.flexibleengine_networking_secgroup_v2.test.name]
+  availability_zone = data.flexibleengine_availability_zones.test.names[0]
+
+  network {
+    uuid = flexibleengine_vpc_subnet_v1.test.id
+  }
+}
+
+resource "flexibleengine_vpcep_service" "test" {
+  name        = "%[2]s"
+  server_type = "VM"
+  vpc_id      = flexibleengine_vpc_v1.test.id
+  port_id     = flexibleengine_compute_instance_v2.ecs.network[0].port
+  approval    = false
+
+  port_mapping {
+    service_port  = 8080
+    terminal_port = 80
+  }
+  tags = {
+    owner = "tf-acc"
+  }
+}
+`, testAccCompute_data, rName)
+}
+
+func testAccVPCEndpoint_Basic(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpcep_endpoint" "test" {
+  service_id  = flexibleengine_vpcep_service.test.id
+  vpc_id      = flexibleengine_vpc_v1.test.id
+  network_id  = flexibleengine_vpc_subnet_v1.test.id
+  enable_dns  = true
+  description = "test description"
+
+  enable_whitelist = true
+  whitelist        = ["192.168.0.0/24", "10.10.10.12"]
+
+  tags = {
+    owner = "tf-acc"
+  }
+}
+`, testAccVPCEndpoint_Precondition(rName))
+}
+
+func testAccVPCEndpoint_Update(rName string) string {
+	return fmt.Sprintf(`
+%s
+
+resource "flexibleengine_vpcep_endpoint" "test" {
+  service_id  = flexibleengine_vpcep_service.test.id
+  vpc_id      = flexibleengine_vpc_v1.test.id
+  network_id  = flexibleengine_vpc_subnet_v1.test.id
+  enable_dns  = true
+  description = "test description2"
+
+  enable_whitelist = true
+  whitelist        = ["192.168.0.0/24", "10.10.10.13"]
+
+  tags = {
+    owner = "tf-acc-update"
+    foo   = "bar"
+  }
+}
+`, testAccVPCEndpoint_Precondition(rName))
+}

--- a/flexibleengine/provider.go
+++ b/flexibleengine/provider.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/config"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/helper/mutexkv"
@@ -49,6 +48,7 @@ import (
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/swr"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/tms"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpc"
+	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/vpcep"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/waf"
 	"github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/utils"
 )
@@ -533,9 +533,7 @@ func Provider() *schema.Provider {
 			"flexibleengine_sdrs_replication_pair_v1":   resourceSdrsReplicationPairV1(),
 			"flexibleengine_sdrs_replication_attach_v1": resourceSdrsReplicationAttachV1(),
 
-			"flexibleengine_vpcep_approval": resourceVPCEndpointApproval(),
-			"flexibleengine_vpcep_endpoint": resourceVPCEndpoint(),
-			"flexibleengine_vpcep_service":  resourceVPCEndpointService(),
+			"flexibleengine_vpcep_service": resourceVPCEndpointService(),
 
 			"flexibleengine_waf_certificate":                resourceWafCertificateV1(),
 			"flexibleengine_waf_domain":                     resourceWafDomainV1(),
@@ -661,6 +659,9 @@ func Provider() *schema.Provider {
 			"flexibleengine_vpc_eip_associate": eip.ResourceEIPAssociate(),
 			"flexibleengine_vpc_route_table":   vpc.ResourceVPCRouteTable(),
 			"flexibleengine_vpc_route":         vpc.ResourceVPCRouteTableRoute(),
+
+			"flexibleengine_vpcep_approval": vpcep.ResourceVPCEndpointApproval(),
+			"flexibleengine_vpcep_endpoint": vpcep.ResourceVPCEndpoint(),
 
 			"flexibleengine_waf_dedicated_instance":    ResourceWafDedicatedInstance(),
 			"flexibleengine_waf_dedicated_policy":      ResourceWafDedicatedPolicyV1(),


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
resource_flexibleengine_vpcep_endpoint
resource_flexibleengine_vpcep_approval

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #xxx

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```md
### resource_flexibleengine_vpcep_endpoint

=== RUN   TestAccVPCEndpoint_Basic
=== PAUSE TestAccVPCEndpoint_Basic
=== CONT  TestAccVPCEndpoint_Basic
--- PASS: TestAccVPCEndpoint_Basic (354.14s)
PASS

coverage: 4.1% of statements in ../../../terraform-provider-flexibleengine/...
```

```md
### resource_flexibleengine_vpcep_approval

=== RUN   TestAccVPCEndpointApproval_Basic
=== PAUSE TestAccVPCEndpointApproval_Basic
=== CONT  TestAccVPCEndpointApproval_Basic
--- PASS: TestAccVPCEndpointApproval_Basic (348.36s)
PASS

coverage: 4.1% of statements in ../../../terraform-provider-flexibleengine/...
```
