### PR TITLE
feat(obs/bucket): support kms_key_project_id and logging agency params

### DIFF
--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -33,6 +33,9 @@ resource "flexibleengine_obs_bucket" "b" {
 ### Enable Logging
 
 ```hcl
+# The agency must be an OBS cloud service agency with the `PutObject` permission.
+variable "agency_name" {}
+
 resource "flexibleengine_obs_bucket" "log_bucket" {
   bucket = "my-tf-log-bucket"
   acl    = "log-delivery-write"
@@ -45,6 +48,7 @@ resource "flexibleengine_obs_bucket" "b" {
   logging {
     target_bucket = flexibleengine_obs_bucket.log_bucket.id
     target_prefix = "log/"
+    agency        = var.agency_name
   }
 }
 ```
@@ -195,7 +199,14 @@ The `logging` object supports:
 
 * `target_bucket` - (Required, String) The name of the bucket that will receive the log objects.
   The acl policy of the target bucket should be `log-delivery-write`.
+
 * `target_prefix` - (Optional, String) To specify a key prefix for log objects.
+
+* `agency` - (Required, String) Specifies the IAM agency of OBS cloud service.
+
+  -> The IAM agency requires the `PutObject` permission for the target bucket.  If default encryption is enabled for the
+  target bucket, the agency also requires the `KMS Administrator` permission in the region where the target bucket is
+  located.
 
 <a name="obs_website"></a>
 The `website` object supports:

--- a/docs/resources/obs_bucket.md
+++ b/docs/resources/obs_bucket.md
@@ -165,7 +165,10 @@ The following arguments are supported:
 
 * `encryption` - (Optional, Bool) Whether enable default server-side encryption of the bucket in SSE-KMS mode.
 
-* `kms_key_id` - (Optional, String) Specifies the ID of a kms key. If omitted, the default master key will be used.
+* `kms_key_id` - (Optional, String) Specifies the ID of a KMS key. If omitted, the default master key will be used.
+
+* `kms_key_project_id` - (Optional, String) Specifies the project ID to which the KMS key belongs. This field is valid
+  only when `kms_key_id` is specified.
 
 * `logging` - (Optional, List) A settings of bucket logging. The [logging](#obs_logging) object structure is documented
   below.

--- a/flexibleengine/resource_flexibleengine_obs_bucket.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket.go
@@ -64,6 +64,12 @@ func resourceObsBucket() *schema.Resource {
 							Optional: true,
 							Default:  "logs/",
 						},
+						"agency": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Computed:    true,
+							Description: "schema: Required",
+						},
 					},
 				},
 			},
@@ -335,7 +341,7 @@ func resourceObsBucketUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("logging") {
-		if err := resourceObsBucketLoggingUpdate(obsClient, d); err != nil {
+		if err := resourceObsBucketLoggingUpdate(obsClientWithSignature, d); err != nil {
 			return err
 		}
 	}
@@ -413,7 +419,7 @@ func resourceObsBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Read the logging configuration
-	if err := setObsBucketLogging(obsClient, d); err != nil {
+	if err := setObsBucketLogging(obsClientWithSignature, d); err != nil {
 		return err
 	}
 
@@ -561,6 +567,10 @@ func resourceObsBucketLoggingUpdate(obsClient *obs.ObsClient, d *schema.Resource
 
 		if val := c["target_prefix"].(string); val != "" {
 			loggingStatus.TargetPrefix = val
+		}
+
+		if val := c["agency"].(string); val != "" {
+			loggingStatus.Agency = val
 		}
 	}
 	log.Printf("[DEBUG] set logging of OBS bucket %s: %#v", bucket, loggingStatus)
@@ -958,6 +968,9 @@ func setObsBucketLogging(obsClient *obs.ObsClient, d *schema.ResourceData) error
 		logging["target_bucket"] = output.TargetBucket
 		if output.TargetPrefix != "" {
 			logging["target_prefix"] = output.TargetPrefix
+		}
+		if output.Agency != "" {
+			logging["agency"] = output.Agency
 		}
 		lcList = append(lcList, logging)
 	}

--- a/flexibleengine/resource_flexibleengine_obs_bucket.go
+++ b/flexibleengine/resource_flexibleengine_obs_bucket.go
@@ -239,6 +239,11 @@ func resourceObsBucket() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"kms_key_project_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"multi_az": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -293,10 +298,15 @@ func resourceObsBucketCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceObsBucketUpdate(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*Config)
-	obsClient, err := config.ObjectStorageClient(GetRegion(d, config))
+	conf := meta.(*Config)
+	region := conf.GetRegion(d)
+	obsClient, err := conf.ObjectStorageClient(region)
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
+		return fmt.Errorf("error creating OBS client: %s", err)
+	}
+	obsClientWithSignature, err := conf.ObjectStorageClientWithSignature(region)
+	if err != nil {
+		return fmt.Errorf("error creating OBS client with signature: %s", err)
 	}
 
 	log.Printf("[DEBUG] Update OBS bucket %s", d.Id())
@@ -318,8 +328,8 @@ func resourceObsBucketUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	if d.HasChanges("encryption", "kms_key_id") {
-		if err := resourceObsBucketEncryptionUpdate(obsClient, d); err != nil {
+	if d.HasChanges("encryption", "kms_key_id", "kms_key_project_id") {
+		if err := resourceObsBucketEncryptionUpdate(obsClientWithSignature, d); err != nil {
 			return err
 		}
 	}
@@ -352,11 +362,15 @@ func resourceObsBucketUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceObsBucketRead(d *schema.ResourceData, meta interface{}) error {
-	config := meta.(*Config)
-	region := GetRegion(d, config)
-	obsClient, err := config.ObjectStorageClient(region)
+	conf := meta.(*Config)
+	region := conf.GetRegion(d)
+	obsClient, err := conf.ObjectStorageClient(region)
 	if err != nil {
-		return fmt.Errorf("Error creating FlexibleEngine OBS client: %s", err)
+		return fmt.Errorf("error creating OBS client: %s", err)
+	}
+	obsClientWithSignature, err := conf.ObjectStorageClientWithSignature(region)
+	if err != nil {
+		return fmt.Errorf("error creating OBS client with signature: %s", err)
 	}
 
 	log.Printf("[DEBUG] Read OBS bucket: %s", d.Id())
@@ -394,7 +408,7 @@ func resourceObsBucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Read the encryption configuration
-	if err := setObsBucketEncryption(obsClient, d); err != nil {
+	if err := setObsBucketEncryption(obsClientWithSignature, d); err != nil {
 		return err
 	}
 
@@ -565,8 +579,11 @@ func resourceObsBucketEncryptionUpdate(obsClient *obs.ObsClient, d *schema.Resou
 	if d.Get("encryption").(bool) {
 		input := &obs.SetBucketEncryptionInput{}
 		input.Bucket = bucket
-		input.SSEAlgorithm = obs.DEFAULT_SSE_KMS_ENCRYPTION
-		input.KMSMasterKeyID = d.Get("kms_key_id").(string)
+		input.SSEAlgorithm = obs.DEFAULT_SSE_KMS_ENCRYPTION_OBS
+		if raw, ok := d.GetOk("kms_key_id"); ok {
+			input.KMSMasterKeyID = raw.(string)
+			input.ProjectID = d.Get("kms_key_project_id").(string)
+		}
 
 		log.Printf("[DEBUG] enable default encryption of OBS bucket %s: %#v", bucket, input)
 		_, err := obsClient.SetBucketEncryption(input)
@@ -905,6 +922,7 @@ func setObsBucketEncryption(obsClient *obs.ObsClient, d *schema.ResourceData) er
 			if obsError.Code == "NoSuchEncryptionConfiguration" || obsError.Code == "FsNotSupport" {
 				d.Set("encryption", false)
 				d.Set("kms_key_id", nil)
+				d.Set("kms_key_project_id", nil)
 				return nil
 			}
 			return fmt.Errorf("Error getting encryption configuration of OBS bucket %s: %s,\n Reason: %s",
@@ -916,9 +934,11 @@ func setObsBucketEncryption(obsClient *obs.ObsClient, d *schema.ResourceData) er
 	if output.SSEAlgorithm != "" {
 		d.Set("encryption", true)
 		d.Set("kms_key_id", output.KMSMasterKeyID)
+		d.Set("kms_key_project_id", output.ProjectID)
 	} else {
 		d.Set("encryption", false)
 		d.Set("kms_key_id", nil)
+		d.Set("kms_key_project_id", nil)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes**:
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
fixes #1112 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
$ make testacc TEST="./flexibleengine" TESTARGS="-run TestAccObsBucket_basic"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccObsBucket_basic -timeout 720m
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_basic (104.81s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 104.864s

$ make testacc TEST="./flexibleengine" TESTARGS="-run TestAccObsBucket_logging"
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine -v -run TestAccObsBucket_logging -timeout 720m
=== RUN   TestAccObsBucket_logging
=== PAUSE TestAccObsBucket_logging
=== CONT  TestAccObsBucket_logging
--- PASS: TestAccObsBucket_logging (65.07s)
PASS
ok      github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine 65.123s
```
