### PR TITLE
feat(identityUserV3): add access_mode capability

### DIFF
--- a/docs/data-sources/identity_users.md
+++ b/docs/data-sources/identity_users.md
@@ -36,6 +36,8 @@ The `users` block contains:
 
 * `name` - Indicates the IAM user name.
 
+* `access_mode` - Indicates the IAM user access mode
+
 * `description` - Indicates the description of the IAM user.
 
 * `enabled` - Indicates the whether the IAM user is enabled.

--- a/docs/resources/identity_user_v3.md
+++ b/docs/resources/identity_user_v3.md
@@ -28,6 +28,9 @@ The following arguments are supported:
     5 to 32 characters. It can contain only uppercase letters, lowercase letters,
     digits, spaces, and special characters (-_) and cannot start with a digit.
 
+* `access_mode` - (Optional, String) Specifies the user access type.
+    Valid values are `program` and `program_console`
+
 * `description` - (Optional, String) Specifies the description of the user.
 
 * `email` - (Optional, String) Specifies the email address with a maximum of 255 characters.

--- a/docs/resources/identity_user_v3.md
+++ b/docs/resources/identity_user_v3.md
@@ -29,7 +29,10 @@ The following arguments are supported:
     digits, spaces, and special characters (-_) and cannot start with a digit.
 
 * `access_mode` - (Optional, String) Specifies the user access type.
-    Valid values are `program` and `program_console`
+  Available options are:
+  + `default`: programmatic access and management console access. This option is the default access type.
+  + `programmatic`: programmatic access.
+  + `console`: management console access.
 
 * `description` - (Optional, String) Specifies the description of the user.
 

--- a/flexibleengine/resource_flexibleengine_identity_user_v3.go
+++ b/flexibleengine/resource_flexibleengine_identity_user_v3.go
@@ -40,7 +40,7 @@ func resourceIdentityUserV3() *schema.Resource {
 			"access_mode": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				ValidateFunc: validation.StringInSlice([]string{"program", "program_console"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"default", "programmatic", "console"}, false),
 			},
 			"description": {
 				Type:     schema.TypeString,

--- a/flexibleengine/resource_flexibleengine_identity_user_v3.go
+++ b/flexibleengine/resource_flexibleengine_identity_user_v3.go
@@ -40,6 +40,7 @@ func resourceIdentityUserV3() *schema.Resource {
 			"access_mode": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Default:      "default"
 				ValidateFunc: validation.StringInSlice([]string{"default", "programmatic", "console"}, false),
 			},
 			"description": {

--- a/flexibleengine/resource_flexibleengine_identity_user_v3.go
+++ b/flexibleengine/resource_flexibleengine_identity_user_v3.go
@@ -40,7 +40,7 @@ func resourceIdentityUserV3() *schema.Resource {
 			"access_mode": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "default"
+				Default:      "default",
 				ValidateFunc: validation.StringInSlice([]string{"default", "programmatic", "console"}, false),
 			},
 			"description": {

--- a/flexibleengine/resource_flexibleengine_identity_user_v3.go
+++ b/flexibleengine/resource_flexibleengine_identity_user_v3.go
@@ -37,6 +37,11 @@ func resourceIdentityUserV3() *schema.Resource {
 				Optional:  true,
 				Sensitive: true,
 			},
+			"access_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"program", "program_console"}, false),
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -92,6 +97,7 @@ func resourceIdentityUserV3Create(ctx context.Context, d *schema.ResourceData, m
 	enabled := d.Get("enabled").(bool)
 	createOpts := iam_users.CreateOpts{
 		Name:        d.Get("name").(string),
+		AccessMode:  d.Get("access_mode").(string),
 		Description: d.Get("description").(string),
 		Email:       d.Get("email").(string),
 		Phone:       d.Get("phone").(string),
@@ -130,6 +136,7 @@ func resourceIdentityUserV3Read(_ context.Context, d *schema.ResourceData, meta 
 
 	d.Set("enabled", user.Enabled)
 	d.Set("name", user.Name)
+	d.Set("access_mode", user.AccessMode)
 	d.Set("description", user.Description)
 	d.Set("email", user.Email)
 	d.Set("country_code", user.AreaCode)
@@ -158,6 +165,10 @@ func resourceIdentityUserV3Update(ctx context.Context, d *schema.ResourceData, m
 
 	if d.HasChange("name") {
 		updateOpts.Name = d.Get("name").(string)
+	}
+
+	if d.HasChange("access_mode") {
+		updateOpts.AccessMode = d.Get("access_mode").(string)
 	}
 
 	if d.HasChange("description") {

--- a/flexibleengine/resource_flexibleengine_identity_user_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_identity_user_v3_test.go
@@ -115,7 +115,7 @@ func testAccIdentityV3User_basic(userName string) string {
 resource "flexibleengine_identity_user_v3" "user_1" {
   name        = "%s"
   password    = "password123@!"
-  access_mode = "program"
+  access_mode = "programmatic"
   enabled     = true
   email       = "foo123@orange-business.com"
   description = "created by terraform"
@@ -127,7 +127,7 @@ func testAccIdentityV3User_update(userName string) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_identity_user_v3" "user_1" {
   name        = "%s"
-  access_mode = "program_console"
+  access_mode = "default"
   enabled     = false
   password    = "password123@!"
   email       = "bar123@orange-business.com"

--- a/flexibleengine/resource_flexibleengine_identity_user_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_identity_user_v3_test.go
@@ -29,6 +29,7 @@ func TestAccIdentityV3User_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityV3UserExists(resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "name", userName),
+					resource.TestCheckResourceAttr(resourceName, "access_mode", "programmatic"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "email", "foo123@orange-business.com"),
 					resource.TestCheckResourceAttr(resourceName, "description", "created by terraform"),
@@ -40,6 +41,7 @@ func TestAccIdentityV3User_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIdentityV3UserExists(resourceName, &user),
 					resource.TestCheckResourceAttr(resourceName, "name", userName),
+					resource.TestCheckResourceAttr(resourceName, "access_mode", "default"),
 					resource.TestCheckResourceAttr(resourceName, "enabled", "false"),
 					resource.TestCheckResourceAttr(resourceName, "email", "bar123@orange-business.com"),
 					resource.TestCheckResourceAttr(resourceName, "description", "updated by terraform"),

--- a/flexibleengine/resource_flexibleengine_identity_user_v3_test.go
+++ b/flexibleengine/resource_flexibleengine_identity_user_v3_test.go
@@ -115,6 +115,7 @@ func testAccIdentityV3User_basic(userName string) string {
 resource "flexibleengine_identity_user_v3" "user_1" {
   name        = "%s"
   password    = "password123@!"
+  access_mode = "program"
   enabled     = true
   email       = "foo123@orange-business.com"
   description = "created by terraform"
@@ -126,6 +127,7 @@ func testAccIdentityV3User_update(userName string) string {
 	return fmt.Sprintf(`
 resource "flexibleengine_identity_user_v3" "user_1" {
   name        = "%s"
+  access_mode = "program_console"
   enabled     = false
   password    = "password123@!"
   email       = "bar123@orange-business.com"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR allows user creation controlling the access type (default, programmatic and console)

**Release note**:
-->

```release-note

```

## PR Checklist

* [x] Tests added/passed.
* [x] Documentation updated.
* [x] Schema updated.

## Acceptance Steps Performed

```
make testacc TEST='./flexibleengine/' TESTARGS='-run TestAccIdentityV3User_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./flexibleengine/ -v -run TestAccIdentityV3User_basic -timeout 720m
=== RUN   TestAccIdentityV3User_basic
--- PASS: TestAccIdentityV3User_basic (14.08s)
PASS
ok  	github.com/FlexibleEngineCloud/terraform-provider-flexibleengine/flexibleengine	14.101s
```
